### PR TITLE
ci: fix prep/prod env logic in CD workflow

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -299,7 +299,7 @@ jobs:
 
   terraform-env-prep:
     name: Environment (prep)
-    if: ${{ always() && !cancelled() && !failure() && needs.release-please.outputs.release_created && needs.orchestrator.outputs.should-apply-prep-environment-terraform || needs.orchestrator.outputs.should-build-and-push-docker || needs.orchestrator.outputs.should-build-app }}
+    if: ${{ always() && !cancelled() && !failure() && needs.release-please.outputs.release_created && (needs.orchestrator.outputs.should-apply-prep-environment-terraform || needs.orchestrator.outputs.should-build-and-push-docker || needs.orchestrator.outputs.should-build-app) }}
     concurrency:
       group: terraform-environment-prep
     needs:
@@ -322,7 +322,7 @@ jobs:
 
   terraform-env-prod:
     name: Environment (prod)
-    if: ${{ needs.release-please.outputs.release_created && needs.orchestrator.outputs.should-apply-prod-environment-terraform || needs.orchestrator.outputs.should-build-and-push-docker || needs.orchestrator.outputs.should-build-app }}
+    if: ${{ needs.release-please.outputs.release_created && (needs.orchestrator.outputs.should-apply-prod-environment-terraform || needs.orchestrator.outputs.should-build-and-push-docker || needs.orchestrator.outputs.should-build-app) }}
     concurrency:
       group: terraform-environment-prod
     needs:


### PR DESCRIPTION
## Description

The `prep` and `prod` environments were trying to apply without a release. This PR tweaks the logic to stop that from happening.

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
