### PR TITLE
feat(docker): add GOV.UK One Login redirect to selfserve

### DIFF
--- a/infra/docker/api/api.conf
+++ b/infra/docker/api/api.conf
@@ -38,7 +38,7 @@ server {
   }
 
   location / {
-   try_files $uri /index.php?$query_string;
+    try_files $uri $uri/ /index.php?$query_string;
   }
 
   location ~ \.php$ {

--- a/infra/docker/internal/internal.conf
+++ b/infra/docker/internal/internal.conf
@@ -130,11 +130,11 @@ server {
   #     dependencies, build scripts, etc.).
 
   location ~* (?:#.*#|\.(?:bak|conf|dist|fla|in[ci]|log|orig|psd|sh|sql|sw[op])|~)$ {
-      deny all;
+    deny all;
   }
 
   location / {
-      try_files $uri /index.php?$query_string;
+    try_files $uri $uri/ /index.php?$query_string;
   }
 
   location ~ \.php$ {

--- a/infra/docker/selfserve/selfserve.conf
+++ b/infra/docker/selfserve/selfserve.conf
@@ -130,11 +130,11 @@ server {
   #     dependencies, build scripts, etc.).
 
   location ~* (?:#.*#|\.(?:bak|conf|dist|fla|in[ci]|log|orig|psd|sh|sql|sw[op])|~)$ {
-      deny all;
+    deny all;
   }
 
   location / {
-      try_files $uri /index.php?$query_string;
+    try_files $uri $uri/ /index.php?$query_string;
   }
 
   location ~ \.php$ {
@@ -144,5 +144,9 @@ server {
     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     fastcgi_index index.php;
     include fastcgi_params;
+  }
+
+  location ~ ^\/govuk-id\/(?:loggedin|loggedout)$ {
+    return 301 /govukaccount-redirect.php;
   }
 }


### PR DESCRIPTION
## Description

Adds a location block to support the handshake from GOV.UK One Login.

Related issue: https://dvsa.atlassian.net/browse/VOL-5337

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
