### PR TITLE
feat(terraform): move `A` record for CDN to private zone

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -69,6 +69,8 @@ module "service" {
   domain_name    = "dev.olcs.dev-dvsacloud.uk"
   assets_version = var.assets_version
 
+  vpc_id = data.aws_vpc.this.id
+
   services = {
     "api" = {
       cpu    = 1024
@@ -150,8 +152,6 @@ module "service" {
 
       lb_listener_arn           = data.aws_lb_listener.this["API"].arn
       listener_rule_host_header = "api.*"
-
-      vpc_id = data.aws_vpc.this.id
     }
 
     "internal" = {
@@ -192,8 +192,6 @@ module "service" {
 
       lb_listener_arn           = data.aws_lb_listener.this["IUWEB"].arn
       listener_rule_host_header = "iuweb.*"
-
-      vpc_id = data.aws_vpc.this.id
     }
 
     "selfserve" = {
@@ -234,8 +232,6 @@ module "service" {
 
       lb_listener_arn           = data.aws_lb_listener.this["SSWEB"].arn
       listener_rule_host_header = "ssweb.*"
-
-      vpc_id = data.aws_vpc.this.id
     }
   }
 }

--- a/infra/terraform/modules/service/README.md
+++ b/infra/terraform/modules/service/README.md
@@ -34,7 +34,8 @@
 | [aws_canonical_user_id.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/canonical_user_id) | data source |
 | [aws_cloudfront_log_delivery_canonical_user_id.cloudfront](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_log_delivery_canonical_user_id) | data source |
 | [aws_iam_policy_document.s3_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
+| [aws_route53_zone.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
+| [aws_route53_zone.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [aws_s3_bucket.assets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 
 ## Inputs
@@ -44,7 +45,8 @@
 | <a name="input_assets_version"></a> [assets\_version](#input\_assets\_version) | The version of the assets | `string` | n/a | yes |
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | The domain name for the environment | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment to deploy to | `string` | n/a | yes |
-| <a name="input_services"></a> [services](#input\_services) | The services to deploy | <pre>map(object({<br>    version    = string<br>    repository = string<br>    cpu        = number<br>    memory     = number<br>    task_iam_role_statements = list(object({<br>      effect    = string<br>      actions   = list(string)<br>      resources = list(string)<br>    }))<br>    add_cdn_url_to_env        = optional(bool, false)<br>    lb_listener_arn           = string<br>    listener_rule_priority    = optional(number, 10)<br>    listener_rule_host_header = optional(string, "*")<br>    security_group_ids        = list(string)<br>    subnet_ids                = list(string)<br>    vpc_id                    = string<br>  }))</pre> | `{}` | no |
+| <a name="input_services"></a> [services](#input\_services) | The services to deploy | <pre>map(object({<br>    version    = string<br>    repository = string<br>    cpu        = number<br>    memory     = number<br>    task_iam_role_statements = list(object({<br>      effect    = string<br>      actions   = list(string)<br>      resources = list(string)<br>    }))<br>    add_cdn_url_to_env        = optional(bool, false)<br>    lb_listener_arn           = string<br>    listener_rule_priority    = optional(number, 10)<br>    listener_rule_host_header = optional(string, "*")<br>    security_group_ids        = list(string)<br>    subnet_ids                = list(string)<br>    vpc_id                    = optional(string, null)<br>  }))</pre> | `{}` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID | `string` | n/a | yes |
 
 ## Outputs
 

--- a/infra/terraform/modules/service/ecs.tf
+++ b/infra/terraform/modules/service/ecs.tf
@@ -5,7 +5,7 @@ resource "aws_lb_target_group" "this" {
   port        = 8080
   protocol    = "HTTP"
   target_type = "ip"
-  vpc_id      = each.value.vpc_id
+  vpc_id      = coalesce(each.value.vpc_id, var.vpc_id)
 
   health_check {
     healthy_threshold   = 2

--- a/infra/terraform/modules/service/variables.tf
+++ b/infra/terraform/modules/service/variables.tf
@@ -13,6 +13,11 @@ variable "assets_version" {
   description = "The version of the assets"
 }
 
+variable "vpc_id" {
+  type        = string
+  description = "The VPC ID"
+}
+
 variable "services" {
   type = map(object({
     version    = string
@@ -30,7 +35,7 @@ variable "services" {
     listener_rule_host_header = optional(string, "*")
     security_group_ids        = list(string)
     subnet_ids                = list(string)
-    vpc_id                    = string
+    vpc_id                    = optional(string, null)
   }))
   description = "The services to deploy"
   default     = {}


### PR DESCRIPTION
## Description

Moves the CDN to behind the VPN. Moves the `A` record to the private zone.

Related issue: https://dvsa.atlassian.net/browse/VOL-5380

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
