### PR TITLE
chore: add Terraform directories to Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -28,3 +28,25 @@ updates:
       dependencies:
         patterns:
           - "*"
+
+  - package-ecosystem: "terraform"
+    directories:
+      # Accounts
+      - "/infra/terraform/accounts/nonprod"
+      - "/infra/terraform/accounts/prod"
+      # Environments
+      - "/infra/terraform/environments/dev"
+      - "/infra/terraform/environments/int"
+      - "/infra/terraform/environments/prep"
+      - "/infra/terraform/environments/prod"
+      # Modules
+      - "/infra/terraform/modules/account"
+      - "/infra/terraform/modules/github"
+      - "/infra/terraform/modules/remote-state"
+      - "/infra/terraform/modules/service"
+    schedule:
+      interval: "monthly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Description

Adds Terraform related directories to the Dependabot config

Related issue: https://dvsa.atlassian.net/browse/VOL-5369

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
