### PR TITLE
feat(docker): add GOV.UK One Login redirect to nginx

### DIFF
--- a/infra/docker/selfserve/selfserve.conf
+++ b/infra/docker/selfserve/selfserve.conf
@@ -137,6 +137,14 @@ server {
       try_files $uri /index.php?$query_string;
   }
 
+  location = /govuk-id/loggedin {
+    return 302 /govukaccount-redirect.php;
+  }
+
+  location = /govuk-id/loggedout {
+    return 302 /govukaccount-redirect.php;
+  }
+
   location ~ \.php$ {
     try_files $uri =404;
     fastcgi_split_path_info ^(.+\.php)(/.+)$;


### PR DESCRIPTION
## Description

Adds an nginx redirect for GOV.UK One Login redirects.

Related issue: https://dvsa.atlassian.net/browse/VOL-5337

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
