### PR TITLE
chore: bump `tflint` AWS ruleset to `v0.31.0`

### DIFF
--- a/infra/terraform/.tflint.hcl
+++ b/infra/terraform/.tflint.hcl
@@ -5,6 +5,6 @@ plugin "terraform" {
 
 plugin "aws" {
   enabled = true
-  version = "0.30.0"
+  version = "0.31.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }


### PR DESCRIPTION
## Description

Bumps the TFLint AWS ruleset to 0.31.0.

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
