### PR TITLE
fix(terraform): make the GitHub module more re-usable

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -300,7 +300,7 @@ jobs:
 
   terraform-env-int:
     name: Environment (int)
-    if: ${{ needs.orchestrator.outputs.should-apply-int-environment-terraform || needs.orchestrator.outputs.should-build-and-push-docker || needs.orchestrator.outputs.should-build-app || needs.orchestrator.outputs.should-build-assets }}
+    if: ${{ always() && !cancelled() && !failure() && needs.orchestrator.outputs.should-apply-int-environment-terraform || needs.orchestrator.outputs.should-build-and-push-docker || needs.orchestrator.outputs.should-build-app || needs.orchestrator.outputs.should-build-assets }}
     concurrency:
       group: terraform-environment-int
     needs:
@@ -366,7 +366,7 @@ jobs:
 
   terraform-env-prod:
     name: Environment (prod)
-    if: ${{ needs.release-please.outputs.release_created && (needs.orchestrator.outputs.should-apply-prod-environment-terraform || needs.orchestrator.outputs.should-build-and-push-docker || needs.orchestrator.outputs.should-build-app || needs.orchestrator.outputs.should-build-assets) }}
+    if: ${{ always() && !cancelled() && !failure() && needs.release-please.outputs.release_created && (needs.orchestrator.outputs.should-apply-prod-environment-terraform || needs.orchestrator.outputs.should-build-and-push-docker || needs.orchestrator.outputs.should-build-app || needs.orchestrator.outputs.should-build-assets) }}
     concurrency:
       group: terraform-environment-prod
     needs:

--- a/compose.yaml
+++ b/compose.yaml
@@ -69,7 +69,6 @@ services:
   db:
     image: mysql:8.0
     command: --log_bin_trust_function_creators=1 --sql_mode=NO_ENGINE_SUBSTITUTION
-    restart: always
     volumes:
       - db-data:/var/lib/mysql
     ports:

--- a/infra/terraform/modules/account/github.tf
+++ b/infra/terraform/modules/account/github.tf
@@ -3,6 +3,8 @@ module "github" {
 
   source = "../../modules/github"
 
+  oidc_role_prefix = "vol-app"
+
   create_oidc_provider      = true
   create_oidc_role          = true
   create_oidc_readonly_role = true

--- a/infra/terraform/modules/github/README.md
+++ b/infra/terraform/modules/github/README.md
@@ -33,6 +33,7 @@ No resources.
 | <a name="input_oidc_readonly_subjects"></a> [oidc\_readonly\_subjects](#input\_oidc\_readonly\_subjects) | The list of GitHub subjects to allow in the OIDC readonly role. | `list(string)` | `[]` | no |
 | <a name="input_oidc_role_permissions_boundary_arn"></a> [oidc\_role\_permissions\_boundary\_arn](#input\_oidc\_role\_permissions\_boundary\_arn) | The ARN of the permissions boundary to use for the role. | `string` | `null` | no |
 | <a name="input_oidc_role_policies"></a> [oidc\_role\_policies](#input\_oidc\_role\_policies) | The map of policies to attach to the OIDC role. | `map(string)` | `{}` | no |
+| <a name="input_oidc_role_prefix"></a> [oidc\_role\_prefix](#input\_oidc\_role\_prefix) | The prefix to use for the OIDC roles. | `string` | `null` | no |
 | <a name="input_oidc_subjects"></a> [oidc\_subjects](#input\_oidc\_subjects) | The list of GitHub subjects to allow in the OIDC role. | `list(string)` | `[]` | no |
 
 ## Outputs

--- a/infra/terraform/modules/github/main.tf
+++ b/infra/terraform/modules/github/main.tf
@@ -1,3 +1,8 @@
+locals {
+  oidc_role_name          = var.oidc_role_prefix != null ? "${var.oidc_role_prefix}-github-actions-role" : "github-actions-role"
+  oidc_readonly_role_name = var.oidc_role_prefix != null ? "${var.oidc_role_prefix}-github-actions-readonly-role" : "github-actions-readonly-role"
+}
+
 module "iam_github_oidc_provider" {
   count = var.create_oidc_provider ? 1 : 0
 
@@ -11,7 +16,7 @@ module "iam_github_oidc_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-role"
   version = "~> 5.24"
 
-  name = "vol-app-github-actions-role"
+  name = local.oidc_role_name
 
   subjects                 = var.oidc_subjects
   permissions_boundary_arn = var.oidc_role_permissions_boundary_arn
@@ -27,7 +32,7 @@ module "iam_github_oidc_readonly_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-role"
   version = "~> 5.24"
 
-  name = "vol-app-github-actions-readonly-role"
+  name = local.oidc_readonly_role_name
 
   subjects                 = var.oidc_readonly_subjects
   permissions_boundary_arn = var.oidc_role_permissions_boundary_arn

--- a/infra/terraform/modules/github/variables.tf
+++ b/infra/terraform/modules/github/variables.tf
@@ -1,3 +1,9 @@
+variable "oidc_role_prefix" {
+  type        = string
+  description = "The prefix to use for the OIDC roles."
+  default     = null
+}
+
 variable "oidc_subjects" {
   type        = list(string)
   description = "The list of GitHub subjects to allow in the OIDC role."


### PR DESCRIPTION
## Description

The GitHub module tweaks that make it more re-usable across different projects. The eventual aim is to make this a re-usable module outside of this repository.
