### PR TITLE
fix(terraform): tighten the permission on state bucket

### DIFF
--- a/infra/terraform/accounts/nonprod/main.tf
+++ b/infra/terraform/accounts/nonprod/main.tf
@@ -44,8 +44,8 @@ module "account" {
 
   github_oidc_readonly_role_policies = merge(
     {
-      DynamodbStateLock = "arn:aws:iam::054614622558:policy/vol-app-054614622558-terraform-state-lock-policy",
-      S3StateLock       = "arn:aws:iam::054614622558:policy/vol-app-054614622558-terraform-state-policy"
+      S3State           = "arn:aws:iam::054614622558:policy/vol-app-054614622558-terraform-state-readonly-policy",
+      DynamodbStateLock = "arn:aws:iam::054614622558:policy/vol-app-054614622558-terraform-state-lock-policy"
     },
     { for env, remote-state in module.environment-remote-state : "${title(env)}DynamodbStateLock" => remote-state.dynamodb_state_lock_policy_arn }
   )

--- a/infra/terraform/modules/remote-state/README.md
+++ b/infra/terraform/modules/remote-state/README.md
@@ -20,6 +20,7 @@
 | <a name="module_dynamodb_table"></a> [dynamodb\_table](#module\_dynamodb\_table) | terraform-aws-modules/dynamodb-table/aws | ~> 4.0 |
 | <a name="module_s3"></a> [s3](#module\_s3) | terraform-aws-modules/s3-bucket/aws | ~> 4.0 |
 | <a name="module_s3_state_policy"></a> [s3\_state\_policy](#module\_s3\_state\_policy) | terraform-aws-modules/iam/aws//modules/iam-policy | ~> 5.28 |
+| <a name="module_s3_state_readonly_policy"></a> [s3\_state\_readonly\_policy](#module\_s3\_state\_readonly\_policy) | terraform-aws-modules/iam/aws//modules/iam-policy | ~> 5.28 |
 
 ## Resources
 
@@ -42,5 +43,6 @@
 | Name | Description |
 |------|-------------|
 | <a name="output_dynamodb_state_lock_policy_arn"></a> [dynamodb\_state\_lock\_policy\_arn](#output\_dynamodb\_state\_lock\_policy\_arn) | The ARN of the IAM policy that allows DynamoDB access for state locking |
-| <a name="output_s3_state_policy_arn"></a> [s3\_state\_policy\_arn](#output\_s3\_state\_policy\_arn) | The ARN of the IAM policy that allows S3 access for state locking |
+| <a name="output_s3_state_policy_arn"></a> [s3\_state\_policy\_arn](#output\_s3\_state\_policy\_arn) | The ARN of the IAM policy that allows S3 access for the state |
+| <a name="output_s3_state_readonly_policy_arn"></a> [s3\_state\_readonly\_policy\_arn](#output\_s3\_state\_readonly\_policy\_arn) | The ARN of the IAM policy that allows S3 read-only access for the state |
 <!-- END_TF_DOCS -->

--- a/infra/terraform/modules/remote-state/main.tf
+++ b/infra/terraform/modules/remote-state/main.tf
@@ -90,7 +90,7 @@ module "s3_state_policy" {
   version = "~> 5.28"
 
   name        = "${local.identifier}-policy"
-  description = "Policy to allow access to the Terraform state in S3"
+  description = "Policy to allow full access to the Terraform state in S3"
 
   policy = jsonencode({
     Version = "2012-10-17",
@@ -100,6 +100,30 @@ module "s3_state_policy" {
         Action = [
           "s3:GetObject",
           "s3:PutObject",
+          "s3:ListBucket"
+        ]
+        Resource = module.s3[0].s3_bucket_arn
+      }
+    ]
+  })
+}
+
+module "s3_state_readonly_policy" {
+  count = var.create_bucket && var.create_bucket_policy ? 1 : 0
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "~> 5.28"
+
+  name        = "${local.identifier}-readonly-policy"
+  description = "Policy to allow readonly access to the Terraform state in S3"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:GetObject",
           "s3:ListBucket"
         ]
         Resource = module.s3[0].s3_bucket_arn

--- a/infra/terraform/modules/remote-state/outputs.tf
+++ b/infra/terraform/modules/remote-state/outputs.tf
@@ -4,6 +4,11 @@ output "dynamodb_state_lock_policy_arn" {
 }
 
 output "s3_state_policy_arn" {
-  description = "The ARN of the IAM policy that allows S3 access for state locking"
+  description = "The ARN of the IAM policy that allows S3 access for the state"
   value       = try(module.s3_state_policy.arn, null)
+}
+
+output "s3_state_readonly_policy_arn" {
+  description = "The ARN of the IAM policy that allows S3 read-only access for the state"
+  value       = try(module.s3_state_readonly_policy.arn, null)
 }


### PR DESCRIPTION
## Description

Tighten the state bucket permissions. Give the read-only OIDC role, only read-only access to the state file.
