### PR TITLE
ci: add `fetch-depth` to re-usable workflow checkout

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -32,6 +32,7 @@ jobs:
           repository: ${{ env.REMOTE_REPOSITORY }}
           ref: ${{ inputs.ref || null }}
           path: app/cdn
+          fetch-depth: ${{ inputs.ref && 0 || 1 }}
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/deploy-account.yaml
+++ b/.github/workflows/deploy-account.yaml
@@ -76,6 +76,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || null }}
           sparse-checkout: infra/terraform
+          fetch-depth: ${{ inputs.ref && 0 || 1 }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/deploy-environment.yaml
+++ b/.github/workflows/deploy-environment.yaml
@@ -109,6 +109,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || null }}
           sparse-checkout: infra/terraform
+          fetch-depth: ${{ inputs.ref && 0 || 1 }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -40,6 +40,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || null }}
           sparse-checkout: ${{ env.WORKING_DIR }}
+          fetch-depth: ${{ inputs.ref && 0 || 1 }}
 
       - uses: hadolint/hadolint-action@v3.1.0
         with:
@@ -53,6 +54,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || null }}
           sparse-checkout: ${{ env.WORKING_DIR }}
+          fetch-depth: ${{ inputs.ref && 0 || 1 }}
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -37,6 +37,7 @@ jobs:
           repository: ${{ env.REMOTE_REPOSITORY }}
           ref: ${{ inputs.ref || null }}
           path: app/${{ inputs.project }}
+          fetch-depth: ${{ inputs.ref && 0 || 1 }}
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:


### PR DESCRIPTION
## Description

By default `actions/checkout` uses a fetch depth of 1. This isn't appropriate if the `ref` is older than the last commit.
