### PR TITLE
ci: fix `fetch-depth` evaluation logic

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -32,7 +32,7 @@ jobs:
           repository: ${{ env.REMOTE_REPOSITORY }}
           ref: ${{ inputs.ref || null }}
           path: app/cdn
-          fetch-depth: ${{ inputs.ref && 0 || 1 }}
+          fetch-depth: ${{ !inputs.ref && 1 || 0 }}
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/deploy-account.yaml
+++ b/.github/workflows/deploy-account.yaml
@@ -76,7 +76,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || null }}
           sparse-checkout: infra/terraform
-          fetch-depth: ${{ inputs.ref && 0 || 1 }}
+          fetch-depth: ${{ !inputs.ref && 1 || 0 }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/deploy-environment.yaml
+++ b/.github/workflows/deploy-environment.yaml
@@ -109,7 +109,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || null }}
           sparse-checkout: infra/terraform
-          fetch-depth: ${{ inputs.ref && 0 || 1 }}
+          fetch-depth: ${{ !inputs.ref && 1 || 0 }}
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -40,7 +40,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || null }}
           sparse-checkout: ${{ env.WORKING_DIR }}
-          fetch-depth: ${{ inputs.ref && 0 || 1 }}
+          fetch-depth: ${{ !inputs.ref && 1 || 0 }}
 
       - uses: hadolint/hadolint-action@v3.1.0
         with:
@@ -54,7 +54,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || null }}
           sparse-checkout: ${{ env.WORKING_DIR }}
-          fetch-depth: ${{ inputs.ref && 0 || 1 }}
+          fetch-depth: ${{ !inputs.ref && 1 || 0 }}
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -37,7 +37,7 @@ jobs:
           repository: ${{ env.REMOTE_REPOSITORY }}
           ref: ${{ inputs.ref || null }}
           path: app/${{ inputs.project }}
-          fetch-depth: ${{ inputs.ref && 0 || 1 }}
+          fetch-depth: ${{ !inputs.ref && 1 || 0 }}
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:


### PR DESCRIPTION
## Before submitting (or marking as "ready for review")
- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you done a self-code review on the changes?
- [x] Did you make sure to update any documentation (`/website`) relating to this change?

## Description
If empty, the logic `inputs.ref` is evaluated then set to `0`, then the `||` is evaluated. This PR inverses the logic to make the logic work as it should.

## How has this been tested?
<!-- Describe how you have tested this change works -->
