### PR TITLE
ci: remove duplicate `latest` tag push

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -68,13 +68,13 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
+          flavor: latest=true
           images: |
             ${{ env.REGISTRY }}/vol-app/${{ inputs.project }}
             ${{ env.REGISTRY_MIRROR }}/dvsa/vol-app/${{ inputs.project }}
           tags: |
             type=sha,prefix=,format=short
             type=semver,enable=${{ inputs.is-release }},pattern={{version}},value=${{ inputs.version }}
-            type=raw,value=latest
 
       - name: Configure AWS credentials
         if: ${{ inputs.push }}


### PR DESCRIPTION
## Description

Removes the duplicate `latest` tag of application images. Most registries detected this as duplicate but this cleans up that bit to not rely on the de-duplication of third parties.

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
