### PR TITLE
fix(terraform): tweak batch config

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -285,6 +285,7 @@ jobs:
     with:
       environment: dev
       api-image-tag: ${{ needs.get-version.outputs.api }}
+      cli-image-tag: ${{ needs.get-version.outputs.cli }}
       selfserve-image-tag: ${{ needs.get-version.outputs.selfserve }}
       internal-image-tag: ${{ needs.get-version.outputs.internal }}
       assets-version: ${{ needs.get-version.outputs.assets }}
@@ -308,6 +309,7 @@ jobs:
     with:
       environment: int
       api-image-tag: ${{ needs.get-version.outputs.api }}
+      cli-image-tag: ${{ needs.get-version.outputs.cli }}
       selfserve-image-tag: ${{ needs.get-version.outputs.selfserve }}
       internal-image-tag: ${{ needs.get-version.outputs.internal }}
       assets-version: ${{ needs.get-version.outputs.assets }}
@@ -351,6 +353,7 @@ jobs:
     with:
       environment: prep
       api-image-tag: ${{ needs.get-version.outputs.api }}
+      cli-image-tag: ${{ needs.get-version.outputs.cli }}
       selfserve-image-tag: ${{ needs.get-version.outputs.selfserve }}
       internal-image-tag: ${{ needs.get-version.outputs.internal }}
       assets-version: ${{ needs.get-version.outputs.assets }}
@@ -375,6 +378,7 @@ jobs:
     with:
       environment: prod
       api-image-tag: ${{ needs.get-version.outputs.api }}
+      cli-image-tag: ${{ needs.get-version.outputs.cli }}
       selfserve-image-tag: ${{ needs.get-version.outputs.selfserve }}
       internal-image-tag: ${{ needs.get-version.outputs.internal }}
       assets-version: ${{ needs.get-version.outputs.assets }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,6 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       api: ${{ steps.api-version.outputs.version }}
+      cli: ${{ steps.cli-version.outputs.version }}
       selfserve: ${{ steps.selfserve-version.outputs.version }}
       internal: ${{ steps.internal-version.outputs.version }}
       assets: ${{ steps.assets-version.outputs.version }}
@@ -139,6 +140,10 @@ jobs:
         uses: ./.github/actions/get-app-version
         with:
           project-path: app/api infra/docker/api
+      - id: cli-version
+        uses: ./.github/actions/get-app-version
+        with:
+          project-path: app/api infra/docker/cli
       - id: selfserve-version
         uses: ./.github/actions/get-app-version
         with:
@@ -305,6 +310,7 @@ jobs:
     with:
       environment: ${{ matrix.environment }}
       api-image-tag: ${{ needs.get-version.outputs.api }}
+      cli-image-tag: ${{ needs.get-version.outputs.cli }}
       selfserve-image-tag: ${{ needs.get-version.outputs.selfserve }}
       internal-image-tag: ${{ needs.get-version.outputs.internal }}
       assets-version: ${{ needs.get-version.outputs.assets }}

--- a/.github/workflows/deploy-environment.yaml
+++ b/.github/workflows/deploy-environment.yaml
@@ -20,6 +20,10 @@ on:
         description: "API image tag"
         type: string
         required: true
+      cli-image-tag:
+        description: "CLI image tag"
+        type: string
+        required: true
       selfserve-image-tag:
         description: "Selfserve image tag"
         type: string
@@ -54,6 +58,10 @@ on:
         type: string
         required: false
       api-image-tag:
+        type: string
+        required: true
+      cli-image-tag:
+        description: "CLI image tag"
         type: string
         required: true
       selfserve-image-tag:
@@ -137,6 +145,7 @@ jobs:
         id: plan
         env:
           TF_VAR_api_image_tag: ${{ inputs.api-image-tag }}
+          TF_VAR_cli_image_tag: ${{ inputs.cli-image-tag }}
           TF_VAR_selfserve_image_tag: ${{ inputs.selfserve-image-tag }}
           TF_VAR_internal_image_tag: ${{ inputs.internal-image-tag }}
           TF_VAR_assets_version: ${{ inputs.assets-version }}
@@ -237,6 +246,7 @@ jobs:
         if: ${{ inputs.apply }}
         env:
           TF_VAR_api_image_tag: ${{ inputs.api-image-tag }}
+          TF_VAR_cli_image_tag: ${{ inputs.cli-image-tag }}
           TF_VAR_selfserve_image_tag: ${{ inputs.selfserve-image-tag }}
           TF_VAR_internal_image_tag: ${{ inputs.internal-image-tag }}
           TF_VAR_assets_version: ${{ inputs.assets-version }}

--- a/infra/terraform/modules/service/batch.tf
+++ b/infra/terraform/modules/service/batch.tf
@@ -39,8 +39,8 @@ locals {
       ],
 
       runtimePlatform = {
-        operating_system_family = "LINUX",
-        cpu_architecture        = "ARM64"
+        operatingSystemFamily = "LINUX",
+        cpuArchitecture       = "ARM64"
       }
 
       fargatePlatformConfiguration = {

--- a/infra/terraform/modules/service/cdn.tf
+++ b/infra/terraform/modules/service/cdn.tf
@@ -76,7 +76,7 @@ module "cloudfront" {
   # `PriceClass_100` is most cost efficient for VOL and covers the main region of the VOL user-base (UK).
   price_class = "PriceClass_100"
 
-  wait_for_deployment = false
+  wait_for_deployment = true
 
   # When you enable additional metrics for a distribution, CloudFront sends up to 8 metrics to CloudWatch in the US East (N. Virginia) Region.
   # This rate is charged only once per month, per metric (up to 8 metrics per distribution).

--- a/infra/terraform/modules/service/ecs.tf
+++ b/infra/terraform/modules/service/ecs.tf
@@ -132,4 +132,7 @@ module "ecs_service" {
   create_security_group = false
   security_group_ids    = var.services[each.key].security_group_ids
   subnet_ids            = var.services[each.key].subnet_ids
+
+  wait_for_steady_state = true
+  wait_until_stable     = true
 }


### PR DESCRIPTION
## Description

- Add `cli-image-tag` to CI/CD to allow the CLI image to be deployed individually.
- Prefix batch job names with environment prefix.
- Add environment variables to batch jobs.
- Change runtime platform to ARM64 of batch jobs.
- Consolidate the batch queues to a single one - this may change in the future but for now is fine.