### PR TITLE
fix(terraform): add `jobRoleArn` to Batch containers

### DIFF
--- a/infra/terraform/modules/service/batch.tf
+++ b/infra/terraform/modules/service/batch.tf
@@ -59,6 +59,7 @@ locals {
       ],
 
       executionRoleArn = module.ecs_service["api"].task_exec_iam_role_arn
+      jobRoleArn       = module.ecs_service["api"].tasks_iam_role_arn
 
       logConfiguration = {
         logDriver = "awslogs"
@@ -110,6 +111,6 @@ module "batch" {
 }
 
 resource "aws_cloudwatch_log_group" "this" {
-  name              = "/aws/batch"
+  name              = "/aws/batch/${var.environment}"
   retention_in_days = 1
 }

--- a/infra/terraform/modules/service/batch.tf
+++ b/infra/terraform/modules/service/batch.tf
@@ -111,6 +111,6 @@ module "batch" {
 }
 
 resource "aws_cloudwatch_log_group" "this" {
-  name              = "/aws/batch/${var.environment}"
+  name              = "/aws/batch/vol-app-${var.environment}"
   retention_in_days = 1
 }


### PR DESCRIPTION
## Description

Adds a `jobRoleArn` for the application when calling AWS via—the SDK.
Update the CloudWatch log name to include environment.