### PR TITLE
fix: add style to fix radio hint alignment issue

### DIFF
--- a/app/cdn/assets/_styles/components/radios.scss
+++ b/app/cdn/assets/_styles/components/radios.scss
@@ -1,5 +1,5 @@
 /**
- * Radio stuff
+ * Temporary override to support how some hints are being defined in translation keys for radio option labels.
  */
 .govuk-radios__label {
   .govuk-hint {

--- a/app/cdn/assets/_styles/components/radios.scss
+++ b/app/cdn/assets/_styles/components/radios.scss
@@ -1,5 +1,6 @@
 /**
  * Temporary override to support how some hints are being defined in translation keys for radio option labels.
+ * Can be removed on resolution of: https://dvsa.atlassian.net/browse/VOL-5688
  */
 .govuk-radios__label {
   .govuk-hint {

--- a/app/cdn/assets/_styles/components/radios.scss
+++ b/app/cdn/assets/_styles/components/radios.scss
@@ -1,0 +1,8 @@
+/**
+ * Radio stuff
+ */
+.govuk-radios__label {
+  .govuk-hint {
+    display: block;
+  }
+}

--- a/app/cdn/assets/_styles/themes/selfserve.scss
+++ b/app/cdn/assets/_styles/themes/selfserve.scss
@@ -76,6 +76,7 @@ $app: selfserve;
 @import '../components/cookie-settings';
 @import '../components/task-list';
 @import '../components/candidate-permit-selection-table';
+@import '../components/radios';
 
 // Views
 @import '../views/selfserve/overview';


### PR DESCRIPTION
## Description

SCSS override to fix hints defined inside radio labels.

Related issue: [VOL-5685](https://dvsa.atlassian.net/browse/VOL-5685)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
