### PR TITLE
ci: scope Docker cache by image

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -113,8 +113,8 @@ jobs:
           load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ inputs.project }}
+          cache-to: type=gha,mode=max,scope=${{ inputs.project }}
 
       - name: Scan
         uses: aquasecurity/trivy-action@0.24.0


### PR DESCRIPTION
## Description

Scope the Docker cache by image. The hope is that this reduces the cache misses while building these images.