### PR TITLE
fix(terraform): allow `dev` environment to push to S3 email bucket

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -65,7 +65,16 @@ locals {
         "arn:aws:sqs:eu-west-1:054614622558:DEVAPPDEV-OLCS-PRI-CHGET-DLQ",
         "arn:aws:sqs:eu-west-1:054614622558:DEVAPPDEV-OLCS-PRI-CHGET"
       ]
-    }
+    },
+    {
+      effect = "Allow"
+      actions = [
+        "s3:PutObject",
+      ]
+      resources = [
+        "arn:aws:s3:::devapp-olcs-pri-olcs-autotest-s3/*",
+      ]
+    },
   ]
 }
 


### PR DESCRIPTION
## Description

Fixes the permission denied when sending emails on `dev`.

Related issue: https://dvsa.atlassian.net/browse/VOL-5681

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
