### PR TITLE
fix(terraform): add Batch queue tags to clean plan

### DIFF
--- a/infra/terraform/modules/service/batch.tf
+++ b/infra/terraform/modules/service/batch.tf
@@ -104,6 +104,12 @@ module "batch" {
       name     = "vol-app-${var.environment}-default"
       state    = "ENABLED"
       priority = 1
+
+      # This doesn't offer much value as a tag, but it's here to avoid: https://github.com/hashicorp/terraform-provider-aws/pull/38636.
+      # If the PR is merged, we can remove this.
+      tags = {
+        JobQueue = "vol-app-${var.environment}-default"
+      }
     }
   }
 


### PR DESCRIPTION
## Description

The plans are all dirty with:

```tf
  ~ resource "aws_batch_job_queue" "this" {
        id                    = "arn:aws:batch:eu-west-1:054614622558:job-queue/vol-app-dev-default"
        name                  = "vol-app-dev-default"
      + tags                  = {}
        # (6 unchanged attributes hidden)
    }
```

This looks to be caused by a provider bug: `terraform-provider-aws/issues/38173`. This only affects certain resources, `aws_batch_job_queue` being one of them it seems.

This PR adds a tag to clean up the plans.