### PR TITLE
fix(terraform): adjust `response_headers_policy_name` for CORS requests

### DIFF
--- a/infra/terraform/modules/service/cdn.tf
+++ b/infra/terraform/modules/service/cdn.tf
@@ -131,7 +131,7 @@ module "cloudfront" {
 
       cache_policy_name            = "Managed-CachingOptimized"
       origin_request_policy_name   = "Managed-UserAgentRefererHeaders"
-      response_headers_policy_name = "Managed-SecurityHeadersPolicy"
+      response_headers_policy_name = "Managed-CORS-with-preflight-and-SecurityHeadersPolicy"
 
       function_association = {
         viewer-request = {


### PR DESCRIPTION
## Description

The VOL app is trying to make a CORS request for the GOV.UK JavaScript. This adjusts the managed policy on CloudFront to pass CORS headers.