### PR TITLE
fix(terraform): remove CPU/Memory division for containers

### DIFF
--- a/infra/terraform/modules/service/ecs.tf
+++ b/infra/terraform/modules/service/ecs.tf
@@ -80,8 +80,8 @@ module "ecs_service" {
 
   container_definitions = {
     (each.key) = {
-      cpu       = try(var.services[each.key].task_cpu_limit, var.services[each.key].cpu / 2)
-      memory    = try(var.services[each.key].task_memory_limit, var.services[each.key].memory / 4)
+      cpu       = try(var.services[each.key].task_cpu_limit, var.services[each.key].cpu)
+      memory    = try(var.services[each.key].task_memory_limit, var.services[each.key].memory)
       essential = true
       image     = "${var.services[each.key].repository}:${var.services[each.key].version}"
       port_mappings = [


### PR DESCRIPTION
## Description

ClamAV is being killed due as the containers do not seemingly have enough memory.

The containers were taking a share of the overall task definition CPU/memory. This is no longer required while the tasks have a single container running inside them.

This may require some tweaking afterwards.