### PR TITLE
fix: set correct weight for govuk text logo

### DIFF
--- a/app/cdn/assets/_styles/components/govuk-header.scss
+++ b/app/cdn/assets/_styles/components/govuk-header.scss
@@ -6,3 +6,6 @@
   margin-bottom: 10px;
 }
 
+.govuk-header__logotype-text {
+  font-weight: 700;
+}


### PR DESCRIPTION
## Description

Fix font weight for GovUK Text logo

Related issue: [VOL-5693](https://dvsa.atlassian.net/browse/VOL-5693)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
