### PR TITLE
fix(terraform): vol5223 remove fair share scheduling policy from batc…

### DIFF
--- a/infra/terraform/modules/service/batch.tf
+++ b/infra/terraform/modules/service/batch.tf
@@ -111,9 +111,10 @@ module "batch" {
 
   job_queues = {
     default = {
-      name     = "vol-app-${var.environment}-default"
-      state    = "ENABLED"
-      priority = 1
+      name                     = "vol-app-${var.environment}-default"
+      state                    = "ENABLED"
+      priority                 = 1
+      create_scheduling_policy = false
 
       # This doesn't offer much value as a tag, but it's here to avoid: https://github.com/hashicorp/terraform-provider-aws/pull/38636.
       # If the PR is merged, we can remove this.


### PR DESCRIPTION
…h job queue

**Description**

The batch module creates a fair share scheduling policy for queues, which requires all jobs submitted to the queue to have a share identifier or scheduling priority. We haven't really got a clue what these should be so best to just remove the scheduling policy for now.

Related issue: https://dvsa.atlassian.net/browse/VOL-5223

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
