### PR TITLE
fix(terraform): vol5223 give batch jobs a priority and share identifier

### DIFF
--- a/infra/terraform/modules/service/batch.tf
+++ b/infra/terraform/modules/service/batch.tf
@@ -81,7 +81,7 @@ locals {
       description         = "Schedule for ${module.batch.job_definitions[job.name].name}"
       schedule_expression = job.schedule
       arn                 = "arn:aws:scheduler:::aws-sdk:batch:submitJob"
-      input               = jsonencode({ 
+      input = jsonencode({
         "JobName" : module.batch.job_definitions[job.name].name,
         "JobQueue" : module.batch.job_queues.default.arn,
         "JobDefinition" : module.batch.job_definitions[job.name].arn,

--- a/infra/terraform/modules/service/batch.tf
+++ b/infra/terraform/modules/service/batch.tf
@@ -73,7 +73,6 @@ locals {
 
     attempt_duration_seconds = job.timeout
     retry_strategy           = local.default_retry_policy
-    scheduling_priority      = 1
   } }
 
   schedules = {
@@ -86,6 +85,7 @@ locals {
         "JobQueue" : module.batch.job_queues.default.arn,
         "JobDefinition" : module.batch.job_definitions[job.name].arn,
         "ShareIdentifier" : "volapp",
+        "schedulingPriorityOverride" : 1
       })
     }
     if job.schedule != ""

--- a/infra/terraform/modules/service/batch.tf
+++ b/infra/terraform/modules/service/batch.tf
@@ -85,7 +85,7 @@ locals {
         "JobQueue" : module.batch.job_queues.default.arn,
         "JobDefinition" : module.batch.job_definitions[job.name].arn,
         "ShareIdentifier" : "volapp",
-        "schedulingPriorityOverride" : 1
+        "SchedulingPriorityOverride" : 1
       })
     }
     if job.schedule != ""


### PR DESCRIPTION
## Description

The queue has been set up with a fair share scheduling policy, so the batch jobs need a share identifier and priority to be submitted. I've set defaults for now but we can make them more specific further down the line.

Annoyingly there is an option to add a scheduling priority to a job definition in terraform, but this option does not yet exist in the batch module, so we need to set an override in the scheduling instead.

Related issue: https://dvsa.atlassian.net/browse/VOL-5223

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
