### PR TITLE
fix(terraform): Increase vcpu of batch compute environment

### DIFF
--- a/infra/terraform/modules/service/batch.tf
+++ b/infra/terraform/modules/service/batch.tf
@@ -108,7 +108,7 @@ module "batch" {
 
       compute_resources = {
         type               = "FARGATE"
-        max_vcpus          = 4
+        max_vcpus          = 16
         security_group_ids = var.services["api"]["security_group_ids"]
         subnets            = var.batch.subnet_ids
       }


### PR DESCRIPTION
## Description

Each job is currently set to 1 cpu, and we have many jobs running concurrently so need to compute environment to be significantly more than 4, otherwise jobs will just keep piling up.

We could decrease the cpu of each job in future and maybe lower the VPCU of the compute environment, but this will require more significant testing.

Related issue: https://dvsa.atlassian.net/browse/VOL-5223

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
