### PR TITLE
fix(terraform): remove specific CloudFront S3 policy condition

### DIFF
--- a/infra/terraform/modules/service/cdn.tf
+++ b/infra/terraform/modules/service/cdn.tf
@@ -223,12 +223,6 @@ data "aws_iam_policy_document" "s3_policy" {
       type        = "Service"
       identifiers = ["cloudfront.amazonaws.com"]
     }
-
-    condition {
-      test     = "StringEquals"
-      variable = "aws:SourceArn"
-      values   = [module.cloudfront.cloudfront_distribution_arn]
-    }
   }
 }
 


### PR DESCRIPTION
## Description

The S3 bucket is re-used so cannot limit by specific distributions. This PR removes that condition.