### PR TITLE
docs: update `baseUrl` to `vol-app`

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -10,7 +10,7 @@ const config: Config = {
   tagline: "VOL documentation",
   favicon: "img/favicon.ico",
   url: "https://dvsa.github.io",
-  baseUrl: "/",
+  baseUrl: "/vol-app/",
   organizationName: "dvsa",
   projectName: "vol-app",
   trailingSlash: false,


### PR DESCRIPTION
## Description

The base URL changes when pages are made public. This updates that now the pages are working again.