### PR TITLE
ci: fix path checkout

### DIFF
--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -65,7 +65,6 @@ jobs:
         with:
           ref: ${{ inputs.ref || null }}
           sparse-checkout: app/${{ inputs.project }}
-          path: app/${{ inputs.project }}
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -114,7 +113,6 @@ jobs:
   #       with:
   #         ref: ${{ inputs.ref || null }}
   #         sparse-checkout: app/${{ inputs.project }}
-  #         path: app/${{ inputs.project }}
   #     - name: Setup PHP
   #       uses: shivammathur/setup-php@v2
   #       with:
@@ -150,7 +148,6 @@ jobs:
         with:
           ref: ${{ inputs.ref || null }}
           sparse-checkout: app/${{ inputs.project }}
-          path: app/${{ inputs.project }}
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/security-app.yaml
+++ b/.github/workflows/security-app.yaml
@@ -15,18 +15,6 @@ jobs:
         working-directory: app
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
-        with:
-          repository: dvsa/olcs-backend
-          path: app/api
-      - uses: actions/checkout@v4
-        with:
-          repository: dvsa/olcs-selfserve
-          path: app/selfserve
-      - uses: actions/checkout@v4
-        with:
-          repository: dvsa/olcs-internal
-          path: app/internal
       - name: Setup Snyk
         uses: snyk/actions/setup@master
       - name: Scan


### PR DESCRIPTION
## Description

Removes the `path` from the checkout. No longer required now a mono-repository.
