### PR TITLE
fix: extra-hosts entry for non Docker Desktop systems

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -105,6 +105,8 @@ services:
       MYSQL_DATABASE: olcs_be
       MYSQL_USER: mysql
       MYSQL_PASSWORD: olcs
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   openldap:
     image: bitnami/openldap:2.6


### PR DESCRIPTION
## Description

Resolve etl refresh not resolving host.docker.internal alias.

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
