### PR TITLE
ci: hardcode the real short SHA in Docker workflow

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -72,8 +72,8 @@ jobs:
             ${{ env.REGISTRY }}/vol-app/${{ inputs.project }}
             ${{ env.REGISTRY_MIRROR }}/dvsa/vol-app/${{ inputs.project }}
           tags: |
-            type=sha,prefix=,format=short
             type=semver,enable=${{ inputs.is-release }},pattern={{version}},value=${{ inputs.version }}
+            type=raw,value=${{ inputs.version }}
             type=raw,value=latest
 
       - name: Configure AWS credentials

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -72,8 +72,9 @@ jobs:
             ${{ env.REGISTRY }}/vol-app/${{ inputs.project }}
             ${{ env.REGISTRY_MIRROR }}/dvsa/vol-app/${{ inputs.project }}
           tags: |
+            type=sha,prefix=
             type=semver,enable=${{ inputs.is-release }},pattern={{version}},value=${{ inputs.version }}
-            type=raw,value=${{ inputs.version }}
+            type=raw,enable=${{ !inputs.is-release }},value=${{ inputs.version }}
             type=raw,value=latest
 
       - name: Configure AWS credentials


### PR DESCRIPTION
## Description

Post mono-repository the short SHA is now 10 characters long instead of the default 7 characters due to the number of commits. The docker/metadata-action is not using git to work out the SHA and truncates the full SHA to 7 characters (https://github.com/docker/metadata-action/blob/60a0d343a0d8a18aedee9d34e62251f752153bdb/src/meta.ts#L310). This is causing a discrepancy between the versions that the workflows use and the version other parts of the workflow are using (e.g. Terraform).

This PR replaces the `sha` tag with a raw sha from the inputs.