### PR TITLE
feat: externalise application log level

### DIFF
--- a/app/api/config/autoload/config.global.php
+++ b/app/api/config/autoload/config.global.php
@@ -376,7 +376,7 @@ return [
                             'priority' => [
                                 'name' => 'priority',
                                 'options' => [
-                                    'priority' => \Laminas\Log\Logger::WARN
+                                    'priority' => '%log_level%'
                                 ]
                             ],
                         ]
@@ -393,7 +393,7 @@ return [
                             'priority' => [
                                 'name' => 'priority',
                                 'options' => [
-                                    'priority' => \Laminas\Log\Logger::WARN
+                                    'priority' => '%log_level%'
                                 ]
                             ],
                         ]

--- a/app/api/config/autoload/local.php.dist
+++ b/app/api/config/autoload/local.php.dist
@@ -194,7 +194,7 @@ return [
               'priority' => [
                 'name' => 'priority',
                 'options' => [
-                  'priority' => \Laminas\Log\Logger::DEBUG
+                  'priority' => \Laminas\Log\Logger::WARN
                 ]
               ],
             ],

--- a/app/internal/config/autoload/config.global.php
+++ b/app/internal/config/autoload/config.global.php
@@ -111,7 +111,7 @@ return [
                             'priority' => [
                                 'name' => 'priority',
                                 'options' => [
-                                    'priority' => \Laminas\Log\Logger::WARN
+                                    'priority' => '%log_level%'
                                 ]
                             ],
                         ]

--- a/app/internal/config/autoload/local.php.dist
+++ b/app/internal/config/autoload/local.php.dist
@@ -82,7 +82,15 @@ return [
             'writers' => [
                 'full' => [
                     'options' => [
-                        'stream' => 'php://stdout'
+                        'stream' => 'php://stdout',
+                        'filters' => [
+                            'priority' => [
+                                'name' => 'priority',
+                                'options' => [
+                                    'priority' => \Laminas\Log\Logger::WARN,
+                                ],
+                            ],
+                        ],
                     ],
                 ]
             ]

--- a/app/selfserve/config/autoload/config.global.php
+++ b/app/selfserve/config/autoload/config.global.php
@@ -136,7 +136,7 @@ return [
                             'priority' => [
                                 'name' => 'priority',
                                 'options' => [
-                                    'priority' => \Laminas\Log\Logger::WARN
+                                    'priority' => '%log_level%'
                                 ]
                             ],
                         ]

--- a/app/selfserve/config/autoload/local.php.dist
+++ b/app/selfserve/config/autoload/local.php.dist
@@ -71,7 +71,15 @@ return [
             'writers' => [
                 'full' => [
                     'options' => [
-                        'stream' => 'php://stdout'
+                        'stream' => 'php://stdout',
+                        'filters' => [
+                            'priority' => [
+                                'name' => 'priority',
+                                'options' => [
+                                    'priority' => \Laminas\Log\Logger::WARN,
+                                ],
+                            ],
+                        ],
                     ],
                 ]
             ]


### PR DESCRIPTION
## Description

Uses the log level provided by parameter store. This allows the log level to be tweaked without building a new image (with the new config file).

Related issue: https://dvsa.atlassian.net/browse/VOL-5751