### PR TITLE
fix: disable events in developer tools

### DIFF
--- a/app/internal/config/autoload/laminas-developer-tools.local.php.dist
+++ b/app/internal/config/autoload/laminas-developer-tools.local.php.dist
@@ -1,153 +1,153 @@
 <?php
-return array(
-    'laminas-developer-tools' => array(
-        /**
-         * General Profiler settings
-         */
-        'profiler' => array(
-            /**
-             * Enables or disables the profiler.
-             *
-             * Expects: bool
-             * Default: true
-             */
-            'enabled' => true,
+return [
+  'laminas-developer-tools' => [
+    /**
+     * General Profiler settings
+     */
+    'profiler' => [
+      /**
+       * Enables or disables the profiler.
+       *
+       * Expects: bool
+       * Default: true
+       */
+      'enabled' => true,
 
-            /**
-             * Enables or disables the strict mode. If the strict mode is enabled, any error will throw an exception,
-             * otherwise all errors will be added to the report (and shown in the toolbar).
-             *
-             * Expects: bool
-             * Default: true
-             */
-            'strict' => true,
+      /**
+       * Enables or disables the strict mode. If the strict mode is enabled, any error will throw an exception,
+       * otherwise all errors will be added to the report (and shown in the toolbar).
+       *
+       * Expects: bool
+       * Default: true
+       */
+      'strict' => true,
 
-            /**
-             * If enabled, the profiler tries to flush the content before the it starts collecting data. This option
-             * will be ignored if the Toolbar is enabled.
-             *
-             * Note: The flush listener listens to the MvcEvent::EVENT_FINISH event with a priority of -9400. You have
-             * to disable this function if you wish to modify the output with a lower priority.
-             *
-             * Expects: bool
-             * Default: false
-             */
-            'flush_early' => false,
+      /**
+       * If enabled, the profiler tries to flush the content before the it starts collecting data. This option
+       * will be ignored if the Toolbar is enabled.
+       *
+       * Note: The flush listener listens to the MvcEvent::EVENT_FINISH event with a priority of -9400. You have
+       * to disable this function if you wish to modify the output with a lower priority.
+       *
+       * Expects: bool
+       * Default: false
+       */
+      'flush_early' => false,
 
-            /**
-             * The cache directory is used in the version check and for every storage type that writes to the disk.
-             * Note: The default value assumes that the current working directory is the application root.
-             *
-             * Expects: string
-             * Default: 'data/cache'
-             */
-            'cache_dir' => sys_get_temp_dir() . '/olcs',
+      /**
+       * The cache directory is used in the version check and for every storage type that writes to the disk.
+       * Note: The default value assumes that the current working directory is the application root.
+       *
+       * Expects: string
+       * Default: 'data/cache'
+       */
+      'cache_dir' => 'data/cache',
 
-            /**
-             * If a matches is defined, the profiler will be disabled if the request does not match the pattern.
-             *
-             * Example: 'matcher' => array('ip' => '127.0.0.1')
-             * OR
-             * 'matcher' => array('url' => array('path' => '/admin')
-             * Note: The matcher is not implemented yet!
-             */
-            'matcher' => array(),
+      /**
+       * If a matches is defined, the profiler will be disabled if the request does not match the pattern.
+       *
+       * Example: 'matcher' => array('ip' => '127.0.0.1')
+       * OR
+       * 'matcher' => array('url' => array('path' => '/admin')
+       * Note: The matcher is not implemented yet!
+       */
+      'matcher' => [],
 
-            /**
-             * Contains a list with all collector the profiler should run. Laminas Developer Tools ships with
-             * 'db' (Laminas\Db), 'time', 'event', 'memory', 'exception', 'request' and 'mail' (Laminas\Mail). If you wish to
-             * disable a default collector, simply set the value to null or false.
-             *
-             * Example: 'collectors' => array('db' => null)
-             * Expects: array
-             */
-            'collectors' => array()
-        ),
-        'events' => array(
-            /**
-             * Set to true to enable event-level logging for collectors that will support it. This enables a wildcard
-             * listener onto the shared event manager that will allow profiling of user-defined events as well as the
-             * built-in ZF events.
-             *
-             * Expects: bool
-             * Default: false
-             */
-            'enabled' => true,
+      /**
+       * Contains a list with all collector the profiler should run. Laminas Developer Tools ships with
+       * 'db' (Laminas\Db), 'time', 'event', 'memory', 'exception', 'request' and 'mail' (Laminas\Mail). If you
+       * wish to disable a default collector, simply set the value to null or false.
+       *
+       * Example: 'collectors' => array('db' => null)
+       * Expects: array
+       */
+      'collectors' => [],
+    ],
+    'events' => [
+      /**
+       * Set to true to enable event-level logging for collectors that will support it. This enables a wildcard
+       * listener onto the shared event manager that will allow profiling of user-defined events as well as the
+       * built-in Laminas events.
+       *
+       * Expects: bool
+       * Default: false
+       */
+      'enabled' => true,
 
-            /**
-             * Contains a list with all event-level collectors that should run. Laminas Developer Tools ships with 'time'
-             * and 'memory'. If you wish to disable a default collector, simply set the value to null or false.
-             *
-             * Example: 'collectors' => array('memory' => null)
-             * Expects: array
-             */
-            'collectors' => array(),
+      /**
+       * Contains a list with all event-level collectors that should run. Laminas Developer Tools ships with
+       * 'time' and 'memory'. If you wish to disable a default collector, simply set the value to null or false.
+       *
+       * Example: 'collectors' => array('memory' => null)
+       * Expects: array
+       */
+      'collectors' => [],
 
-            /**
-             * Contains event identifiers used with the event listener. Laminas Developer Tools defaults to listen to all
-             * events. If you wish to disable the default all-inclusive identifier, simply set the value to null or
-             * false.
-             *
-             * Example: 'identifiers' => array('all' => null, 'dispatchable' => 'Laminas\Stdlib\DispatchableInterface')
-             * Expects: array
-             */
-            'identifiers' => array()
-        ),
-        /**
-         * General Toolbar settings
-         */
-        'toolbar' => array(
-            /**
-             * Enables or disables the Toolbar.
-             *
-             * Expects: bool
-             * Default: false
-             */
-            'enabled' => true,
+      /**
+       * Contains event identifiers used with the event listener. Laminas Developer Tools defaults to listen to
+       * all events. If you wish to disable the default all-inclusive identifier, simply set the value to null or
+       * false.
+       *
+       * Example: 'identifiers' => array('all' => null, 'dispatchable' => 'Laminas\Stdlib\DispatchableInterface')
+       * Expects: array
+       */
+      'identifiers' => [],
+    ],
+    /**
+     * General Toolbar settings
+     */
+    'toolbar' => [
+      /**
+       * Enables or disables the Toolbar.
+       *
+       * Expects: bool
+       * Default: false
+       */
+      'enabled' => true,
 
-            /**
-             * If enabled, every empty collector will be hidden.
-             *
-             * Expects: bool
-             * Default: false
-             */
-            'auto_hide' => false,
+      /**
+       * If enabled, every empty collector will be hidden.
+       *
+       * Expects: bool
+       * Default: false
+       */
+      'auto_hide' => false,
 
-            /**
-             * The Toolbar position.
-             *
-             * Expects: string ('bottom' or 'top')
-             * Default: bottom
-             */
-            'position' => 'bottom',
+      /**
+       * The Toolbar position.
+       *
+       * Expects: string ('bottom' or 'top')
+       * Default: bottom
+       */
+      'position' => 'bottom',
 
-            /**
-             * If enabled, the Toolbar will check if your current Laminas Framework version is up-to-date.
-             * Note: The check will only occur once every hour.
-             *
-             * Expects: bool
-             * Default: false
-             */
-            'version_check' => false,
+      /**
+       * If enabled, the Toolbar will check if your current Laminas version is up-to-date.
+       * Note: The check will only occur once every hour.
+       *
+       * Expects: bool
+       * Default: false
+       */
+      'version_check' => false,
 
-            /**
-             * Contains a list with all collector toolbar templates. The name  of the array key must be same as the name
-             * of the collector.
-             *
-             * Example: 'profiler' => array(
-             *  'collectors' => array(
-             *      // My_Collector_Example::getName() -> mycollector
-             *      'MyCollector' => 'My_Collector_Example',
-             *  )
-             * ),
-             * 'toolbar' => array(
-             *  'entries' => array(
-             *      'mycollector' => 'example/toolbar/my-collector',
-             *  )
-             * ),
-             * Expects: array
-             */
-            'entries' => array()
-        )
-    )
-);
+      /**
+       * Contains a list with all collector toolbar templates. The name  of the array key must be same as the name
+       * of the collector.
+       *
+       * Example: 'profiler' => array(
+       *  'collectors' => array(
+       *      // My_Collector_Example::getName() -> mycollector
+       *      'MyCollector' => 'My_Collector_Example',
+       *  )
+       * ),
+       * 'toolbar' => array(
+       *  'entries' => array(
+       *      'mycollector' => 'example/toolbar/my-collector',
+       *  )
+       * ),
+       * Expects: array
+       */
+      'entries' => [],
+    ],
+  ],
+];

--- a/app/internal/config/autoload/laminas-developer-tools.local.php.dist
+++ b/app/internal/config/autoload/laminas-developer-tools.local.php.dist
@@ -91,7 +91,9 @@ return [
        * Example: 'identifiers' => array('all' => null, 'dispatchable' => 'Laminas\Stdlib\DispatchableInterface')
        * Expects: array
        */
-      'identifiers' => [],
+      'identifiers' => [
+        'all' => null,
+      ],
     ],
     /**
      * General Toolbar settings

--- a/app/internal/config/autoload/laminas-developer-tools.local.php.dist
+++ b/app/internal/config/autoload/laminas-developer-tools.local.php.dist
@@ -92,6 +92,8 @@ return [
        * Expects: array
        */
       'identifiers' => [
+        // There's a bug in Laminas Form that causes a TypeError caused by the Laminas Developer tools returning `void` into a `bool` type hint.
+        // https://github.com/laminas/laminas-form/blob/6e6e8210ef7b54fdecc0eb31c8ad30613b4ab299/src/Annotation/AbstractBuilder.php#L320
         'all' => null,
       ],
     ],

--- a/app/selfserve/config/autoload/laminas-developer-tools.local.php.dist
+++ b/app/selfserve/config/autoload/laminas-developer-tools.local.php.dist
@@ -1,153 +1,157 @@
 <?php
-return array(
-    'laminas-developer-tools' => array(
-        /**
-         * General Profiler settings
-         */
-        'profiler' => array(
-            /**
-             * Enables or disables the profiler.
-             *
-             * Expects: bool
-             * Default: true
-             */
-            'enabled' => true,
+return [
+  'laminas-developer-tools' => [
+    /**
+     * General Profiler settings
+     */
+    'profiler' => [
+      /**
+       * Enables or disables the profiler.
+       *
+       * Expects: bool
+       * Default: true
+       */
+      'enabled' => true,
 
-            /**
-             * Enables or disables the strict mode. If the strict mode is enabled, any error will throw an exception,
-             * otherwise all errors will be added to the report (and shown in the toolbar).
-             *
-             * Expects: bool
-             * Default: true
-             */
-            'strict' => true,
+      /**
+       * Enables or disables the strict mode. If the strict mode is enabled, any error will throw an exception,
+       * otherwise all errors will be added to the report (and shown in the toolbar).
+       *
+       * Expects: bool
+       * Default: true
+       */
+      'strict' => true,
 
-            /**
-             * If enabled, the profiler tries to flush the content before the it starts collecting data. This option
-             * will be ignored if the Toolbar is enabled.
-             *
-             * Note: The flush listener listens to the MvcEvent::EVENT_FINISH event with a priority of -9400. You have
-             * to disable this function if you wish to modify the output with a lower priority.
-             *
-             * Expects: bool
-             * Default: false
-             */
-            'flush_early' => false,
+      /**
+       * If enabled, the profiler tries to flush the content before the it starts collecting data. This option
+       * will be ignored if the Toolbar is enabled.
+       *
+       * Note: The flush listener listens to the MvcEvent::EVENT_FINISH event with a priority of -9400. You have
+       * to disable this function if you wish to modify the output with a lower priority.
+       *
+       * Expects: bool
+       * Default: false
+       */
+      'flush_early' => false,
 
-            /**
-             * The cache directory is used in the version check and for every storage type that writes to the disk.
-             * Note: The default value assumes that the current working directory is the application root.
-             *
-             * Expects: string
-             * Default: 'data/cache'
-             */
-            'cache_dir' => sys_get_temp_dir() . '/olcs',
+      /**
+       * The cache directory is used in the version check and for every storage type that writes to the disk.
+       * Note: The default value assumes that the current working directory is the application root.
+       *
+       * Expects: string
+       * Default: 'data/cache'
+       */
+      'cache_dir' => 'data/cache',
 
-            /**
-             * If a matches is defined, the profiler will be disabled if the request does not match the pattern.
-             *
-             * Example: 'matcher' => array('ip' => '127.0.0.1')
-             * OR
-             * 'matcher' => array('url' => array('path' => '/admin')
-             * Note: The matcher is not implemented yet!
-             */
-            'matcher' => array(),
+      /**
+       * If a matches is defined, the profiler will be disabled if the request does not match the pattern.
+       *
+       * Example: 'matcher' => array('ip' => '127.0.0.1')
+       * OR
+       * 'matcher' => array('url' => array('path' => '/admin')
+       * Note: The matcher is not implemented yet!
+       */
+      'matcher' => [],
 
-            /**
-             * Contains a list with all collector the profiler should run. Laminas Developer Tools ships with
-             * 'db' (Laminas\Db), 'time', 'event', 'memory', 'exception', 'request' and 'mail' (Laminas\Mail). If you wish to
-             * disable a default collector, simply set the value to null or false.
-             *
-             * Example: 'collectors' => array('db' => null)
-             * Expects: array
-             */
-            'collectors' => array()
-        ),
-        'events' => array(
-            /**
-             * Set to true to enable event-level logging for collectors that will support it. This enables a wildcard
-             * listener onto the shared event manager that will allow profiling of user-defined events as well as the
-             * built-in ZF events.
-             *
-             * Expects: bool
-             * Default: false
-             */
-            'enabled' => true,
+      /**
+       * Contains a list with all collector the profiler should run. Laminas Developer Tools ships with
+       * 'db' (Laminas\Db), 'time', 'event', 'memory', 'exception', 'request' and 'mail' (Laminas\Mail). If you
+       * wish to disable a default collector, simply set the value to null or false.
+       *
+       * Example: 'collectors' => array('db' => null)
+       * Expects: array
+       */
+      'collectors' => [],
+    ],
+    'events' => [
+      /**
+       * Set to true to enable event-level logging for collectors that will support it. This enables a wildcard
+       * listener onto the shared event manager that will allow profiling of user-defined events as well as the
+       * built-in Laminas events.
+       *
+       * Expects: bool
+       * Default: false
+       */
+      'enabled' => true,
 
-            /**
-             * Contains a list with all event-level collectors that should run. Laminas Developer Tools ships with 'time'
-             * and 'memory'. If you wish to disable a default collector, simply set the value to null or false.
-             *
-             * Example: 'collectors' => array('memory' => null)
-             * Expects: array
-             */
-            'collectors' => array(),
+      /**
+       * Contains a list with all event-level collectors that should run. Laminas Developer Tools ships with
+       * 'time' and 'memory'. If you wish to disable a default collector, simply set the value to null or false.
+       *
+       * Example: 'collectors' => array('memory' => null)
+       * Expects: array
+       */
+      'collectors' => [],
 
-            /**
-             * Contains event identifiers used with the event listener. Laminas Developer Tools defaults to listen to all
-             * events. If you wish to disable the default all-inclusive identifier, simply set the value to null or
-             * false.
-             *
-             * Example: 'identifiers' => array('all' => null, 'dispatchable' => 'Laminas\Stdlib\DispatchableInterface')
-             * Expects: array
-             */
-            'identifiers' => array()
-        ),
-        /**
-         * General Toolbar settings
-         */
-        'toolbar' => array(
-            /**
-             * Enables or disables the Toolbar.
-             *
-             * Expects: bool
-             * Default: false
-             */
-            'enabled' => true,
+      /**
+       * Contains event identifiers used with the event listener. Laminas Developer Tools defaults to listen to
+       * all events. If you wish to disable the default all-inclusive identifier, simply set the value to null or
+       * false.
+       *
+       * Example: 'identifiers' => array('all' => null, 'dispatchable' => 'Laminas\Stdlib\DispatchableInterface')
+       * Expects: array
+       */
+      'identifiers' => [
+        // There's a bug in Laminas Form that causes a TypeError caused by the Laminas Developer tools returning `void` into a `bool` type hint.
+        // https://github.com/laminas/laminas-form/blob/6e6e8210ef7b54fdecc0eb31c8ad30613b4ab299/src/Annotation/AbstractBuilder.php#L320
+        'all' => null,
+      ],
+    ],
+    /**
+     * General Toolbar settings
+     */
+    'toolbar' => [
+      /**
+       * Enables or disables the Toolbar.
+       *
+       * Expects: bool
+       * Default: false
+       */
+      'enabled' => true,
 
-            /**
-             * If enabled, every empty collector will be hidden.
-             *
-             * Expects: bool
-             * Default: false
-             */
-            'auto_hide' => false,
+      /**
+       * If enabled, every empty collector will be hidden.
+       *
+       * Expects: bool
+       * Default: false
+       */
+      'auto_hide' => false,
 
-            /**
-             * The Toolbar position.
-             *
-             * Expects: string ('bottom' or 'top')
-             * Default: bottom
-             */
-            'position' => 'bottom',
+      /**
+       * The Toolbar position.
+       *
+       * Expects: string ('bottom' or 'top')
+       * Default: bottom
+       */
+      'position' => 'bottom',
 
-            /**
-             * If enabled, the Toolbar will check if your current Laminas Framework version is up-to-date.
-             * Note: The check will only occur once every hour.
-             *
-             * Expects: bool
-             * Default: false
-             */
-            'version_check' => false,
+      /**
+       * If enabled, the Toolbar will check if your current Laminas version is up-to-date.
+       * Note: The check will only occur once every hour.
+       *
+       * Expects: bool
+       * Default: false
+       */
+      'version_check' => false,
 
-            /**
-             * Contains a list with all collector toolbar templates. The name  of the array key must be same as the name
-             * of the collector.
-             *
-             * Example: 'profiler' => array(
-             *  'collectors' => array(
-             *      // My_Collector_Example::getName() -> mycollector
-             *      'MyCollector' => 'My_Collector_Example',
-             *  )
-             * ),
-             * 'toolbar' => array(
-             *  'entries' => array(
-             *      'mycollector' => 'example/toolbar/my-collector',
-             *  )
-             * ),
-             * Expects: array
-             */
-            'entries' => array()
-        )
-    )
-);
+      /**
+       * Contains a list with all collector toolbar templates. The name  of the array key must be same as the name
+       * of the collector.
+       *
+       * Example: 'profiler' => array(
+       *  'collectors' => array(
+       *      // My_Collector_Example::getName() -> mycollector
+       *      'MyCollector' => 'My_Collector_Example',
+       *  )
+       * ),
+       * 'toolbar' => array(
+       *  'entries' => array(
+       *      'mycollector' => 'example/toolbar/my-collector',
+       *  )
+       * ),
+       * Expects: array
+       */
+      'entries' => [],
+    ],
+  ],
+];


### PR DESCRIPTION
## Description

To workaround the `laminas-form` bug. This disables the events so no collectors are ran during event triggers. Can be re-enables when `laminas-form` is fixed.