### PR TITLE
feat(docker): update PHP-FPM config

### DIFF
--- a/infra/docker/api/Dockerfile
+++ b/infra/docker/api/Dockerfile
@@ -21,6 +21,9 @@ RUN apk add --no-cache libreoffice cups-client poppler-utils
 # PHP config file
 COPY ./php.ini ${PHP_INI_DIR}/conf.d/zzzz-php.ini
 
+# PHP-FPM config file
+COPY php-fpm.conf /usr/local/etc/php-fpm.d/zzzz-www.conf
+
 # nginx server config file
 COPY api.conf /etc/nginx/conf.d/api.conf
 

--- a/infra/docker/api/php-fpm.conf
+++ b/infra/docker/api/php-fpm.conf
@@ -1,0 +1,29 @@
+; The access log file.
+; Default value: not set
+access.log = /dev/null
+
+; The number of child processes to be created when pm is set to 'static' and the
+; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.
+; This value sets the limit on the number of simultaneous requests that will be
+; served. Equivalent to the ApacheMaxClients directive with mpm_prefork.
+; Equivalent to the PHP_FCGI_CHILDREN environment variable in the original PHP
+; CGI. The below defaults are based on a server without much resources. Don't
+; forget to tweak pm.* to fit your needs.
+; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
+; Note: This value is mandatory.
+pm.max_children = 40
+
+; The number of child processes created on startup.
+; Note: Used only when pm is set to 'dynamic'
+; Default Value: (min_spare_servers + max_spare_servers) / 2
+pm.start_servers = 4
+
+; The desired minimum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.min_spare_servers = 2
+
+; The desired maximum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.max_spare_servers = 4

--- a/infra/docker/cli/Dockerfile
+++ b/infra/docker/cli/Dockerfile
@@ -18,6 +18,9 @@ RUN apk add --no-cache icu-dev \
 # PHP config file
 COPY ./php.ini ${PHP_INI_DIR}/conf.d/zzzz-php.ini
 
+# PHP-FPM config file
+COPY php-fpm.conf /usr/local/etc/php-fpm.d/zzzz-www.conf
+
 EXPOSE 8080
 
 FROM cli AS production

--- a/infra/docker/cli/php-fpm.conf
+++ b/infra/docker/cli/php-fpm.conf
@@ -1,0 +1,29 @@
+; The access log file.
+; Default value: not set
+access.log = /dev/null
+
+; The number of child processes to be created when pm is set to 'static' and the
+; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.
+; This value sets the limit on the number of simultaneous requests that will be
+; served. Equivalent to the ApacheMaxClients directive with mpm_prefork.
+; Equivalent to the PHP_FCGI_CHILDREN environment variable in the original PHP
+; CGI. The below defaults are based on a server without much resources. Don't
+; forget to tweak pm.* to fit your needs.
+; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
+; Note: This value is mandatory.
+pm.max_children = 40
+
+; The number of child processes created on startup.
+; Note: Used only when pm is set to 'dynamic'
+; Default Value: (min_spare_servers + max_spare_servers) / 2
+pm.start_servers = 4
+
+; The desired minimum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.min_spare_servers = 2
+
+; The desired maximum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.max_spare_servers = 4

--- a/infra/docker/internal/Dockerfile
+++ b/infra/docker/internal/Dockerfile
@@ -26,6 +26,9 @@ COPY /clamav/supervisord.conf /etc/supervisor/conf.d/clamd.conf
 # PHP config file
 COPY ./php.ini ${PHP_INI_DIR}/conf.d/zzzz-php.ini
 
+# PHP-FPM config file
+COPY php-fpm.conf /usr/local/etc/php-fpm.d/zzzz-www.conf
+
 # nginx server config file
 COPY internal.conf /etc/nginx/conf.d/internal.conf
 

--- a/infra/docker/internal/php-fpm.conf
+++ b/infra/docker/internal/php-fpm.conf
@@ -1,0 +1,29 @@
+; The access log file.
+; Default value: not set
+access.log = /dev/null
+
+; The number of child processes to be created when pm is set to 'static' and the
+; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.
+; This value sets the limit on the number of simultaneous requests that will be
+; served. Equivalent to the ApacheMaxClients directive with mpm_prefork.
+; Equivalent to the PHP_FCGI_CHILDREN environment variable in the original PHP
+; CGI. The below defaults are based on a server without much resources. Don't
+; forget to tweak pm.* to fit your needs.
+; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
+; Note: This value is mandatory.
+pm.max_children = 40
+
+; The number of child processes created on startup.
+; Note: Used only when pm is set to 'dynamic'
+; Default Value: (min_spare_servers + max_spare_servers) / 2
+pm.start_servers = 4
+
+; The desired minimum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.min_spare_servers = 2
+
+; The desired maximum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.max_spare_servers = 4

--- a/infra/docker/selfserve/Dockerfile
+++ b/infra/docker/selfserve/Dockerfile
@@ -26,6 +26,9 @@ COPY /clamav/supervisord.conf /etc/supervisor/conf.d/clamd.conf
 # PHP config file
 COPY ./php.ini ${PHP_INI_DIR}/conf.d/zzzz-php.ini
 
+# PHP-FPM config file
+COPY php-fpm.conf /usr/local/etc/php-fpm.d/zzzz-www.conf
+
 # nginx server config file
 COPY selfserve.conf /etc/nginx/conf.d/selfserve.conf
 

--- a/infra/docker/selfserve/php-fpm.conf
+++ b/infra/docker/selfserve/php-fpm.conf
@@ -1,0 +1,29 @@
+; The access log file.
+; Default value: not set
+access.log = /dev/null
+
+; The number of child processes to be created when pm is set to 'static' and the
+; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.
+; This value sets the limit on the number of simultaneous requests that will be
+; served. Equivalent to the ApacheMaxClients directive with mpm_prefork.
+; Equivalent to the PHP_FCGI_CHILDREN environment variable in the original PHP
+; CGI. The below defaults are based on a server without much resources. Don't
+; forget to tweak pm.* to fit your needs.
+; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
+; Note: This value is mandatory.
+pm.max_children = 40
+
+; The number of child processes created on startup.
+; Note: Used only when pm is set to 'dynamic'
+; Default Value: (min_spare_servers + max_spare_servers) / 2
+pm.start_servers = 4
+
+; The desired minimum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.min_spare_servers = 2
+
+; The desired maximum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.max_spare_servers = 4


### PR DESCRIPTION
## Description

- Removes the PHP-FPM access logging to clear up the logging.
- Tweaks the process manager config to align with available resources. This is to trial with the non-functional tests.

`max_children` 
Equation: max memory / memory for single process 

4GB / 100MB (768MB is max PHP memory, but the app uses ~50MB on a typical request. 100MB was doubling the 50MB) = 40 (ish). This will be subject to change in the future as memory fluctuates.

`start_servers`
Equation: number of CPU cores * 4 

`min_spare_servers`
Equation: number of CPU cores * 2

`max_spare_servers`
Equation: number of CPU cores * 4