### PR TITLE
feat(docker): exclude `/healthcheck` from access logs

### DIFF
--- a/infra/docker/api/api.conf
+++ b/infra/docker/api/api.conf
@@ -1,3 +1,9 @@
+map $request_uri $should_log {
+  default 1;
+  # The security group healthcheck endpoint.
+  ~^/healthcheck 0;
+}
+
 server {
   listen 8080;
   listen [::]:8080;
@@ -5,6 +11,8 @@ server {
   server_name _;
 
   root /var/www/html/public;
+
+  access_log /dev/stdout main if=$should_log;
 
   # Prevent some browsers from MIME-sniffing the response.
   #

--- a/infra/docker/internal/internal.conf
+++ b/infra/docker/internal/internal.conf
@@ -1,3 +1,9 @@
+map $request_uri $should_log {
+  default 1;
+  # The security group healthcheck endpoint.
+  ~^/healthcheck 0;
+}
+
 # Add Access-Control-Allow-Origin.
 map $sent_http_content_type $cors {
   # Images
@@ -30,6 +36,8 @@ server {
   server_name _;
 
   root /var/www/html/public;
+
+  access_log /dev/stdout main if=$should_log;
 
   # Protect website against clickjacking.
   #

--- a/infra/docker/selfserve/selfserve.conf
+++ b/infra/docker/selfserve/selfserve.conf
@@ -1,3 +1,9 @@
+map $request_uri $should_log {
+  default 1;
+  # The security group healthcheck endpoint.
+  ~^/healthcheck 0;
+}
+
 # Add Access-Control-Allow-Origin.
 map $sent_http_content_type $cors {
   # Images
@@ -30,6 +36,8 @@ server {
   server_name _;
 
   root /var/www/html/public;
+
+  access_log /dev/stdout main if=$should_log;
 
   # Protect website against clickjacking.
   #


### PR DESCRIPTION
## Description

The `/healthcheck` is used by the load balancers as a health check endpoint. The access log entry is not useful to anyone and causes lots of noise.

This PR excludes that endpoint from the access logs.