### PR TITLE
feat: expand list of licence and application statuses in dropdown

### DIFF
--- a/app/api/module/Api/src/Domain/QueryHandler/Messaging/ApplicationLicenceList/ByOrganisation.php
+++ b/app/api/module/Api/src/Domain/QueryHandler/Messaging/ApplicationLicenceList/ByOrganisation.php
@@ -43,13 +43,22 @@ class ByOrganisation extends AbstractQueryHandler implements ToggleRequiredInter
 
         $licences = $licenceRepository->fetchByOrganisationIdAndStatuses(
             $orgId,
-            [Licence::LICENCE_STATUS_VALID, Licence::LICENCE_STATUS_SUSPENDED, Licence::LICENCE_STATUS_CURTAILED],
+            [
+                Licence::LICENCE_STATUS_VALID,
+                Licence::LICENCE_STATUS_SUSPENDED,
+                Licence::LICENCE_STATUS_CURTAILED,
+                Licence::LICENCE_STATUS_SURRENDER_UNDER_CONSIDERATION
+            ],
         );
 
         /** @var Application[] $applications */
         $applications = $applicationRepository->fetchByOrganisationIdAndStatuses(
             $orgId,
-            [Entity::APPLICATION_STATUS_UNDER_CONSIDERATION, Entity::APPLICATION_STATUS_UNDER_CONSIDERATION],
+            [
+                Entity::APPLICATION_STATUS_UNDER_CONSIDERATION,
+                Entity::APPLICATION_STATUS_UNDER_CONSIDERATION,
+                Entity::APPLICATION_STATUS_GRANTED
+            ],
         );
 
         $results = array_fill_keys(['licences', 'applications'], []);

--- a/app/api/test/module/Api/src/Domain/QueryHandler/Messaging/ApplicationLicenceList/ByOrganisationTest.php
+++ b/app/api/test/module/Api/src/Domain/QueryHandler/Messaging/ApplicationLicenceList/ByOrganisationTest.php
@@ -28,9 +28,21 @@ class ByOrganisationTest extends QueryHandlerTestCase
         $this->mockRepo(Repository\Application::class, Repository\Application::class);
         $this->mockRepo(Repository\Licence::class, Repository\Licence::class);
 
-        $this->mockedSmServices = ['SectionAccessService' => m::mock(), AuthorizationService::class => m::mock(AuthorizationService::class)->shouldReceive('isGranted')->with(Permission::SELFSERVE_USER, null)->andReturn(true)->shouldReceive('isGranted')->with(Permission::INTERNAL_USER, null)->andReturn(false)->getMock(),];
+        $this->mockedSmServices = [
+            'SectionAccessService' => m::mock(),
+            AuthorizationService::class => m::mock(AuthorizationService::class)
+                ->shouldReceive('isGranted')
+                ->with(Permission::SELFSERVE_USER, null)
+                ->andReturn(true)
+                ->shouldReceive('isGranted')
+                ->with(Permission::INTERNAL_USER, null)
+                ->andReturn(false)
+                ->getMock(),
+            ];
 
-        $this->mockedSmServices[AuthorizationService::class]->shouldReceive('getIdentity->getUser->getId')->andReturn(1);
+        $this->mockedSmServices[AuthorizationService::class]
+            ->shouldReceive('getIdentity->getUser->getId')
+            ->andReturn(1);
 
         parent::setUp();
     }


### PR DESCRIPTION
## Description

Add new statuses to include in messaging Licence/Application select dropdown on Create Message page.

Related issue: [VOL-5749](https://dvsa.atlassian.net/browse/VOL-5749)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
