### PR TITLE
feat: change the continuation information email templates to use translation key

### DIFF
--- a/app/api/module/Email/view/email/cy_GB/html/licensing-information-continuation.phtml
+++ b/app/api/module/Email/view/email/cy_GB/html/licensing-information-continuation.phtml
@@ -1,14 +1,7 @@
-<p>Annwyl weithredwr,</p>
+<?php echo $this->translate('email.licensing-information-continuation-html.body'); ?>
 
-<p>Rhoddwyd dogfennaeth bwysig ynghylch parhad eich Trwydded Gweithredwr&rsquo;s
-    am <?php echo $this->escapeHtml($this->licNo) . ' ' . $this->escapeHtml($this->operatorName); ?> wedi'i rhoi yn eich
-    mewnflwch gohebiaeth Hunan Wasanaeth.</p>
-
-<p>Nodwch fod rhaid ichi brintio'r ddogfen barhad, ei llofnodi a'i dychwelyd i'r swyddfa cyn gynted â phosibl,
-    gan amlygu unrhyw newidiadau i'r manylion ar y ddogfen.</p>
-
-<p>Nid anfonir copi papur o'r ddogfen hon ichi.</p>
+<p>Trwydded: <?php echo $this->escapeHtml($this->licNo) . ' ' . $this->escapeHtml($this->operatorName); ?></p>
 
 <p>
-    <a href="<?php echo $this->escapeHtml($this->url); ?>">Mewngofnodi i'ch cyfrif</a>
+  <a href="<?php echo $this->escapeHtml($this->url); ?>">Mewngofnodi i'ch cyfrif</a>
 </p>

--- a/app/api/module/Email/view/email/cy_GB/plain/licensing-information-continuation.phtml
+++ b/app/api/module/Email/view/email/cy_GB/plain/licensing-information-continuation.phtml
@@ -1,9 +1,5 @@
-Annwyl weithredwr,
+<?php echo $this->translate('email.licensing-information-continuation-plain.body'); ?>
 
-Rhoddwyd dogfennaeth bwysig ynghylch parhad eich Trwydded Gweithredwr's am<?php echo $this->licNo . ' ' . $this->operatorName; ?> wedi'i rhoi yn eich mewnflwch gohebiaeth Hunan Wasanaeth.
+Trwydded: <?php echo $this->licNo . ' ' . $this->operatorName; ?>
 
-Nodwch fod rhaid ichi brintio'r ddogfen barhad, ei llofnodi a'i dychwelyd i'r swyddfa cyn gynted â phosibl, gan amlygu unrhyw newidiadau i'r manylion ar y ddogfen.
-
-Nid anfonir copi papur o'r ddogfen hon ichi.
-
-Mewngofnodi i'ch cyfrif <?php echo $this->url; ?>.
+Mewngofnodi i'ch cyfrif yn: <?php echo $this->url; ?>.

--- a/app/api/module/Email/view/email/en_GB/html/licensing-information-continuation.phtml
+++ b/app/api/module/Email/view/email/en_GB/html/licensing-information-continuation.phtml
@@ -1,14 +1,7 @@
-<p>Dear operator,</p>
+<?php echo $this->translate('email.licensing-information-continuation-html.body'); ?>
 
-<p>Important documentation relating to your Operator&rsquo;s Licence continuation for
- <?php echo $this->escapeHtml($this->licNo) . ' ' . $this->escapeHtml($this->operatorName); ?> has been placed in your
- Self Service correspondence inbox.</p>
-
-<p>Please note that you must print off the continuation document, sign it and return it
-to the office as soon as possible, highlighting any changes to the details on the document.</p>
-
-<p>You will not be sent a paper copy of this document.</p>
+<p>Licence: <?php echo $this->escapeHtml($this->licNo) . ' ' . $this->escapeHtml($this->operatorName); ?></p>
 
 <p>
-    <a href="<?php echo $this->escapeHtml($this->url); ?>">Sign in to your account</a>
+  <a href="<?php echo $this->escapeHtml($this->url); ?>">Sign in to your account</a>
 </p>

--- a/app/api/module/Email/view/email/en_GB/plain/licensing-information-continuation.phtml
+++ b/app/api/module/Email/view/email/en_GB/plain/licensing-information-continuation.phtml
@@ -1,9 +1,5 @@
-Dear operator,
+<?php echo $this->translate('email.licensing-information-continuation-plain.body'); ?>
 
-Important documentation relating to your Operator's Licence continuation for <?php echo $this->licNo . ' ' . $this->operatorName; ?> has been placed in your Self Service correspondence inbox.
-
-Please note that you must print off the continuation document, sign it and return it to the office as soon as possible, highlighting any changes to the details on the document.
-
-You will not be sent a paper copy of this document.
+Licence: <?php echo $this->licNo . ' ' . $this->operatorName; ?>
 
 Sign in to your account at <?php echo $this->url; ?>.


### PR DESCRIPTION
## Description

Update english and welsh templates to pull main body from a translation key for continuation information emails.

Related issue: [VOL-5756](https://dvsa.atlassian.net/browse/VOL-5756)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
