### PR TITLE
fix(terraform): use `legacy_environment` for environment name in the batch jobs

### DIFF
--- a/infra/terraform/modules/service/README.md
+++ b/infra/terraform/modules/service/README.md
@@ -23,7 +23,7 @@
 | <a name="module_ecs_service"></a> [ecs\_service](#module\_ecs\_service) | terraform-aws-modules/ecs/aws//modules/service | ~> 5.10 |
 | <a name="module_eventbridge"></a> [eventbridge](#module\_eventbridge) | terraform-aws-modules/eventbridge/aws | ~> 3.7 |
 | <a name="module_log_bucket"></a> [log\_bucket](#module\_log\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 4.0 |
-| <a name="module_records"></a> [records](#module\_records) | terraform-aws-modules/route53/aws//modules/records | ~> 3.1 |
+| <a name="module_records"></a> [records](#module\_records) | terraform-aws-modules/route53/aws//modules/records | ~> 4.0 |
 | <a name="module_route53_records"></a> [route53\_records](#module\_route53\_records) | terraform-aws-modules/acm/aws | ~> 5.0 |
 
 ## Resources

--- a/infra/terraform/modules/service/batch.tf
+++ b/infra/terraform/modules/service/batch.tf
@@ -30,7 +30,7 @@ locals {
       environment = [
         {
           name  = "ENVIRONMENT_NAME"
-          value = var.environment
+          value = var.legacy_environment
         },
         {
           name  = "APP_VERSION"


### PR DESCRIPTION
## Description

The `ENVIRONMENT_NAME` variable is used to fetch parameters and secrets. Parameters and secrets are using the old environment names. 

The `legacy_environment` variable will contain that old name.
