### PR TITLE
fix(internal): remove unnecessary login hop

### DIFF
--- a/app/internal/module/Olcs/src/Controller/Auth/LoginController.php
+++ b/app/internal/module/Olcs/src/Controller/Auth/LoginController.php
@@ -128,7 +128,7 @@ class LoginController implements InjectApplicationEventInterface
         $result = $this->attemptAuthentication($request);
 
         if ($result->getCode() === Result::SUCCESS) {
-            return $this->handleSuccessfulAuthentication($result, $response, $request);
+            return $this->redirectHelper->toRoute(static::ROUTE_DASHBOARD);
         }
 
         if ($result->getCode() === static::AUTH_SUCCESS_WITH_CHALLENGE) {
@@ -220,33 +220,6 @@ class LoginController implements InjectApplicationEventInterface
 
         $result = $this->authenticationService->authenticate($this->authenticationAdapter);
         return $result;
-    }
-
-    /**
-     * Handles successful authentication.
-     *
-     * @return Response
-     */
-    private function handleSuccessfulAuthentication(Result $result, Response $response, Request $request)
-    {
-        $identityProvider = $result->getIdentity()['provider'];
-
-        if ($identityProvider === self::DVSA_OLCS_AUTH_CLIENT_COGNITO) {
-            return $this->handleSuccessCognitoResult();
-        }
-
-        return $this->redirectHelper->toRoute(static::ROUTE_AUTH_LOGIN_GET);
-    }
-
-    /**
-     * @param array $identity
-     * @param Request $request
-     * @param Response $response
-     * @return Response
-     */
-    private function handleSuccessCognitoResult()
-    {
-        return $this->redirectHelper->toRoute(static::ROUTE_DASHBOARD);
     }
 
     /**


### PR DESCRIPTION
## Description

On successful login, the user was being redirected back to the login page due to a bug. This was not noticeable as the login page would then redirect back to the dashboard. This fixes that unnecessary hop.

This is a bug as the hop wouldn't be triggered but we were trying to find `provider` in the API response, this is keyed as `Provider` instead.

https://github.com/dvsa/vol-app/pull/299/files#diff-dc696a5ccd77b1427575a83f6c3ab13433dde405bb961223735f87a82b400ac7L232