### PR TITLE
fix(docker): add `port_in_redirect off` for One Login redirect

### DIFF
--- a/infra/docker/selfserve/selfserve.conf
+++ b/infra/docker/selfserve/selfserve.conf
@@ -146,10 +146,12 @@ server {
   }
 
   location = /govuk-id/loggedin {
+    port_in_redirect off;
     return 302 /govukaccount-redirect.php;
   }
 
   location = /govuk-id/loggedout {
+    port_in_redirect off;
     return 302 /govukaccount-redirect.php;
   }
 


### PR DESCRIPTION
## Description

Removes the port from the redirect. This will fix Gov.UK One login on ECS.

Before on the redirect, it was trying to go to port `8080` (instead of 80).