### PR TITLE
fix(docker): forward query parameters for GOV.UK OneLogin redirect

### DIFF
--- a/app/api/config/autoload/local.php.dist
+++ b/app/api/config/autoload/local.php.dist
@@ -337,7 +337,7 @@ return [
     ],
   ],
   'govuk_account' => [
-    'redirectUri' => 'https://ssweb.dev.olcs.dev-dvsacloud.uk/govuk-id/loggedin',
+    'redirectUri' => 'http://ssweb.local.olcs.dev-dvsacloud.uk/govuk-id/loggedin',
     'discovery_endpoint' => 'https://oidc.integration.account.gov.uk/.well-known/openid-configuration',
     'client_id' => '',
     'keys' => [
@@ -347,8 +347,8 @@ return [
       'identity_assurance_public_key' => (array)json_decode('{"kty":"EC","use":"sig","crv":"P-256","x":"NPGA7cyIKtH1nz2CJIH14s9_CtC93NwdCQcEi-ADvxg=","y":"2cTdmHAmZjighly34lXcxEw50cbKFV7FTOdZKhOG7ps=","alg":"ES256"}'),
     ],
     'redirect_uri' => [
-      'logged_in' => 'https://olcs-selfserve/govuk-id/loggedin',
-      'logged_out' => 'https://olcs-selfserve/govuk-id/loggedout',
+      'logged_in' => 'http://ssweb.local.olcs.dev-dvsacloud.uk/govuk-id/loggedin',
+      'logged_out' => 'http://ssweb.local.olcs.dev-dvsacloud.uk/govuk-id/loggedout',
     ],
     'expected_core_identity_issuer' => 'https://identity.integration.account.gov.uk/',
     'proxy' => new \Laminas\Stdlib\ArrayUtils\MergeRemoveKey(),

--- a/infra/docker/selfserve/selfserve.conf
+++ b/infra/docker/selfserve/selfserve.conf
@@ -147,12 +147,12 @@ server {
 
   location = /govuk-id/loggedin {
     port_in_redirect off;
-    return 302 /govukaccount-redirect.php;
+    return 302 /govukaccount-redirect.php$is_args$args;
   }
 
   location = /govuk-id/loggedout {
     port_in_redirect off;
-    return 302 /govukaccount-redirect.php;
+    return 302 /govukaccount-redirect.php$is_args$args;
   }
 
   location ~ \.php$ {


### PR DESCRIPTION
## Description

Forwards the query parameters when doing the GOV.UK OneLogin journey. This should hopefully fix the OneLogin issue in ECS.

This PR also updates the local config domains to be more accurate.