### PR TITLE
fix(api): fix the local register journey while using LDAP

### DIFF
--- a/app/api/module/Auth/src/Adapter/LdapAdapter.php
+++ b/app/api/module/Auth/src/Adapter/LdapAdapter.php
@@ -92,7 +92,10 @@ class LdapAdapter extends AbstractAdapter
      */
     public function register(string $identifier, string $password, string $email, array $attributes = []): void
     {
-        $attributes = array_merge(['email' => $email], $attributes);
+        // The `sn` attribute is required while using the object class `inetOrgPerson`.
+        // This is a local authentication adapter so the data in the `sn` field isn't important.
+        $attributes['sn'] = $identifier;
+
         $this->client->register($identifier, $password, $attributes);
     }
 

--- a/app/api/module/Auth/src/Adapter/LdapAdapterFactory.php
+++ b/app/api/module/Auth/src/Adapter/LdapAdapterFactory.php
@@ -12,7 +12,13 @@ class LdapAdapterFactory implements FactoryInterface
 {
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): LdapAdapter
     {
+        /**
+         * @var Client $client
+         */
         $client = $container->get(Client::class);
+
+        // Using an object class without a `userAccountControl` attribute.
+        $client->setUserAccountControlAttribute(null);
 
         return new LdapAdapter($client);
     }


### PR DESCRIPTION
## Description

The Ldap user objectClass requires a `sn` attribute passing. As this is only a local adapter, the `sn` is populated by the identifier to satisfy the schema.

The objectClass also doesn't have any user account control so that has been disabled.