### PR TITLE
fix: alter CDN module to create public record rather than private

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -142,7 +142,7 @@ module "service" {
 
   legacy_environment = "DEV"
 
-  domain_name    = "dev.olcs.dev-dvsacloud.uk"
+  domain_name    = "dev-dvsacloud.uk"
   assets_version = var.assets_version
 
   vpc_id = data.aws_vpc.this.id

--- a/infra/terraform/environments/int/main.tf
+++ b/infra/terraform/environments/int/main.tf
@@ -142,7 +142,7 @@ module "service" {
 
   legacy_environment = "QA"
 
-  domain_name    = "qa.olcs.dev-dvsacloud.uk"
+  domain_name    = "dev-dvsacloud.uk"
   assets_version = var.assets_version
 
   vpc_id = data.aws_vpc.this.id

--- a/infra/terraform/modules/service/README.md
+++ b/infra/terraform/modules/service/README.md
@@ -36,7 +36,6 @@
 | [aws_lb_target_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
 | [aws_canonical_user_id.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/canonical_user_id) | data source |
 | [aws_cloudfront_log_delivery_canonical_user_id.cloudfront](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_log_delivery_canonical_user_id) | data source |
-| [aws_route53_zone.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [aws_route53_zone.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [aws_s3_bucket.assets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 

--- a/infra/terraform/modules/service/cdn.tf
+++ b/infra/terraform/modules/service/cdn.tf
@@ -200,7 +200,7 @@ module "records" {
   source  = "terraform-aws-modules/route53/aws//modules/records"
   version = "~> 4.0"
 
-  zone_id = data.aws_route53_zone.private.zone_id
+  zone_id = data.aws_route53_zone.public.zone_id
 
   records = [
     {

--- a/infra/terraform/modules/service/cdn.tf
+++ b/infra/terraform/modules/service/cdn.tf
@@ -23,7 +23,7 @@ data "aws_route53_zone" "public" {
 
 locals {
   domain_name = data.aws_route53_zone.public.name
-  subdomain   = "${environment}-cdn"
+  subdomain   = "${var.environment}-cdn"
 }
 
 module "acm" {

--- a/infra/terraform/modules/service/cdn.tf
+++ b/infra/terraform/modules/service/cdn.tf
@@ -21,15 +21,9 @@ data "aws_route53_zone" "public" {
   name = var.domain_name
 }
 
-data "aws_route53_zone" "private" {
-  name = var.domain_name
-
-  private_zone = true
-}
-
 locals {
-  domain_name = trimsuffix(data.aws_route53_zone.public.name, ".")
-  subdomain   = "cdn"
+  domain_name = data.aws_route53_zone.public.name
+  subdomain   = "${environment}-cdn"
 }
 
 module "acm" {


### PR DESCRIPTION
## Description

currently the CDN service module create a private route53 record which is causing some issues with the VOL app.

Related issue: [VOL-5755](https://dvsa.atlassian.net/browse/VOL-5755)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
