### PR TITLE
fix: local.php.dist api service mappings require full URLs

### DIFF
--- a/app/internal/config/autoload/local.php.dist
+++ b/app/internal/config/autoload/local.php.dist
@@ -31,7 +31,7 @@ return [
         'endpoints' => [
             // Backend service URI *Environment specific*
             'backend' => [
-                'url' => 'api.local.olcs.dev-dvsacloud.uk',
+                'url' => 'http://api.local.olcs.dev-dvsacloud.uk/',
             ],
             // Postcode/Address service URI *Environment specific*
             'postcode' => [

--- a/app/selfserve/config/autoload/local.php.dist
+++ b/app/selfserve/config/autoload/local.php.dist
@@ -31,7 +31,7 @@ return [
         'endpoints' => [
             // Backend service URI *Environment specific*
             'backend' => [
-                'url' => 'api.local.olcs.dev-dvsacloud.uk',
+                'url' => 'http://api.local.olcs.dev-dvsacloud.uk/',
             ],
             // Postcode/Address service URI *Environment specific*
             'postcode' => [


### PR DESCRIPTION
## Description

API Service Mapping Endpoints require URLs to be defined containing the Scheme, Host and Trailing Slash (as per existing postcode endpoint). 

Related issue: N/A

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
