### PR TITLE
fix: ecs environments defer to parameter assets_url for asset path

### DIFF
--- a/app/internal/config/autoload/config.global.php
+++ b/app/internal/config/autoload/config.global.php
@@ -79,7 +79,7 @@ return [
     ],
 
     // Asset path, URI to olcs-static (CSS, JS, etc] *Environment specific*
-    'asset_path' => (\Aws\Credentials\CredentialProvider::shouldUseEcs() ? 'https://cdn.%domain%' : '/static/public'),
+    'asset_path' => (\Aws\Credentials\CredentialProvider::shouldUseEcs() ? '%assets_url%' : '/static/public'),
 
     /**
      * Configure the location of the application log

--- a/app/selfserve/config/autoload/config.global.php
+++ b/app/selfserve/config/autoload/config.global.php
@@ -54,18 +54,8 @@ return [
     ],
 
     // Asset path, URI to olcs-static (CSS, JS, etc] *Environment specific*
-    'asset_path' => function () {
-        global $environment;
-        if (\Aws\Credentials\CredentialProvider::shouldUseEcs()) {
-            return match ($environment) {
-                'DEV' => 'https://dev-cdn.dev-dvsacloud.uk',
-                'QA' => 'https://int-cdn.dev-dvsacloud.uk',
-                default => throw new \InvalidArgumentException('Asset Path: Should use ECS but environment not recognised'),
-            };
-        }
-        return '/static/public';
-    },
-
+    'asset_path' => (\Aws\Credentials\CredentialProvider::shouldUseEcs() ? '%assets_url%' : '/static/public'),
+    
     'cookie-manager' => [
         'delete-undefined-cookies' => true,
         'user-preference-cookie-name' => 'cookie_policy',

--- a/app/selfserve/config/autoload/config.global.php
+++ b/app/selfserve/config/autoload/config.global.php
@@ -54,7 +54,18 @@ return [
     ],
 
     // Asset path, URI to olcs-static (CSS, JS, etc] *Environment specific*
-    'asset_path' => (\Aws\Credentials\CredentialProvider::shouldUseEcs() ? 'https://cdn.%domain%' : '/static/public'),
+    'asset_path' => function () {
+        global $environment;
+        if (\Aws\Credentials\CredentialProvider::shouldUseEcs()) {
+            return match ($environment) {
+                'DEV' => 'https://dev-cdn.dev-dvsacloud.uk',
+                'QA' => 'https://int-cdn.dev-dvsacloud.uk',
+                default => throw new \InvalidArgumentException('Asset Path: Should use ECS but environment not recognised'),
+            };
+        }
+        return '/static/public';
+    },
+
     'cookie-manager' => [
         'delete-undefined-cookies' => true,
         'user-preference-cookie-name' => 'cookie_policy',


### PR DESCRIPTION
## Description

ECS environments defer to parameter `assets_url` for asset path.

Prerequisites:
https://github.com/dvsa/vol-terraform/pull/316

Related issue: https://dvsa.atlassian.net/browse/VOL-5788

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
