### PR TITLE
fix: cater for some "attached_to" CU fields being null in the DB

### DIFF
--- a/app/api/module/Api/src/Entity/Licence/Licence.php
+++ b/app/api/module/Api/src/Entity/Licence/Licence.php
@@ -565,7 +565,7 @@ class Licence extends AbstractLicence implements ContextProviderInterface, Organ
         /** @var ConditionUndertaking $cu */
         foreach ($conditionsUndertakings as &$cu) {
             $conditionType = $map[$cu->getConditionType()->getId()];
-            if ($cu->getAttachedTo()->getId() === ConditionUndertaking::ATTACHED_TO_LICENCE) {
+            if ($cu->getAttachedTo()?->getId() === ConditionUndertaking::ATTACHED_TO_LICENCE) {
                 $licenceConditionsUndertakings[$conditionType][] = [
                     'notes' => $cu->getNotes(),
                     'createdOn' => $cu->getCreatedOn(true)

--- a/app/api/module/Api/src/Service/Publication/Context/Variation/ConditionUndertaking.php
+++ b/app/api/module/Api/src/Service/Publication/Context/Variation/ConditionUndertaking.php
@@ -89,13 +89,10 @@ final class ConditionUndertaking extends AbstractContext implements AddressForma
     private function getAttachedToText(ConditionUndertakingEntity $conditionUndertaking)
     {
         $text = null;
-        if (
-            $conditionUndertaking->getAttachedTo()->getId() ===
-            ConditionUndertakingEntity::ATTACHED_TO_OPERATING_CENTRE
-        ) {
+        if ($conditionUndertaking->getAttachedTo()?->getId() === ConditionUndertakingEntity::ATTACHED_TO_OPERATING_CENTRE) {
             $text = 'Attached to Operating: ' .
-                $this->getAddressFormatter()->format($conditionUndertaking->getOperatingCentre()->getAddress());
-        } elseif ($conditionUndertaking->getAttachedTo()->getId() === ConditionUndertakingEntity::ATTACHED_TO_LICENCE) {
+                $this->getAddressFormatter()->format($conditionUndertaking->getOperatingCentre()?->getAddress());
+        } elseif ($conditionUndertaking->getAttachedTo()?->getId() === ConditionUndertakingEntity::ATTACHED_TO_LICENCE) {
             $text = 'Attached to licence';
         }
 

--- a/app/api/module/Api/src/Service/Submission/Sections/ConditionsAndUndertakings.php
+++ b/app/api/module/Api/src/Service/Submission/Sections/ConditionsAndUndertakings.php
@@ -121,7 +121,7 @@ final class ConditionsAndUndertakings extends AbstractSection
         $thisEntity['addedVia'] = $entity->getAddedVia()->getDescription();
         $thisEntity['isFulfilled'] = $entity->getIsFulfilled();
         $thisEntity['isDraft'] = $entity->getIsDraft();
-        $thisEntity['attachedTo'] = $entity->getAttachedTo()->getDescription();
+        $thisEntity['attachedTo'] = $entity->getAttachedTo()?->getDescription();
         $thisEntity['notes'] = $entity->getNotes();
 
         if (empty($entity->getOperatingCentre())) {


### PR DESCRIPTION
## Description

`attached_to` col on `conditions_undertakings` is null by design for some rows. Some places in api we call `->getAttachedTo()->getId()` style chained methods. Added nullsafe to all the instances i could see calling `getAttachedTo()` on in a chain on a conditions undertakings entity.

Related issue: [VOL-5786](https://dvsa.atlassian.net/browse/VOL-5786)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
