### PR TITLE
fix: restore "No (Operator to post)" radio for internal caseworker form

### DIFF
--- a/app/internal/module/Olcs/src/FormService/Form/Lva/OperatingCentre/LvaOperatingCentre.php
+++ b/app/internal/module/Olcs/src/FormService/Form/Lva/OperatingCentre/LvaOperatingCentre.php
@@ -48,6 +48,13 @@ class LvaOperatingCentre extends CommonOperatingCentre
         $advertisements = $form->get('advertisements');
         $advertisements->setLabel('application_operating-centres_authorisation-sub-action.advertisements.adPlaced');
 
+        $adPlaced = $advertisements->get('radio');
+
+        // Add operator to post option back in just for caseworker form: https://dvsa.atlassian.net/browse/VOL-5814
+        $valueOptions = $adPlaced->getValueOptions();
+        $valueOptions['adSendByPost'] = 'No (operator to post)';
+        $adPlaced->setValueOptions($valueOptions);
+
         $form->get('data')->get('guidance')->setValue('lva-operating-centre-newspaper-advert');
         $form->get('data')->get('permission')->setLabel('');
 

--- a/app/internal/test/Olcs/src/FormService/Form/Lva/OperatingCentre/LvaOperatingCentreTest.php
+++ b/app/internal/test/Olcs/src/FormService/Form/Lva/OperatingCentre/LvaOperatingCentreTest.php
@@ -64,13 +64,20 @@ class LvaOperatingCentreTest extends MockeryTestCase
                         m::mock(ElementInterface::class)
                         ->shouldReceive('getValueOptions')
                         ->andReturn(['foo' => 'bar', OperatingCentreMapper::VALUE_OPTION_AD_UPLOAD_LATER => 'cake'])
-                        ->once()
+                        ->twice()
                         ->shouldReceive('setValueOptions')
                         ->with(['foo' => 'bar'])
                         ->once()
+                        ->shouldReceive('setValueOptions')
+                        ->with([
+                            'foo' => 'bar',
+                            'adPlacedLater' => 'cake',
+                            'adSendByPost' => 'No (operator to post)'
+                        ])
+                        ->once()
                         ->getMock()
                     )
-                    ->once()
+                    ->twice()
                     ->shouldReceive('setLabel')
                     ->with('application_operating-centres_authorisation-sub-action.advertisements.adPlaced')
                     ->once()


### PR DESCRIPTION
## Description

Restores a radio option regarding sending evidence by post, for internal caseworker use only.

Related issue: [VOL-5814](https://dvsa.atlassian.net/browse/VOL-5814)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
