### PR TITLE
fix: Check records are actually related to an Operating Centre before access

### DIFF
--- a/app/api/module/Api/src/Entity/Licence/Licence.php
+++ b/app/api/module/Api/src/Entity/Licence/Licence.php
@@ -570,7 +570,7 @@ class Licence extends AbstractLicence implements ContextProviderInterface, Organ
                     'notes' => $cu->getNotes(),
                     'createdOn' => $cu->getCreatedOn(true)
                 ];
-            } else {
+            } elseif ($cu->getOperatingCentre() !== null && $cu->getOperatingCentre()->getId() !== null) {
                 $ocConditionsUndertakings[$cu->getOperatingCentre()->getId()][$conditionType][] = [
                     'notes' => $cu->getNotes(),
                     'address' => [


### PR DESCRIPTION
## Description

Skip trying to populate operating centres CU array when old records are being processed that lack the relationship.

Related issue: [VOL-5786](https://dvsa.atlassian.net/browse/VOL-5786)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
