### PR TITLE
fix: external vehicle search access bug vol 5828

### DIFF
--- a/app/selfserve/module/Olcs/src/Controller/Search/SearchController.php
+++ b/app/selfserve/module/Olcs/src/Controller/Search/SearchController.php
@@ -66,6 +66,12 @@ class SearchController extends AbstractController
     {
         $index = $this->params()->fromRoute('index');
 
+        if ($index === 'vehicle-external') {
+            if (!$this->authService->isGranted('selfserve-search-vehicle-external')) {
+                return $this->redirect()->toRoute('auth/login/GET');
+            }
+        }
+
         if (empty($index)) {
             // show index page if index empty
             $view = new ViewModel();

--- a/app/selfserve/test/Olcs/src/Controller/Search/SearchControllerTest.php
+++ b/app/selfserve/test/Olcs/src/Controller/Search/SearchControllerTest.php
@@ -1,39 +1,98 @@
 <?php
 
-/**
- * Class Search Controller Test
- */
-
 namespace OlcsTest\Controller\Search;
 
+use Common\Service\Helper\FormHelperService;
+use Common\Service\Helper\TranslationHelperService;
+use Common\Service\Script\ScriptFactory;
+use Dvsa\Olcs\Utils\Translation\NiTextTranslation;
+use Laminas\Form\FormElementManager;
+use LmcRbacMvc\Service\AuthorizationService;
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase as TestCase;
 use Olcs\Controller\Search\SearchController as Sut;
+use Laminas\View\Model\ViewModel;
+use Laminas\Mvc\Controller\Plugin\Redirect;
 
 /**
- * Class Search Controller Test
+ * Class SearchControllerTest
  */
 class SearchControllerTest extends TestCase
 {
+    /** @var Sut */
     protected $sut;
+
+    /** @var m\MockInterface */
+    protected $authService;
 
     public function setUp(): void
     {
-        $this->sut = m::mock(Sut::class)
+        $niTextTranslationUtil = m::mock(NiTextTranslation::class);
+        $this->authService = m::mock(AuthorizationService::class);
+        $scriptFactory = m::mock(ScriptFactory::class);
+        $formHelper = m::mock(FormHelperService::class);
+        $navigation = m::mock();
+        $formElementManager = m::mock(FormElementManager::class);
+        $viewHelperManager = m::mock();
+        $dataServiceManager = m::mock();
+        $translationHelper = m::mock(TranslationHelperService::class);
+
+        $this->sut = m::mock(Sut::class, [
+            $niTextTranslationUtil,
+            $this->authService,
+            $scriptFactory,
+            $formHelper,
+            $navigation,
+            $formElementManager,
+            $viewHelperManager,
+            $dataServiceManager,
+            $translationHelper
+        ])
             ->makePartial()
             ->shouldAllowMockingProtectedMethods();
     }
 
     public function testIndexActionWithoutIndex(): void
     {
-        $this->sut->shouldReceive('params->fromRoute')
+        $params = m::mock();
+        $params->shouldReceive('fromRoute')
             ->with('index')
             ->once()
             ->andReturn(null);
 
+        $this->sut->shouldReceive('params')->andReturn($params);
+
         $view = $this->sut->indexAction();
 
-        $this->assertInstanceOf(\Laminas\View\Model\ViewModel::class, $view);
+        $this->assertInstanceOf(ViewModel::class, $view);
         $this->assertEquals('search/index', $view->getTemplate());
+    }
+
+    public function testIndexActionRedirectsWhenNotAuthorizedForVehicleExternal()
+    {
+        $params = m::mock();
+        $params->shouldReceive('fromRoute')
+            ->with('index')
+            ->once()
+            ->andReturn('vehicle-external');
+
+        $this->sut->shouldReceive('params')->andReturn($params);
+
+        $this->authService->shouldReceive('isGranted')
+            ->with('selfserve-search-vehicle-external')
+            ->once()
+            ->andReturn(false);
+
+        $redirectMock = m::mock(Redirect::class);
+        $redirectMock->shouldReceive('toRoute')
+            ->with('auth/login/GET')
+            ->once()
+            ->andReturn('redirectResponse');
+
+        $this->sut->shouldReceive('redirect')->andReturn($redirectMock);
+
+        $result = $this->sut->indexAction();
+
+        $this->assertEquals('redirectResponse', $result);
     }
 }


### PR DESCRIPTION
## Description

Resolves an RBAC issue allowing external access via direct URL to a search index intended only for some logged in users.

Related issue: [VOL-5828](https://dvsa.atlassian.net/browse/VOL-5828)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
