### PR TITLE
fix: Ensure filter button is rendered at the end of the filter form.

### DIFF
--- a/app/internal/module/Olcs/src/Form/Model/Form/UnlicensedOperator.php
+++ b/app/internal/module/Olcs/src/Form/Model/Form/UnlicensedOperator.php
@@ -39,12 +39,14 @@ class UnlicensedOperator
      *     "label_attributes": {"class": "form-control form-control--checkbox form-control--advanced"},
      * })
      * @Form\Type("\Common\Form\Elements\InputFilters\SingleCheckbox")
+     * @Form\Flags({"priority": -1})
      */
     public $isExempt = null;
 
     /**
      * @Form\Name("form-actions")
      * @Form\ComposedObject("Olcs\Form\Model\Fieldset\OperatorActions")
+     * @Form\Flags({"priority": -2})
      */
     public $formActions = null;
 }


### PR DESCRIPTION
## Description

Relocate checkbox correctly on unlicensed operator modal form.

Related issue: [VOL-5832](https://dvsa.atlassian.net/browse/VOL-5832)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
