### PR TITLE
fix: operator representation registration form radio options switched

### DIFF
--- a/app/selfserve/module/Olcs/src/Form/Model/Fieldset/OperatorRepresentation.php
+++ b/app/selfserve/module/Olcs/src/Form/Model/Fieldset/OperatorRepresentation.php
@@ -16,7 +16,7 @@ class OperatorRepresentation
      * @Form\Options({
      *     "label": "user-registration.field.act-on-operators-behalf.label",
      *     "hint": "user-registration.field.act-on-operators-behalf.hint",
-     *     "value_options":{"N":"select-option-no", "Y":"select-option-yes"},
+     *     "value_options":{"Y":"select-option-yes", "N":"select-option-no"},
      *     "label_attributes": {"class": "form-control form-control--radio form-control--inline"}
      * })
      * @Form\Required(true)


### PR DESCRIPTION
## Description

Switches the radio buttons for the registration journey Operator Representation.

Related issue: https://dvsa.atlassian.net/browse/VOL-4705

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
