### PR TITLE
fix: updated businessType label for register for operator to have its own translation key

### DIFF
--- a/app/selfserve/module/Olcs/src/Form/Model/Fieldset/RegisterForOperator.php
+++ b/app/selfserve/module/Olcs/src/Form/Model/Fieldset/RegisterForOperator.php
@@ -81,7 +81,7 @@ class RegisterForOperator
      * @Form\Type("DynamicRadio")
      * @Form\Options({
      *     "fieldset-attributes": {"id": "businessType"},
-     *     "label": "user-registration.field.businessType.label",
+     *     "label": "register-for-operator.field.businessType.label",
      *     "label_attributes": {"class": "form-control form-control--radio"},
      *     "disable_inarray_validator": false,
      *     "category": "org_type",


### PR DESCRIPTION


## Description

Updated register for operator form, business type field to have it's own translation key as the label is slightly varient to the standard.

Related issue: N/A

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
