### PR TITLE
ci: specify a different repository for trivy-db to avoid ratelimit

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -122,6 +122,8 @@ jobs:
         with:
           image-ref: ${{ steps.build-and-push.outputs.imageid }}
           skip-dirs: /var/clamav
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
 
       - name: Setup Notation CLI
         if: ${{ inputs.push }}

--- a/.github/workflows/security-docker.yaml
+++ b/.github/workflows/security-docker.yaml
@@ -22,6 +22,8 @@ jobs:
           output: "trivy-results.sarif"
           severity: "MEDIUM,HIGH,CRITICAL"
           limit-severities-for-sarif: true
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
       - name: Upload Results to GitHub Code Scanning
         if: ${{ always() }}
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/security-terraform.yaml
+++ b/.github/workflows/security-terraform.yaml
@@ -22,6 +22,8 @@ jobs:
           output: "trivy-results.sarif"
           severity: "CRITICAL"
           limit-severities-for-sarif: true
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
       - name: Upload Results to GitHub Code Scanning
         if: ${{ always() }}
         uses: github/codeql-action/upload-sarif@v3

--- a/app/api/.gitignore
+++ b/app/api/.gitignore
@@ -26,4 +26,4 @@ phpcs.xml
 phpstan.neon
 phpunit.xml
 psalm.xml
-# Trigger CD - 2024-10-07-1217
+# Trigger CD - 2024-10-07-1613

--- a/app/cdn/.gitignore
+++ b/app/cdn/.gitignore
@@ -26,4 +26,4 @@ composer.lock
 editorconfig.org
 assets/vendor
 .scannerwork/
-# Trigger CD - 2024-10-07-1217
+# Trigger CD - 2024-10-07-1613

--- a/app/internal/.gitignore
+++ b/app/internal/.gitignore
@@ -27,5 +27,5 @@ phpcs.xml
 phpstan.neon
 phpunit.xml
 psalm.xml
-# Trigger CD - 2024-10-07-1217
+# Trigger CD - 2024-10-07-1613
 

--- a/app/selfserve/.gitignore
+++ b/app/selfserve/.gitignore
@@ -26,5 +26,5 @@ phpcs.xml
 phpstan.neon
 phpunit.xml
 psalm.xml
-# Trigger CD - 2024-10-07-1217
+# Trigger CD - 2024-10-07-1613
 


### PR DESCRIPTION
## Description

Alternate trivy DB repo to avoid ratelimit errors affecting multiple github actions users.