### PR TITLE
fix: two methods in DataGovUkExport did not call new parent uploadTos3

### DIFF
--- a/app/api/module/Cli/src/Domain/CommandHandler/DataGovUkExport.php
+++ b/app/api/module/Cli/src/Domain/CommandHandler/DataGovUkExport.php
@@ -104,6 +104,12 @@ final class DataGovUkExport extends AbstractDataExport
             ['id' => $document->getId('document')],
             $document->getId('document')
         );
+
+        $tempFilePath = tempnam(sys_get_temp_dir(), 'psv_operator_list_');
+        file_put_contents($tempFilePath, $csvContent);
+        $this->uploadToS3($tempFilePath);
+        unlink($tempFilePath);
+
         $email = $this->handleSideEffect($emailQueue);
         $this->result->merge($email);
 
@@ -134,6 +140,8 @@ final class DataGovUkExport extends AbstractDataExport
             ['id' => $document->getId('document')],
             $document->getId('document')
         );
+
+        $this->uploadToS3($csvContent);
 
         $email = $this->handleSideEffect($emailQueue);
         $this->result->merge($email);

--- a/app/api/test/module/Cli/src/Domain/CommandHandler/DataGovUkExportTest.php
+++ b/app/api/test/module/Cli/src/Domain/CommandHandler/DataGovUkExportTest.php
@@ -180,15 +180,22 @@ class DataGovUkExportTest extends AbstractCommandHandlerTestCase
             ]
         );
 
+        $this->mockS3client->shouldAllowMockingMethod('putObject');
+        $this->mockS3client->shouldReceive('putObject')
+            ->once()
+            ->andReturn([]);
+
         $actual = $this->sut->handleCommand($cmd);
 
         $date = new DateTime('now');
-        $expectedFile = $this->tmpPath . '/' . $fileName . '_' .
+
+        $expectedFileName = $fileName . '_' .
             $date->format(DataGovUkExport::FILE_DATETIME_FORMAT) . '.csv';
+        $expectedFilePath = $this->tmpPath . '/' . $expectedFileName;
 
         $expectMsg =
             'Fetching data for international goods list' .
-            'Creating CSV file: ' . $expectedFile;
+            'Creating CSV file: ' . $expectedFilePath . 'Uploaded file to S3: '.$expectedFileName;
 
         $this->assertEquals(
             $expectMsg,
@@ -294,16 +301,20 @@ class DataGovUkExportTest extends AbstractCommandHandlerTestCase
             ]
         );
 
+        $this->mockS3client->shouldAllowMockingMethod('putObject');
+        $this->mockS3client->shouldReceive('putObject')
+            ->once()
+            ->andReturn([]);
+
         $actual = $this->sut->handleCommand($cmd);
 
         $expectMsg =
             'Fetching data from DB for PSV Operators' .
-            'create csv file content';
+            'create csv file contentUploaded file to S3: psv_operator_list_';
 
-        static::assertEquals(
-            $expectMsg,
-            implode('', $actual->toArray()['messages'])
-        );
+        $actualMsg = implode('', $actual->toArray()['messages']);
+
+        static::assertStringStartsWith($expectMsg, $actualMsg);
     }
 
     public function testOperatorLicenceOk()


### PR DESCRIPTION
## Description

Fix to ensure all report type call the uploadToS3 method

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
