### PR TITLE
fix: added missing subheading for operator self registration

### DIFF
--- a/app/selfserve/module/Olcs/src/Form/Model/Fieldset/OperatorRegistration.php
+++ b/app/selfserve/module/Olcs/src/Form/Model/Fieldset/OperatorRegistration.php
@@ -6,8 +6,8 @@ use Laminas\Form\Annotation as Form;
 
 /**
  * @Form\Name("OperatorRegistration")
- * @Form\Attributes({"method":"post"})
- * @Form\Options({"prefer_form_input_filter": true, "label": ""})
+ * @Form\Attributes({"method":"post","label":"user-registration.form.label"})
+ * @Form\Options({"prefer_form_input_filter": true, "label": "user-registration.form.label"})
  */
 class OperatorRegistration
 {


### PR DESCRIPTION
## Description

Added missing subheading for operator self registration.

Related issue: https://dvsa.atlassian.net/browse/VOL-5653

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
