### PR TITLE
feat: ensure there is always one `operator` with `admin` permissions

### DIFF
--- a/app/api/module/Api/src/Domain/CommandHandler/User/DeleteUser.php
+++ b/app/api/module/Api/src/Domain/CommandHandler/User/DeleteUser.php
@@ -58,9 +58,8 @@ final class DeleteUser extends AbstractCommandHandler implements
         $user = $this->getUser($command);
 
         if ($user->getPermission() == 'admin') {
-            $operatorAdmins = $user->getRelatedOrganisation()->getAdminUsers('admin');
-            $operatorAdminsCount = $operatorAdmins->count();
-            if (($operatorAdminsCount - 1) == 0) {
+            $adminUsersCount = $this->getCurrentOrganisation()->getAdminOrganisationUsers('admin')->count();
+            if (($adminUsersCount - 1) == 0) {
                 throw new BadRequestException('You can not have 0 admin users');
             }
         }

--- a/app/api/module/Api/src/Domain/CommandHandler/User/DeleteUser.php
+++ b/app/api/module/Api/src/Domain/CommandHandler/User/DeleteUser.php
@@ -57,6 +57,14 @@ final class DeleteUser extends AbstractCommandHandler implements
 
         $user = $this->getUser($command);
 
+        if ($user->getPermission() == 'admin') {
+            $operatorAdmins = $user->getRelatedOrganisation()->getAdminUsers('admin');
+            $operatorAdminsCount = $operatorAdmins->count();
+            if (($operatorAdminsCount - 1) == 0) {
+                throw new BadRequestException('You can not have 0 admin users');
+            }
+        }
+
         $this->guardAgainstOpenTasks($user);
 
         $this->deleteUser($user);

--- a/app/api/module/Api/src/Domain/CommandHandler/User/DeleteUserSelfserve.php
+++ b/app/api/module/Api/src/Domain/CommandHandler/User/DeleteUserSelfserve.php
@@ -53,8 +53,7 @@ final class DeleteUserSelfserve extends AbstractCommandHandler implements
         $user = $this->getRepo()->fetchUsingId($command);
 
         if ($user->getPermission() == 'admin') {
-            $adminUsersCount = $this->getCurrentOrganisation()->getAdminUsers()->count();
-
+            $adminUsersCount = $this->getCurrentOrganisation()->getAdminOrganisationUsers('admin')->count();
             if (($adminUsersCount - 1) == 0) {
                 throw new BadRequestException('You can not have 0 admin users');
             }

--- a/app/api/module/Api/src/Domain/CommandHandler/User/DeleteUserSelfserve.php
+++ b/app/api/module/Api/src/Domain/CommandHandler/User/DeleteUserSelfserve.php
@@ -52,7 +52,7 @@ final class DeleteUserSelfserve extends AbstractCommandHandler implements
         $adminUsersCount = $this->getCurrentOrganisation()->getAdminUsers()->count();
 
         if (($adminUsersCount - 1) == 0) {
-            throw new BadRequestException('You can not have no admin users');
+            throw new BadRequestException('You can not have 0 admin users');
         }
 
         /** @var \Dvsa\Olcs\Api\Entity\User\User $user */

--- a/app/api/module/Api/src/Domain/CommandHandler/User/DeleteUserSelfserve.php
+++ b/app/api/module/Api/src/Domain/CommandHandler/User/DeleteUserSelfserve.php
@@ -49,6 +49,12 @@ final class DeleteUserSelfserve extends AbstractCommandHandler implements
             throw new BadRequestException('You can not delete yourself');
         }
 
+        $adminUsersCount = $this->getCurrentOrganisation()->getAdminUsers()->count();
+
+        if (($adminUsersCount - 1) == 0) {
+            throw new BadRequestException('You can not have no admin users');
+        }
+
         /** @var \Dvsa\Olcs\Api\Entity\User\User $user */
         $user = $this->getRepo()->fetchUsingId($command);
 

--- a/app/api/module/Api/src/Domain/CommandHandler/User/DeleteUserSelfserve.php
+++ b/app/api/module/Api/src/Domain/CommandHandler/User/DeleteUserSelfserve.php
@@ -52,7 +52,7 @@ final class DeleteUserSelfserve extends AbstractCommandHandler implements
         /** @var \Dvsa\Olcs\Api\Entity\User\User $user */
         $user = $this->getRepo()->fetchUsingId($command);
 
-        if ($user->isAdministrator()) {
+        if ($user->getPermission() == 'admin') {
             $adminUsersCount = $this->getCurrentOrganisation()->getAdminUsers()->count();
 
             if (($adminUsersCount - 1) == 0) {

--- a/app/api/module/Api/src/Domain/CommandHandler/User/DeleteUserSelfserve.php
+++ b/app/api/module/Api/src/Domain/CommandHandler/User/DeleteUserSelfserve.php
@@ -49,14 +49,16 @@ final class DeleteUserSelfserve extends AbstractCommandHandler implements
             throw new BadRequestException('You can not delete yourself');
         }
 
-        $adminUsersCount = $this->getCurrentOrganisation()->getAdminUsers()->count();
-
-        if (($adminUsersCount - 1) == 0) {
-            throw new BadRequestException('You can not have 0 admin users');
-        }
-
         /** @var \Dvsa\Olcs\Api\Entity\User\User $user */
         $user = $this->getRepo()->fetchUsingId($command);
+
+        if ($user->isAdministrator()) {
+            $adminUsersCount = $this->getCurrentOrganisation()->getAdminUsers()->count();
+
+            if (($adminUsersCount - 1) == 0) {
+                throw new BadRequestException('You can not have 0 admin users');
+            }
+        }
 
         $this->getRepo('OrganisationUser')->deleteByUserId($user->getId());
         $this->getRepo()->delete($user);

--- a/app/api/module/Api/src/Domain/CommandHandler/User/UpdateUser.php
+++ b/app/api/module/Api/src/Domain/CommandHandler/User/UpdateUser.php
@@ -109,9 +109,8 @@ final class UpdateUser extends AbstractUserCommandHandler implements
         $this->validateRoles($data['roles'], $user->getRoles()->toArray());
 
         if ($user->getPermission() == 'admin' && $data['roles'] != 'operator-admin') {
-            $operatorAdmins = $user->getRelatedOrganisation()->getAdminUsers('admin');
-            $operatorAdminsCount = $operatorAdmins->count();
-            if (($operatorAdminsCount - 1) == 0) {
+            $adminUsersCount = $this->getCurrentOrganisation()->getAdminOrganisationUsers('admin')->count();
+            if (($adminUsersCount - 1) == 0) {
                 throw new BadRequestException('You can not have 0 admin users');
             }
         }

--- a/app/api/module/Api/src/Domain/CommandHandler/User/UpdateUserSelfserve.php
+++ b/app/api/module/Api/src/Domain/CommandHandler/User/UpdateUserSelfserve.php
@@ -66,10 +66,10 @@ final class UpdateUserSelfserve extends AbstractUserCommandHandler implements
 
         $data = $command->getArrayCopy();
 
-        if ($user->getPermission() == 'admin' && $data['permission'] == 'user') {
-            $adminUsersCount = $this->getCurrentOrganisation()->getAdminUsers()->count();
+        if ($user->getPermission() == 'admin' && $data['roles'] != 'operator-admin') {
+            $adminUsersCount = $this->getCurrentOrganisation()->getAdminOrganisationUsers('admin')->count();
             if (($adminUsersCount - 1) == 0) {
-                throw new BadRequestException('You can not have 0 admin users');
+                throw new BadRequestException('You must have at least one Operator Administrator');
             }
         }
 

--- a/app/api/module/Api/src/Domain/CommandHandler/User/UpdateUserSelfserve.php
+++ b/app/api/module/Api/src/Domain/CommandHandler/User/UpdateUserSelfserve.php
@@ -66,7 +66,7 @@ final class UpdateUserSelfserve extends AbstractUserCommandHandler implements
 
         $data = $command->getArrayCopy();
 
-        if ($user->isAdministrator() && $data['permission'] == 'user') {
+        if ($user->getPermission() == 'admin' && $data['permission'] == 'user') {
             $adminUsersCount = $this->getCurrentOrganisation()->getAdminUsers()->count();
             if (($adminUsersCount - 1) == 0) {
                 throw new BadRequestException('You can not have 0 admin users');

--- a/app/api/module/Api/src/Entity/Organisation/AbstractOrganisation.php
+++ b/app/api/module/Api/src/Entity/Organisation/AbstractOrganisation.php
@@ -1216,32 +1216,7 @@ abstract class AbstractOrganisation implements BundleSerializableInterface, Json
     {
         return $this->organisationUsers;
     }
-
-    /**
-     * Get the organisation users that are admins
-     *
-     * @return ArrayCollection
-     */
-    public function getAdminUsers($filter = 'all')
-    {
-        $adminUsers = new ArrayCollection();
-
-        foreach ($this->organisationUsers as $organisationUser) {
-            if ($organisationUser->getIsAdministrator() != 'Y') {
-                continue;
-            }
-            if ($filter == 'all') {
-                $adminUsers->add($organisationUser);
-                continue;
-            }
-
-            $user = $organisationUser->getUser();
-            if ($user->getPermission() == $filter) {
-                $adminUsers->add($organisationUser);
-            }
-        }
-        return $adminUsers;
-    }
+    
     /**
      * Add a organisation users
      *

--- a/app/api/module/Api/src/Entity/Organisation/AbstractOrganisation.php
+++ b/app/api/module/Api/src/Entity/Organisation/AbstractOrganisation.php
@@ -1218,6 +1218,23 @@ abstract class AbstractOrganisation implements BundleSerializableInterface, Json
     }
 
     /**
+     * Get the organisation users that are admins
+     *
+     * @return ArrayCollection
+     */
+    public function getAdminUsers()
+    {
+        $adminUsers = new ArrayCollection();
+
+        foreach ($this->organisationUsers as $organisationUser) {
+            if ($organisationUser->getIsAdministrator() == 'Y') {
+                $adminUsers->add($organisationUser);
+            }
+        }
+
+        return $adminUsers;
+    }
+    /**
      * Add a organisation users
      *
      * @param ArrayCollection|mixed $organisationUsers collection being added

--- a/app/api/module/Api/src/Entity/Organisation/AbstractOrganisation.php
+++ b/app/api/module/Api/src/Entity/Organisation/AbstractOrganisation.php
@@ -1222,16 +1222,24 @@ abstract class AbstractOrganisation implements BundleSerializableInterface, Json
      *
      * @return ArrayCollection
      */
-    public function getAdminUsers()
+    public function getAdminUsers($filter = 'all')
     {
         $adminUsers = new ArrayCollection();
 
         foreach ($this->organisationUsers as $organisationUser) {
-            if ($organisationUser->getIsAdministrator() == 'Y') {
+            if ($organisationUser->getIsAdministrator() != 'Y') {
+                continue;
+            }
+            if ($filter == 'all') {
+                $adminUsers->add($organisationUser);
+                continue;
+            }
+
+            $user = $organisationUser->getUser();
+            if ($user->getPermission() == $filter) {
                 $adminUsers->add($organisationUser);
             }
         }
-
         return $adminUsers;
     }
     /**

--- a/app/api/module/Api/src/Entity/Organisation/Organisation.php
+++ b/app/api/module/Api/src/Entity/Organisation/Organisation.php
@@ -14,6 +14,7 @@ use Dvsa\Olcs\Api\Entity\TrafficArea\TrafficArea as TrafficAreaEntity;
 use Dvsa\Olcs\Api\Entity\User\User as UserEntity;
 use Dvsa\Olcs\Api\Service\Document\ContextProviderInterface;
 use Doctrine\ORM\EntityNotFoundException;
+use function Aws\filter;
 
 /**
  * Organisation Entity
@@ -73,7 +74,7 @@ class Organisation extends AbstractOrganisation implements ContextProviderInterf
      *
      * @return ArrayCollection|OrganisationUserEntity[]
      */
-    public function getAdminOrganisationUsers()
+    public function getAdminOrganisationUsers($filter = 'all')
     {
         $criteria = Criteria::create();
         $criteria->andWhere(
@@ -94,7 +95,9 @@ class Organisation extends AbstractOrganisation implements ContextProviderInterf
                     $user instanceof UserEntity
                     && $user->getAccountDisabled() !== 'Y'
                 ) {
-                    $enabledOrgUsers->add($orgUser);
+                    if ($filter == 'all' || $user->getPermission() == $filter) {
+                        $enabledOrgUsers->add($orgUser);
+                    }
                 }
             } catch (EntityNotFoundException) {
                 // we may have the user id but will not be able to load it

--- a/app/api/module/Api/src/Entity/User/User.php
+++ b/app/api/module/Api/src/Entity/User/User.php
@@ -500,7 +500,7 @@ class User extends AbstractUser implements OrganisationProviderInterface
      *
      * @return bool
      */
-    private function isAdministrator()
+    public function isAdministrator()
     {
         // is admin if has roles for admin permission
         return $this->hasRoles(

--- a/app/api/module/Api/src/Entity/User/User.php
+++ b/app/api/module/Api/src/Entity/User/User.php
@@ -500,7 +500,7 @@ class User extends AbstractUser implements OrganisationProviderInterface
      *
      * @return bool
      */
-    public function isAdministrator()
+    private function isAdministrator()
     {
         // is admin if has roles for admin permission
         return $this->hasRoles(

--- a/app/api/test/module/Api/src/Domain/CommandHandler/User/DeleteUserSelfserveTest.php
+++ b/app/api/test/module/Api/src/Domain/CommandHandler/User/DeleteUserSelfserveTest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Dvsa\OlcsTest\Api\Domain\CommandHandler\User;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Dvsa\Olcs\Api\Domain\CommandHandler\User\DeleteUserSelfserve;
 use Dvsa\Olcs\Api\Domain\Exception\BadRequestException;
 use Dvsa\Olcs\Api\Domain\Repository;
+use Dvsa\Olcs\Api\Entity\Organisation\Organisation;
 use Dvsa\Olcs\Api\Entity\User\User as UserEntity;
 use Dvsa\Olcs\Auth\Adapter\CognitoAdapter;
 use Dvsa\Olcs\Auth\Exception\DeleteUserException;
@@ -103,10 +105,10 @@ class DeleteUserSelfserveTest extends AbstractCommandHandlerTestCase
 
         $command = Cmd::create($data);
 
-        $userEntity = m::mock(UserEntity::class);
-        $userEntity->expects('getId')->withNoArgs()->andReturn(self::USER_ID);
-        $userEntity->expects('getLoginId')->withNoArgs()->andReturn(self::LOGIN_ID);
-        $userEntity->expects('isAdministrator')->withNoArgs()->andReturn(false);
+        $userEntity = new UserEntity(self::USER_ID, UserEntity::USER_TYPE_OPERATOR);
+        $userEntity->setId(self::USER_ID);
+        $userEntity->setLoginId(self::LOGIN_ID);
+        $userEntity->setOrganisationUsers(new ArrayCollection([$userEntity]));
 
         $cognitoResult = m::mock(DeleteUserResult::class);
         $cognitoResult->expects('isValid')->withNoArgs()->andReturnFalse();

--- a/app/api/test/module/Api/src/Domain/CommandHandler/User/DeleteUserSelfserveTest.php
+++ b/app/api/test/module/Api/src/Domain/CommandHandler/User/DeleteUserSelfserveTest.php
@@ -106,6 +106,7 @@ class DeleteUserSelfserveTest extends AbstractCommandHandlerTestCase
         $userEntity = m::mock(UserEntity::class);
         $userEntity->expects('getId')->withNoArgs()->andReturn(self::USER_ID);
         $userEntity->expects('getLoginId')->withNoArgs()->andReturn(self::LOGIN_ID);
+        $userEntity->expects('isAdministrator')->withNoArgs()->andReturn(false);
 
         $cognitoResult = m::mock(DeleteUserResult::class);
         $cognitoResult->expects('isValid')->withNoArgs()->andReturnFalse();

--- a/app/api/test/module/Api/src/Domain/CommandHandler/User/DeleteUserTest.php
+++ b/app/api/test/module/Api/src/Domain/CommandHandler/User/DeleteUserTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Dvsa\OlcsTest\Api\Domain\CommandHandler\User;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Dvsa\Olcs\Api\Domain\CommandHandler\TransactionedInterface;
 use Dvsa\Olcs\Api\Domain\Exception\BadRequestException;
 use Dvsa\Olcs\Api\Domain\Exception\ForbiddenException;
@@ -11,6 +12,7 @@ use Dvsa\Olcs\Api\Domain\Repository\OrganisationUser as OrganisationUserRepo;
 use Dvsa\Olcs\Api\Domain\Repository\Task as TaskRepo;
 use Dvsa\Olcs\Api\Domain\Repository\User as UserRepo;
 use Dvsa\Olcs\Api\Entity\User\Permission as PermissionEntity;
+use Dvsa\Olcs\Api\Entity\User\Role;
 use Dvsa\Olcs\Api\Entity\User\User as UserEntity;
 use Dvsa\Olcs\Auth\Adapter\CognitoAdapter;
 use Dvsa\Olcs\Auth\Exception\DeleteUserException;
@@ -51,6 +53,7 @@ class DeleteUserTest extends AbstractCommandHandlerTestCase
         $this->userEntity = m::mock(UserEntity::class)->makePartial();
         $this->userEntity->setId('DUMMY-USER-ID');
         $this->userEntity->setLoginId('login_id');
+        $this->userEntity->setRoles(new ArrayCollection([new Role()]));
 
         $this->repoMap['User']
             ->shouldReceive('fetchUsingId')

--- a/app/api/test/module/Api/src/Domain/CommandHandler/User/UpdateUserSelfserveTest.php
+++ b/app/api/test/module/Api/src/Domain/CommandHandler/User/UpdateUserSelfserveTest.php
@@ -239,6 +239,7 @@ class UpdateUserSelfserveTest extends AbstractCommandHandlerTestCase
         $user->setContactDetails($contactDetails);
         $user->setRoles(new ArrayCollection([new Role()]));
 
+        // times > 1 due to $user->getPermission calling getUserType twice
         $user->shouldReceive('getUserType')->times(3)->withNoArgs()->andReturn($userType);
 
         $user->shouldReceive('update')->once()->with($data)->andReturnSelf();

--- a/app/api/test/module/Api/src/Domain/CommandHandler/User/UpdateUserSelfserveTest.php
+++ b/app/api/test/module/Api/src/Domain/CommandHandler/User/UpdateUserSelfserveTest.php
@@ -6,11 +6,13 @@
 
 namespace Dvsa\OlcsTest\Api\Domain\CommandHandler\User;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Query;
 use Dvsa\Olcs\Api\Domain\Repository\ContactDetails;
 use Dvsa\Olcs\Api\Domain\Repository\User;
 use Dvsa\Olcs\Api\Entity\ContactDetails\ContactDetails as ContactDetailsEntity;
 use Dvsa\Olcs\Api\Entity\System\RefData;
+use Dvsa\Olcs\Api\Entity\User\Role;
 use Dvsa\Olcs\Api\Entity\User\User as UserEntity;
 use Dvsa\Olcs\Api\Rbac\JWTIdentityProvider;
 use Dvsa\Olcs\Api\Service\EventHistory\Creator as EventHistoryCreator;
@@ -124,6 +126,7 @@ class UpdateUserSelfserveTest extends AbstractCommandHandlerTestCase
         /** @var UserEntity $user */
         $user = m::mock(UserEntity::class)->makePartial();
         $user->setContactDetails($contactDetails);
+        $user->setRoles(new ArrayCollection([new Role()]));
         $user->setId($userId);
         $user->setPid('pid');
         $user->setLoginId($data['loginId']);
@@ -234,8 +237,9 @@ class UpdateUserSelfserveTest extends AbstractCommandHandlerTestCase
         $user->setPid('pid');
         $user->setLoginId($data['loginId']);
         $user->setContactDetails($contactDetails);
+        $user->setRoles(new ArrayCollection([new Role()]));
 
-        $user->shouldReceive('getUserType')->once()->withNoArgs()->andReturn($userType);
+        $user->shouldReceive('getUserType')->times(3)->withNoArgs()->andReturn($userType);
 
         $user->shouldReceive('update')->once()->with($data)->andReturnSelf();
 

--- a/app/internal/module/Olcs/src/Table/Tables/operator-users.table.php
+++ b/app/internal/module/Olcs/src/Table/Tables/operator-users.table.php
@@ -2,11 +2,22 @@
 
 use Common\Service\Table\TableBuilder;
 use Common\Util\Escape;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 return [
     'variables' => [
         'title' => 'Users',
         'titleSingular' => 'User',
+    ],
+    'settings' => [
+        'crud' => [
+            'actions' => [
+                'delete' => [
+                    'requireRows' => false,
+                    'class' => 'govuk-button govuk-button--warning js-require--one'
+                ]
+            ]
+        ]
     ],
     'columns' => [
         [
@@ -41,6 +52,11 @@ return [
             'title' => 'Role',
             'name' => 'role',
             'formatter' => fn($row) => empty($row['roles']) ? 'N/A' : Escape::html($row['roles'][0]['description'])
-        ]
+        ],
+        [
+            'title' => 'markup-table-th-action', //this is a view partial from olcs-common
+            'width' => 'checkbox',
+            'format' => '{{[elements/radio]}}'
+        ],
     ]
 ];

--- a/app/selfserve/module/Olcs/src/Table/Tables/users.table.php
+++ b/app/selfserve/module/Olcs/src/Table/Tables/users.table.php
@@ -53,6 +53,7 @@ return [
                          * @var TableBuilder $this
                          * @psalm-scope-this TableBuilder
                          */
+                        //@TODO Remove [. ' ']
                         $this->translator->translate('role.' . $role['role'] . ' '),
                     $row['roles']
                 )

--- a/app/selfserve/module/Olcs/src/Table/Tables/users.table.php
+++ b/app/selfserve/module/Olcs/src/Table/Tables/users.table.php
@@ -62,12 +62,13 @@ return [
         [
             'title' => 'markup-table-th-remove', //this is a view partial from olcs-common
             'type' => 'ActionLinks',
-            'isRemoveVisible' => fn($row) =>
-                /**
-                 * @var TableBuilder $this
-                 * @psalm-scope-this TableBuilder
-                 */
-                $this->permissionService->canRemoveSelfserveUser($row['id']),
+//            'isRemoveVisible' => fn($row) =>
+//                /**
+//                 * @var TableBuilder $this
+//                 * @psalm-scope-this TableBuilder
+//                 */
+//
+//                $this->permissionService->canRemoveSelfserveUser($row['id']),
             'ariaDescription' => function ($row, $column) {
                 $column['formatter'] = Name::class;
                 /**

--- a/app/selfserve/module/Olcs/src/Table/Tables/users.table.php
+++ b/app/selfserve/module/Olcs/src/Table/Tables/users.table.php
@@ -53,7 +53,7 @@ return [
                          * @var TableBuilder $this
                          * @psalm-scope-this TableBuilder
                          */
-                        $this->translator->translate('role.' . $role['role']),
+                        $this->translator->translate('role.' . $role['role'] . ' '),
                     $row['roles']
                 )
             )

--- a/app/selfserve/module/Olcs/src/Table/Tables/users.table.php
+++ b/app/selfserve/module/Olcs/src/Table/Tables/users.table.php
@@ -62,13 +62,12 @@ return [
         [
             'title' => 'markup-table-th-remove', //this is a view partial from olcs-common
             'type' => 'ActionLinks',
-//            'isRemoveVisible' => fn($row) =>
-//                /**
-//                 * @var TableBuilder $this
-//                 * @psalm-scope-this TableBuilder
-//                 */
-//
-//                $this->permissionService->canRemoveSelfserveUser($row['id']),
+            'isRemoveVisible' => fn($row) =>
+                /**
+                 * @var TableBuilder $this
+                 * @psalm-scope-this TableBuilder
+                 */
+                $this->permissionService->canRemoveSelfserveUser($row['id'], $row['disableRemove']),
             'ariaDescription' => function ($row, $column) {
                 $column['formatter'] = Name::class;
                 /**


### PR DESCRIPTION
## Description
Ensure there is always one `operator` with `admin` permissions. This can be the `operator-admin` and `operator-tc`roles.

Related issue: [VOL-4718](https://dvsa.atlassian.net/browse/VOL-4718)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?

## Related PR
[olcs-common#175](https://github.com/dvsa/olcs-common/pull/175)
