### PR TITLE
fix: add/manage user TC role hidden when TC toggle disabled

### DIFF
--- a/app/selfserve/module/Olcs/src/Controller/UserController.php
+++ b/app/selfserve/module/Olcs/src/Controller/UserController.php
@@ -4,6 +4,7 @@ namespace Olcs\Controller;
 
 use Common\Controller\Lva\AbstractController;
 use Common\Controller\Lva\Traits\CrudTableTrait;
+use Common\FeatureToggle;
 use Common\Form\Form;
 use Common\Service\Helper\FlashMessengerHelperService;
 use Common\Service\Helper\FormHelperService;
@@ -13,6 +14,7 @@ use Common\Service\Script\ScriptFactory;
 use Dvsa\Olcs\Transfer\Command\User\CreateUserSelfserve as CreateDto;
 use Dvsa\Olcs\Transfer\Command\User\DeleteUserSelfserve as DeleteDto;
 use Dvsa\Olcs\Transfer\Command\User\UpdateUserSelfserve as UpdateDto;
+use Dvsa\Olcs\Transfer\Query\FeatureToggle\IsEnabled as IsEnabledQry;
 use Dvsa\Olcs\Transfer\Query\User\UserListSelfserve as ListDto;
 use Dvsa\Olcs\Transfer\Query\User\UserSelfserve as ItemDto;
 use Dvsa\Olcs\Utils\Translation\NiTextTranslation;
@@ -196,6 +198,13 @@ class UserController extends AbstractController
      */
     public function alterForm($form, $data)
     {
+        // Hide TC option when feature toggle is disabled
+        if (!$this->handleQuery(IsEnabledQry::create(['ids' => [FeatureToggle::TRANSPORT_CONSULTANT_ROLE]]))->getResult()['isEnabled']) {
+            $form->get('main')
+                ->get('permission')
+                ->unsetValueOption('tc');
+        }
+
         if (!isset($data['main']['currentPermission']) || ($data['main']['currentPermission'] !== 'tm')) {
             // the option should only be available if editing already TM user
             $form->get('main')

--- a/app/selfserve/test/Olcs/src/Controller/UserControllerTest.php
+++ b/app/selfserve/test/Olcs/src/Controller/UserControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OlcsTest\Controller;
 
 use Common\Form\Form;
+use Common\Service\Cqrs\Response;
 use Common\Service\Helper\FlashMessengerHelperService;
 use Common\Service\Helper\FormHelperService;
 use Common\Service\Helper\GuidanceHelperService;
@@ -243,6 +244,12 @@ class UserControllerTest extends MockeryTestCase
         $this->mockFormHelper
             ->shouldReceive('createFormWithRequest')->with('User', $this->mockRequest)->andReturn($this->mockForm);
 
+        $mockIsEnabledResponse = m::mock(Response::class);
+        $mockIsEnabledResponse->shouldReceive('getResult')->andReturn([
+            'isEnabled' => true,
+        ]);
+        $this->sut->shouldReceive('handleQuery')->with(m::type(TransferQry\FeatureToggle\IsEnabled::class))->andReturn($mockIsEnabledResponse);
+
         $view = $this->sut->editAction();
 
         $this->assertInstanceOf(Form::class, $view->getVariable('form'));
@@ -432,6 +439,13 @@ class UserControllerTest extends MockeryTestCase
             ->shouldReceive('disableElement')
             ->with($this->mockForm, 'main->loginId')
             ->once();
+
+        $mockIsEnabledResponse = m::mock(Response::class);
+        $mockIsEnabledResponse->shouldReceive('getResult')->andReturn([
+            'isEnabled' => true,
+        ]);
+        $this->sut->shouldReceive('handleQuery')->with(m::type(TransferQry\FeatureToggle\IsEnabled::class))->andReturn($mockIsEnabledResponse);
+
 
         $view = $this->sut->editAction();
 


### PR DESCRIPTION
## Description

Ensures the Transport Consultant role is hidden from Add/Manage Users page when the feature toggle `transport_consultant_role` is **disabled**

Related issue: https://dvsa.atlassian.net/browse/VOL-4706

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
