### PR TITLE
fix: use aws trivy java db registry avoid ratelimits

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -295,16 +295,13 @@ jobs:
       pull-requests: write
     secrets: inherit
 
-  test-dev:
+  test_dev:
     name: Run Tests on DEV
     needs:
       - terraform_env_dev
-    runs-on: ubuntu-latest
-    steps:
-      - name: Run E2E Smoke Test on DEV
-        uses: dvsa/vol-functional-tests/.github/workflows/e2eSmoke.yaml@main
-        with:
-          platform_env: dev
+    uses: dvsa/vol-functional-tests/.github/workflows/e2eSmoke.yaml@main
+    with:
+      platform_env: dev
 
   terraform_env_int:
     name: Environment (int)
@@ -334,12 +331,9 @@ jobs:
     name: Run Tests on INT
     needs:
       - terraform_env_int
-    runs-on: ubuntu-latest
-    steps:
-      - name: Run E2E Smoke Test on INT
-        uses: dvsa/vol-functional-tests/.github/workflows/e2eSmoke.yaml@main
-        with:
-          platform_env: int
+    uses: dvsa/vol-functional-tests/.github/workflows/e2eSmoke.yaml@main
+    with:
+      platform_env: int
 
   rollback_int:
     name: Rollback INT Deployment

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -99,6 +99,7 @@ jobs:
           version: "v0.54.1"
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
 
       - name: Configure AWS credentials
         if: ${{ inputs.push }}

--- a/.github/workflows/security-docker.yaml
+++ b/.github/workflows/security-docker.yaml
@@ -25,6 +25,7 @@ jobs:
           version: "v0.54.1"
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
       - name: Upload Results to GitHub Code Scanning
         if: ${{ always() }}
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/security-terraform.yaml
+++ b/.github/workflows/security-terraform.yaml
@@ -25,6 +25,7 @@ jobs:
           version: "v0.54.1"
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
       - name: Upload Results to GitHub Code Scanning
         if: ${{ always() }}
         uses: github/codeql-action/upload-sarif@v3

--- a/app/api/.gitignore
+++ b/app/api/.gitignore
@@ -26,4 +26,4 @@ phpcs.xml
 phpstan.neon
 phpunit.xml
 psalm.xml
-# Trigger CD - 2024-10-25-0940
+# Trigger CD - 2024-10-25-1020

--- a/app/api/.gitignore
+++ b/app/api/.gitignore
@@ -26,4 +26,4 @@ phpcs.xml
 phpstan.neon
 phpunit.xml
 psalm.xml
-# Trigger CD - 2024-10-07-1613
+# Trigger CD - 2024-10-25-0940

--- a/app/cdn/.gitignore
+++ b/app/cdn/.gitignore
@@ -26,4 +26,4 @@ composer.lock
 editorconfig.org
 assets/vendor
 .scannerwork/
-# Trigger CD - 2024-10-07-1613
+# Trigger CD - 2024-10-25-0940

--- a/app/cdn/.gitignore
+++ b/app/cdn/.gitignore
@@ -26,4 +26,4 @@ composer.lock
 editorconfig.org
 assets/vendor
 .scannerwork/
-# Trigger CD - 2024-10-25-0940
+# Trigger CD - 2024-10-25-1020

--- a/app/internal/.gitignore
+++ b/app/internal/.gitignore
@@ -27,5 +27,5 @@ phpcs.xml
 phpstan.neon
 phpunit.xml
 psalm.xml
-# Trigger CD - 2024-10-07-1613
+# Trigger CD - 2024-10-25-0940
 

--- a/app/internal/.gitignore
+++ b/app/internal/.gitignore
@@ -27,5 +27,5 @@ phpcs.xml
 phpstan.neon
 phpunit.xml
 psalm.xml
-# Trigger CD - 2024-10-25-0940
+# Trigger CD - 2024-10-25-1020
 

--- a/app/selfserve/.gitignore
+++ b/app/selfserve/.gitignore
@@ -26,5 +26,5 @@ phpcs.xml
 phpstan.neon
 phpunit.xml
 psalm.xml
-# Trigger CD - 2024-10-07-1613
+# Trigger CD - 2024-10-25-0940
 

--- a/app/selfserve/.gitignore
+++ b/app/selfserve/.gitignore
@@ -26,5 +26,5 @@ phpcs.xml
 phpstan.neon
 phpunit.xml
 psalm.xml
-# Trigger CD - 2024-10-25-0940
+# Trigger CD - 2024-10-25-1020
 


### PR DESCRIPTION
## Description

Specify trivy JAVA DB repository to avoid ghcr.io ratelimit errors
