### PR TITLE
chore: rollback int if e2etest workflow ends prematurely

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -338,7 +338,7 @@ jobs:
     name: Run Tests on INT
     needs:
       - terraform_env_int
-    uses: dvsa/vol-functional-tests/.github/workflows/e2eSmoke.yaml@main
+    uses: dvsa/vol-functional-tests/.github/workflows/e2eSmoke.yaml@fail
     with:
       platform_env: int
     permissions:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -348,7 +348,10 @@ jobs:
 
   rollback_int:
     name: Rollback INT Deployment
-    if: ${{ needs.test_int.result == 'failure' }}
+    if: |
+      always() &&
+      (needs.test_int.result == 'failure' || needs.test_int.result == 'cancelled') &&
+      needs.terraform_env_int.result == 'success'
     needs:
       - test_int
       - terraform_env_int

--- a/app/api/.gitignore
+++ b/app/api/.gitignore
@@ -26,4 +26,4 @@ phpcs.xml
 phpstan.neon
 phpunit.xml
 psalm.xml
-# Trigger CD - 2024-10-28-1630
+# Trigger CD - 2024-10-29-0745

--- a/app/api/.gitignore
+++ b/app/api/.gitignore
@@ -26,4 +26,4 @@ phpcs.xml
 phpstan.neon
 phpunit.xml
 psalm.xml
-# Trigger CD - 2024-10-28
+# Trigger CD - 2024-10-28-1514

--- a/app/api/.gitignore
+++ b/app/api/.gitignore
@@ -26,4 +26,4 @@ phpcs.xml
 phpstan.neon
 phpunit.xml
 psalm.xml
-# Trigger CD - 2024-10-28-1514
+# Trigger CD - 2024-10-28-1630


### PR DESCRIPTION
## Description

rollback it when tests fail explicitly or the called workflow dies some other way
