### PR TITLE
feat: remove option to change correspondence type

### DIFF
--- a/app/api/module/Api/src/Entity/Organisation/AbstractOrganisation.php
+++ b/app/api/module/Api/src/Entity/Organisation/AbstractOrganisation.php
@@ -53,9 +53,9 @@ abstract class AbstractOrganisation implements BundleSerializableInterface, Json
      *
      * @var string
      *
-     * @ORM\Column(type="yesno", name="allow_email", nullable=false, options={"default": 0})
+     * @ORM\Column(type="yesno", name="allow_email", nullable=false, options={"default": 1})
      */
-    protected $allowEmail = 0;
+    protected $allowEmail = 1;
 
     /**
      * Company cert seen


### PR DESCRIPTION
## Description
Remove the option to change correspondence type on selfserve.
Internal users can still change the correspondence type if needed.

<!--
Include a summary of the change here.
-->

Related issue: [5774](https://dvsa.atlassian.net/browse/VOL-5774)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?

## Related PRs
https://github.com/dvsa/olcs-etl/pull/70
https://github.com/dvsa/olcs-common/pull/176
