### PR TITLE
fix: only op-tc are affected by the submit app/var block op-adm check

### DIFF
--- a/app/selfserve/module/Olcs/src/Controller/Lva/AbstractUndertakingsController.php
+++ b/app/selfserve/module/Olcs/src/Controller/Lva/AbstractUndertakingsController.php
@@ -20,6 +20,7 @@ use Dvsa\Olcs\Transfer\Util\Annotation\AnnotationBuilder;
 use Dvsa\Olcs\Utils\Translation\NiTextTranslation;
 use Exception;
 use LmcRbacMvc\Service\AuthorizationService;
+use Rbac\Role\Role;
 
 /**
  * External Abstract Undertakings Controller
@@ -348,12 +349,9 @@ abstract class AbstractUndertakingsController extends AbstractController
      */
     protected function checkIfOperatorAdminHasLoggedIn($organisationId, $form = null): bool
     {
-        /**
-         * @todo we need this check to always return true for now
-         * @see https://dvsa.atlassian.net/browse/VOL-5886
-         * @see https://dvsa.atlassian.net/browse/VOL-5885
-         */
-        return true;
+        if (!$this->authService->isGranted(RefData::ROLE_OPERATOR_TC)) {
+            return true;
+        }
 
         $operatorAdminHasLoggedIn = $this->operatorAdminForOrganisationHasLoggedIn($organisationId);
 

--- a/app/selfserve/module/Olcs/src/Controller/Lva/AbstractUndertakingsController.php
+++ b/app/selfserve/module/Olcs/src/Controller/Lva/AbstractUndertakingsController.php
@@ -15,12 +15,10 @@ use Dvsa\Olcs\Transfer\Command\Application\UpdateDeclaration;
 use Dvsa\Olcs\Transfer\Command\GovUkAccount\GetGovUkAccountRedirect;
 use Dvsa\Olcs\Transfer\Query\FeatureToggle\IsEnabled as IsEnabledQry;
 use Dvsa\Olcs\Transfer\Query\User\OperatorAdminForOrganisationHasLoggedIn;
-use Dvsa\Olcs\Transfer\Query\User\UserListSelfserve;
 use Dvsa\Olcs\Transfer\Util\Annotation\AnnotationBuilder;
 use Dvsa\Olcs\Utils\Translation\NiTextTranslation;
 use Exception;
 use LmcRbacMvc\Service\AuthorizationService;
-use Rbac\Role\Role;
 
 /**
  * External Abstract Undertakings Controller


### PR DESCRIPTION
## Description

Ensures only Operator Transport Consultants are affected when it comes to the prevention of submitting an application or variation if an Operator Admin for the same organisation has never logged in.

Related issue: https://dvsa.atlassian.net/browse/VOL-5885

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
