### PR TITLE
feat: permission fixes, improve permission tests, faciltate check for last op admin user VOL-4718 VOL-5796

### DIFF
--- a/app/api/module/Api/src/Domain/QueryHandler/MyAccount/MyAccount.php
+++ b/app/api/module/Api/src/Domain/QueryHandler/MyAccount/MyAccount.php
@@ -54,6 +54,7 @@ class MyAccount extends AbstractQueryHandler implements CacheAwareInterface
         $isEligibleForPrompt = false;
         $hasActivePsv = false;
         $hasSubmittedLicenceApplication = false;
+        $canDeleteOperatorAdmin = false;
         $numVehicles = 0;
 
         $dataAccess = [];
@@ -79,6 +80,7 @@ class MyAccount extends AbstractQueryHandler implements CacheAwareInterface
             ];
         } elseif ($userId !== User::USER_TYPE_ANON) {
             $isEligibleForPermits = $user->isEligibleForPermits();
+            $canDeleteOperatorAdmin = $user->organisationCanDeleteOperatorAdmin();
 
             if ($isEligibleForPermits) {
                 //for now we need to leave this, as selfserve users don't have access to system param query
@@ -118,6 +120,7 @@ class MyAccount extends AbstractQueryHandler implements CacheAwareInterface
                 'eligibleForPrompt' => $isEligibleForPrompt,
                 'dataAccess' => $dataAccess,
                 'isInternal' => $isInternal,
+                'canDeleteOperatorAdmin' => $canDeleteOperatorAdmin,
             ]
         );
 

--- a/app/api/module/Api/src/Entity/Organisation/Organisation.php
+++ b/app/api/module/Api/src/Entity/Organisation/Organisation.php
@@ -530,6 +530,28 @@ class Organisation extends AbstractOrganisation implements ContextProviderInterf
     }
 
     /**
+     * can only delete operator admin if more than one exists
+     */
+    public function canDeleteOperatorAdmin(): bool
+    {
+        $numOperatorAdmins = 0;
+        $administratorUsers = $this->getAdministratorUsers();
+
+        /** @var OrganisationUserEntity $orgUser */
+        foreach ($administratorUsers as $orgUser) {
+            if ($orgUser->getUser()->isOperatorAdministrator()) {
+                $numOperatorAdmins++;
+            }
+
+            if ($numOperatorAdmins > 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Returns the latest Trading Name that hasnt been deleted
      *
      * @return string

--- a/app/api/test/module/Api/src/Domain/QueryHandler/MyAccount/MyAccountTest.php
+++ b/app/api/test/module/Api/src/Domain/QueryHandler/MyAccount/MyAccountTest.php
@@ -84,7 +84,7 @@ class MyAccountTest extends QueryHandlerTestCase
     /**
      * @dataProvider dpHandleQuery
      */
-    public function testHandleQuery($isSelfservePromptEnabled, $isEligibleForPermits, $expectedEligibleForPrompt): void
+    public function testHandleQuery($isSelfservePromptEnabled, $isEligibleForPermits, $expectedEligibleForPrompt, $canDeleteAdmin): void
     {
         $userId = 1;
 
@@ -98,6 +98,7 @@ class MyAccountTest extends QueryHandlerTestCase
         $mockUser->shouldReceive('hasOrganisationSubmittedLicenceApplication')->andReturn(true);
         $mockUser->expects('isEligibleForPermits')->withNoArgs()->andReturn($isEligibleForPermits);
         $mockUser->expects('getTeam')->never();
+        $mockUser->expects('organisationCanDeleteOperatorAdmin')->withNoArgs()->andReturn($canDeleteAdmin);
 
         $this->mockedSmServices[AuthorizationService::class]->shouldReceive('getIdentity->getUser')
             ->andReturn($mockUser);
@@ -123,6 +124,7 @@ class MyAccountTest extends QueryHandlerTestCase
             'eligibleForPrompt' => $expectedEligibleForPrompt,
             'dataAccess' => [],
             'isInternal' => false,
+            'canDeleteOperatorAdmin' => $canDeleteAdmin,
         ];
 
         $this->mockedSmServices[CacheEncryption::class]->expects('setCustomItem')
@@ -186,6 +188,7 @@ class MyAccountTest extends QueryHandlerTestCase
         $mockUser->shouldReceive('hasOrganisationSubmittedLicenceApplication')->never();
         $mockUser->expects('isEligibleForPermits')->never();
         $mockUser->expects('getTeam')->andReturn($mockTeam);
+        $mockUser->expects('organisationCanDeleteOperatorAdmin')->never();
 
         $this->mockedSmServices[AuthorizationService::class]->shouldReceive('getIdentity->getUser')
             ->andReturn($mockUser);
@@ -205,6 +208,7 @@ class MyAccountTest extends QueryHandlerTestCase
             'eligibleForPrompt' => false,
             'dataAccess' => $dataAccess,
             'isInternal' => true,
+            'canDeleteOperatorAdmin' => false,
         ];
 
         $this->mockedSmServices[CacheEncryption::class]->expects('setCustomItem')
@@ -224,16 +228,19 @@ class MyAccountTest extends QueryHandlerTestCase
                 'isSelfservePromptEnabled' => false,
                 'isEligibleForPermits' => true,
                 'expectedEligibleForPrompt' => false,
+                'expectedDeleteAdmin' => false,
             ],
             [
                 'isSelfservePromptEnabled' => true,
                 'isEligibleForPermits' => false,
                 'expectedEligibleForPrompt' => false,
+                'expectedDeleteAdmin' => false,
             ],
             [
                 'isSelfservePromptEnabled' => true,
                 'isEligibleForPermits' => true,
                 'expectedEligibleForPrompt' => true,
+                'expectedDeleteAdmin' => true,
             ],
         ];
     }
@@ -252,6 +259,7 @@ class MyAccountTest extends QueryHandlerTestCase
         $mockUser->shouldReceive('hasOrganisationSubmittedLicenceApplication')->never();
         $mockUser->expects('isEligibleForPermits')->never();
         $mockUser->expects('getTeam')->never();
+        $mockUser->expects('organisationCanDeleteOperatorAdmin')->never();
 
         $this->mockedSmServices[AuthorizationService::class]->shouldReceive('getIdentity->getUser')
             ->andReturn($mockUser);
@@ -271,6 +279,7 @@ class MyAccountTest extends QueryHandlerTestCase
             'eligibleForPrompt' => false,
             'dataAccess' => [],
             'isInternal' => false,
+            'canDeleteOperatorAdmin' => false,
         ];
 
         $this->mockedSmServices[CacheEncryption::class]->expects('setCustomItem')

--- a/app/api/test/module/Api/src/Entity/User/UserEntityTest.php
+++ b/app/api/test/module/Api/src/Entity/User/UserEntityTest.php
@@ -123,6 +123,7 @@ class UserEntityTest extends EntityTester
         $this->assertEquals(0, $entity->getOrganisationUsers()->count());
         $this->assertEquals('DVSA', $entity->getRelatedOrganisationName());
         $this->assertEquals(false, $entity->isAnonymous());
+        $this->assertFalse($entity->isAdministrator());
     }
 
     public function dpCreateInternal()
@@ -194,6 +195,7 @@ class UserEntityTest extends EntityTester
         $this->assertEquals(0, $entity->getOrganisationUsers()->count());
         $this->assertEquals('DVSA', $entity->getRelatedOrganisationName());
         $this->assertEquals(false, $entity->isAnonymous());
+        $this->assertFalse($entity->isAdministrator());
     }
 
     public function dpUpdateInternal()
@@ -210,10 +212,10 @@ class UserEntityTest extends EntityTester
     /**
      * @dataProvider dpOperatorAdminRoles
      */
-    public function testCreateTransportManager(string $adminRoleAsString): void
+    public function testCreateTransportManager(): void
     {
         $adminRole = m::mock(RoleEntity::class)->makePartial();
-        $adminRole->setRole($adminRoleAsString);
+        $adminRole->setRole(RoleEntity::ROLE_OPERATOR_ADMIN);
 
         $orgName = 'Org Name';
         $org = m::mock(OrganisationEntity::class)->makePartial();
@@ -248,6 +250,9 @@ class UserEntityTest extends EntityTester
         $this->assertEquals('Y', $entity->getOrganisationUsers()->first()->getIsAdministrator());
         $this->assertEquals($orgName, $entity->getRelatedOrganisationName());
         $this->assertEquals(false, $entity->isAnonymous());
+        $this->assertTrue($entity->isAdministrator());
+        $this->assertTrue($entity->isOperatorAdministrator());
+        $this->assertFalse($entity->isConsultantAdministrator());
     }
 
     public function testUpdateTransportManager()
@@ -308,6 +313,7 @@ class UserEntityTest extends EntityTester
         $this->assertEquals('N', $entity->getOrganisationUsers()->first()->getIsAdministrator());
         $this->assertEquals($orgName, $entity->getRelatedOrganisationName());
         $this->assertEquals(false, $entity->isAnonymous());
+        $this->assertFalse($entity->isAdministrator());
     }
 
     public function testCreatePartner()
@@ -349,6 +355,7 @@ class UserEntityTest extends EntityTester
         $this->assertEquals(0, $entity->getOrganisationUsers()->count());
         $this->assertEquals($orgName, $entity->getRelatedOrganisationName());
         $this->assertEquals(false, $entity->isAnonymous());
+        $this->assertFalse($entity->isAdministrator());
     }
 
     public function testUpdatePartner()
@@ -410,6 +417,7 @@ class UserEntityTest extends EntityTester
         $this->assertEquals(0, $entity->getOrganisationUsers()->count());
         $this->assertEquals($orgName, $entity->getRelatedOrganisationName());
         $this->assertEquals(false, $entity->isAnonymous());
+        $this->assertFalse($entity->isAdministrator());
     }
 
     public function testCreateLocalAuthority()
@@ -451,6 +459,7 @@ class UserEntityTest extends EntityTester
         $this->assertEquals(0, $entity->getOrganisationUsers()->count());
         $this->assertEquals($orgName, $entity->getRelatedOrganisationName());
         $this->assertEquals(false, $entity->isAnonymous());
+        $this->assertFalse($entity->isAdministrator());
     }
 
     public function testUpdateLocalAuthority()
@@ -512,15 +521,16 @@ class UserEntityTest extends EntityTester
         $this->assertEquals(0, $entity->getOrganisationUsers()->count());
         $this->assertEquals($orgName, $entity->getRelatedOrganisationName());
         $this->assertEquals(false, $entity->isAnonymous());
+        $this->assertFalse($entity->isAdministrator());
     }
 
     /**
      * @dataProvider dpOperatorAdminRoles
      */
-    public function testCreateOperator(string $adminRoleAsString): void
+    public function testCreateOperatorAdmin(): void
     {
         $adminRole = m::mock(RoleEntity::class)->makePartial();
-        $adminRole->setRole($adminRoleAsString);
+        $adminRole->setRole(RoleEntity::ROLE_OPERATOR_ADMIN);
 
         $orgName = 'Org Name';
         $org = m::mock(OrganisationEntity::class)->makePartial();
@@ -555,9 +565,55 @@ class UserEntityTest extends EntityTester
         $this->assertEquals('Y', $entity->getOrganisationUsers()->first()->getIsAdministrator());
         $this->assertEquals($orgName, $entity->getRelatedOrganisationName());
         $this->assertEquals(false, $entity->isAnonymous());
+        $this->assertTrue($entity->isAdministrator());
+        $this->assertTrue($entity->isOperatorAdministrator());
+        $this->assertFalse($entity->isConsultantAdministrator());
     }
 
-    public function testUpdateOperator()
+    public function testCreateTransportConsultant(): void
+    {
+        $adminRole = m::mock(RoleEntity::class)->makePartial();
+        $adminRole->setRole(RoleEntity::ROLE_OPERATOR_TC);
+
+        $orgName = 'Org Name';
+        $org = m::mock(OrganisationEntity::class)->makePartial();
+        $org->setName($orgName);
+
+        $data = [
+            'loginId' => 'loginId',
+            'roles' => [$adminRole],
+            'translateToWelsh' => 'N',
+            'accountDisabled' => 'Y',
+            'team' => m::mock(TeamEntity::class),
+            'transportManager' => m::mock(TransportManagerEntity::class),
+            'partnerContactDetails' => m::mock(ContactDetailsEntity::class),
+            'localAuthority' => m::mock(LocalAuthorityEntity::class),
+            'organisations' => [$org],
+        ];
+
+        $entity = Entity::create('pid', Entity::USER_TYPE_OPERATOR, $data);
+
+        $this->assertEquals($data['loginId'], $entity->getLoginId());
+        $this->assertEquals($data['roles'], $entity->getRoles()->toArray());
+        $this->assertEquals($data['translateToWelsh'], $entity->getTranslateToWelsh());
+        $this->assertEquals($data['accountDisabled'], $entity->getAccountDisabled());
+        $this->assertInstanceOf(\DateTime::class, $entity->getDisabledDate());
+
+        $this->assertEquals(Entity::USER_TYPE_OPERATOR, $entity->getUserType());
+        $this->assertEquals(null, $entity->getTeam());
+        $this->assertEquals(null, $entity->getTransportManager());
+        $this->assertEquals(null, $entity->getPartnerContactDetails());
+        $this->assertEquals(null, $entity->getLocalAuthority());
+        $this->assertEquals(1, $entity->getOrganisationUsers()->count());
+        $this->assertEquals('Y', $entity->getOrganisationUsers()->first()->getIsAdministrator());
+        $this->assertEquals($orgName, $entity->getRelatedOrganisationName());
+        $this->assertEquals(false, $entity->isAnonymous());
+        $this->assertTrue($entity->isAdministrator());
+        $this->assertFalse($entity->isOperatorAdministrator());
+        $this->assertTrue($entity->isConsultantAdministrator());
+    }
+
+    public function testUpdateOperatorUser()
     {
         $nonAdminRole = m::mock(RoleEntity::class)->makePartial();
         $nonAdminRole->setRole(RoleEntity::ROLE_OPERATOR_USER);
@@ -615,6 +671,7 @@ class UserEntityTest extends EntityTester
         $this->assertEquals('N', $entity->getOrganisationUsers()->first()->getIsAdministrator());
         $this->assertEquals($orgName, $entity->getRelatedOrganisationName());
         $this->assertEquals(false, $entity->isAnonymous());
+        $this->assertFalse($entity->isAdministrator());
     }
 
     /**
@@ -1416,5 +1473,59 @@ class UserEntityTest extends EntityTester
         $this->assertFalse($user->hasAgreedTermsAndConditions());
         $user->agreeTermsAndConditions();
         $this->assertTrue($user->hasAgreedTermsAndConditions());
+    }
+
+    public function testIsNotLastOperatorAdmin(): void
+    {
+        $adminRole = m::mock(RoleEntity::class)->makePartial();
+        $adminRole->setRole(RoleEntity::ROLE_OPERATOR_ADMIN);
+
+        $org = m::mock(OrganisationEntity::class)->makePartial();
+        $org->expects('canDeleteOperatorAdmin')->withNoArgs()->andReturnTrue();
+
+        $data = [
+            'loginId' => 'loginId',
+            'roles' => [$adminRole],
+            'organisations' => [$org],
+        ];
+
+        $entity = Entity::create('pid', Entity::USER_TYPE_OPERATOR, $data);
+        $this->assertFalse($entity->isLastOperatorAdmin());
+    }
+
+    public function testIsLastOperatorAdmin(): void
+    {
+        $adminRole = m::mock(RoleEntity::class)->makePartial();
+        $adminRole->setRole(RoleEntity::ROLE_OPERATOR_ADMIN);
+
+        $org = m::mock(OrganisationEntity::class)->makePartial();
+        $org->expects('canDeleteOperatorAdmin')->withNoArgs()->andReturnFalse();
+
+        $data = [
+            'loginId' => 'loginId',
+            'roles' => [$adminRole],
+            'organisations' => [$org],
+        ];
+
+        $entity = Entity::create('pid', Entity::USER_TYPE_OPERATOR, $data);
+        $this->assertTrue($entity->isLastOperatorAdmin());
+    }
+
+    public function testTransportConsultantNeverLastAdministrator(): void
+    {
+        $adminRole = m::mock(RoleEntity::class)->makePartial();
+        $adminRole->setRole(RoleEntity::ROLE_OPERATOR_TC);
+
+        $org = m::mock(OrganisationEntity::class)->makePartial();
+        $org->expects('canDeleteOperatorAdmin')->never();
+
+        $data = [
+            'loginId' => 'loginId',
+            'roles' => [$adminRole],
+            'organisations' => [$org],
+        ];
+
+        $entity = Entity::create('pid', Entity::USER_TYPE_OPERATOR, $data);
+        $this->assertFalse($entity->isLastOperatorAdmin());
     }
 }

--- a/app/selfserve/module/Olcs/src/Table/Tables/users.table.php
+++ b/app/selfserve/module/Olcs/src/Table/Tables/users.table.php
@@ -66,7 +66,7 @@ return [
                  * @var TableBuilder $this
                  * @psalm-scope-this TableBuilder
                  */
-                $this->permissionService->canRemoveSelfserveUser($row['id']),
+                $this->permissionService->canRemoveSelfserveUser($row['id'], $row['roles'][0]['role']),
             'ariaDescription' => function ($row, $column) {
                 $column['formatter'] = Name::class;
                 /**


### PR DESCRIPTION
This PR deals with the selfserve portion of VOL-4718.

Also includes fixes as a result of the permissions reviewed in VOL-5796. Primarily this is preventing transport consultant role being incorrectly given to transport managers. Have also expanded unit tests in this area, in relation to who is and isn't considered an administrator, which was helpful for both tickets. 

Related issue: [VOL-4718](https://dvsa.atlassian.net/browse/VOL-4718)
Related issue: [VOL-5796](https://dvsa.atlassian.net/browse/VOL-5796)

