### PR TITLE
fix: reinstate transport manager ability to have TC role

### DIFF
--- a/app/api/module/Api/src/Entity/User/User.php
+++ b/app/api/module/Api/src/Entity/User/User.php
@@ -65,6 +65,7 @@ class User extends AbstractUser implements OrganisationProviderInterface
             RoleEntity::ROLE_OPERATOR_TM,
         ],
         self::USER_TYPE_TRANSPORT_MANAGER => [
+            RoleEntity::ROLE_OPERATOR_TC,
             RoleEntity::ROLE_OPERATOR_ADMIN,
             RoleEntity::ROLE_OPERATOR_USER,
             RoleEntity::ROLE_OPERATOR_TM,
@@ -103,6 +104,7 @@ class User extends AbstractUser implements OrganisationProviderInterface
             self::PERMISSION_TM => [RoleEntity::ROLE_OPERATOR_TM],
         ],
         self::USER_TYPE_TRANSPORT_MANAGER => [
+            self::PERMISSION_TC => [RoleEntity::ROLE_OPERATOR_TC],
             self::PERMISSION_ADMIN => [RoleEntity::ROLE_OPERATOR_ADMIN],
             self::PERMISSION_USER => [RoleEntity::ROLE_OPERATOR_USER],
             self::PERMISSION_TM => [RoleEntity::ROLE_OPERATOR_TM],


### PR DESCRIPTION
Related issue: [VOL-5796](https://dvsa.atlassian.net/browse/VOL-5796)
