### PR TITLE
fix: remove placeholders that have been removed from paramstore

### DIFF
--- a/app/api/config/autoload/config.global.php
+++ b/app/api/config/autoload/config.global.php
@@ -317,7 +317,7 @@ return [
             'oauth2' => [
                 'client_id' => '%olcs_txc_client_id%',
                 'client_secret' => '%olcs_txc_client_secret%',
-                'token_url' => '%olcs_txc_token_url%',
+                'token_url' => '',
                 'scope' => '%olcs_txc_scope%',
                 'proxy' => 'http://%shd_proxy%',
                 'service_name' => 'TransXchange',
@@ -343,7 +343,7 @@ return [
     'nr' => [
         // @to-do currently waiting on the actual nr address
         'inr_service' => [
-            'uri' => '%olcs_natreg_uri%',
+            'uri' => '',
             'adapter' => Laminas\Http\Client\Adapter\Curl::class,
             'options' => [
                 'sslcert' => '/opt/dvsa/inr/certs/inr_client_cert.pem',
@@ -359,7 +359,7 @@ return [
             ]
         ],
         'repute_url' => [
-            'uri' => '%olcs_natreg_repute%'
+            'uri' => ''
         ],
     ],
 
@@ -436,7 +436,7 @@ return [
     // Nysiis configuration
     'nysiis' => [
         'rest' => [
-            'uri' => 'http://localhost:8080/nysiis-%olcs_nysiis_version%/nysiis/convert',
+            'uri' => 'http://localhost:8080/nysiis-/nysiis/convert',
             'options' => [
                 'timeout' => 5
             ]


### PR DESCRIPTION
## Description

Remove placeholders for parameters which no longer exist in AWS Param store.

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
