### PR TITLE
fix: default language for spellcheck to en_GB

### DIFF
--- a/app/cdn/public/tinymce/plugins/spellchecker/OlcsEngine.php
+++ b/app/cdn/public/tinymce/plugins/spellchecker/OlcsEngine.php
@@ -27,7 +27,7 @@ class OlcsEngine extends TinyMCE_SpellChecker_Engine
         header("Pragma: no-cache");
 
         $method = self::getParam("method", "spellcheck");
-        $lang = self::getParam("lang", "en_US");
+        $lang = self::getParam("lang", "en_GB");
         $text = self::getParam("text");
 
         if ($method == "spellcheck") {


### PR DESCRIPTION
## Description

The default language for spellchecking is now en_GB. It should be noted that the version of TinyMCE and associated spellchecker are very old, dating back to 2015 and 2014 respectively. We should do something about this going forward.

Related issue: [VOL-5907](https://dvsa.atlassian.net/browse/VOL-5907)
