### PR TITLE
fix: 5936 lb toggle on ecs service

### DIFF
--- a/infra/terraform/modules/service/ecs.tf
+++ b/infra/terraform/modules/service/ecs.tf
@@ -135,7 +135,7 @@ module "ecs_service" {
       container_name   = each.key
       container_port   = 8080
     }
-  } : null
+  } : {}
 
   create_security_group = false
   security_group_ids    = var.services[each.key].security_group_ids

--- a/infra/terraform/modules/service/ecs.tf
+++ b/infra/terraform/modules/service/ecs.tf
@@ -129,8 +129,8 @@ module "ecs_service" {
       memory_reservation = 100
     }
   }
-
   load_balancer = {
+    count = var.services[each.key].listener_rule_enable ? 1 : 0
     service = {
       target_group_arn = aws_lb_target_group.this[each.key].arn
       container_name   = each.key

--- a/infra/terraform/modules/service/ecs.tf
+++ b/infra/terraform/modules/service/ecs.tf
@@ -130,12 +130,11 @@ module "ecs_service" {
     }
   }
   load_balancer = {
-    count = var.services[each.key].listener_rule_enable ? 1 : 0
-    service = {
+    service = var.services[each.key].listener_rule_enable ? {
       target_group_arn = aws_lb_target_group.this[each.key].arn
       container_name   = each.key
       container_port   = 8080
-    }
+    } : {}
   }
 
   create_security_group = false

--- a/infra/terraform/modules/service/ecs.tf
+++ b/infra/terraform/modules/service/ecs.tf
@@ -129,13 +129,13 @@ module "ecs_service" {
       memory_reservation = 100
     }
   }
-  load_balancer = {
-    service = var.services[each.key].listener_rule_enable ? {
+  load_balancer = var.services[each.key].listener_rule_enable ? {
+    service = {
       target_group_arn = aws_lb_target_group.this[each.key].arn
       container_name   = each.key
       container_port   = 8080
-    } : {}
-  }
+    }
+  } : null
 
   create_security_group = false
   security_group_ids    = var.services[each.key].security_group_ids


### PR DESCRIPTION
## Description
Fixing the error:
The target group does not have an associated load balancer.
We are fixing this by removing the target group from the ecs service when the target group is not attached to a load balancer
<!--
Fixing the error:
The target group does not have an associated load balancer.
We are fixing this by removing the target group from the ecs service when the target group is not attached to a load balancer
-->

Related issue: https://dvsa.atlassian.net/browse/VOL-5936

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
