### PR TITLE
fix: terms and conditions link populated on TC journey VOL-5943

### DIFF
--- a/app/selfserve/module/Olcs/src/Controller/ConsultantRegistrationController.php
+++ b/app/selfserve/module/Olcs/src/Controller/ConsultantRegistrationController.php
@@ -168,7 +168,7 @@ class ConsultantRegistrationController extends AbstractController
         }
 
         return $this->prepareView('olcs/user-registration/index', [
-            'form' => $form,
+            'form' => $this->alterForm($form),
             'pageTitle' => 'register-consultant-account.form.label'
         ]);
     }
@@ -195,6 +195,23 @@ class ConsultantRegistrationController extends AbstractController
         $this->flashMessengerHelper->addErrorMessage('unknown-error');
 
         $this->redirect()->toRoute('user-registration');
+    }
+
+    private function alterForm($form)
+    {
+        // inject link into terms agreed label
+        $termsAgreed = $form->get('fields')->get('termsAgreed');
+
+        $label = $this->translationHelper->translateReplace(
+            $termsAgreed->getLabel(),
+            [
+                $this->urlHelper->fromRoute('terms-and-conditions')
+            ]
+        );
+
+        $termsAgreed->setLabel($label);
+
+        return $form;
     }
 
     /**

--- a/app/selfserve/module/Olcs/src/Controller/OperatorRegistrationController.php
+++ b/app/selfserve/module/Olcs/src/Controller/OperatorRegistrationController.php
@@ -58,9 +58,26 @@ class OperatorRegistrationController extends AbstractController
         }
 
         return $this->prepareView('olcs/user-registration/index', [
-            'form' => $form,
+            'form' => $this->alterForm($form),
             'pageTitle' => 'operator-registration.page.title'
         ]);
+    }
+
+    private function alterForm($form)
+    {
+        // inject link into terms agreed label
+        $termsAgreed = $form->get('fields')->get('termsAgreed');
+
+        $label = $this->translationHelper->translateReplace(
+            $termsAgreed->getLabel(),
+            [
+                $this->urlHelper->fromRoute('terms-and-conditions')
+            ]
+        );
+
+        $termsAgreed->setLabel($label);
+
+        return $form;
     }
 
     private function prepareView(string $template, array $variables = []): ViewModel

--- a/app/selfserve/module/Olcs/src/Controller/WelcomeController.php
+++ b/app/selfserve/module/Olcs/src/Controller/WelcomeController.php
@@ -6,6 +6,7 @@ namespace Olcs\Controller;
 
 use Common\Service\Helper\FormHelperService;
 use Common\Service\Helper\TranslationHelperService;
+use Common\Service\Helper\UrlHelperService;
 use Common\Service\Table\TableFactory;
 use Dvsa\Olcs\Transfer\Command\User\AgreeTerms as AgreeTermsCmd;
 use Laminas\Http\Response;
@@ -38,7 +39,8 @@ class WelcomeController extends AbstractSelfserveController
         TranslationHelperService $translationHelper,
         FormHelperService $formHelper,
         TableFactory $tableBuilder,
-        MapperManager $mapperManager
+        MapperManager $mapperManager,
+        private readonly UrlHelperService $urlHelper
     ) {
         parent::__construct($translationHelper, $formHelper, $tableBuilder, $mapperManager);
     }
@@ -55,5 +57,22 @@ class WelcomeController extends AbstractSelfserveController
         if ($this->currentUser()->getIdentity()->hasAgreedTerms()) {
             return $this->conditionalDisplayNotMet('index');
         }
+    }
+
+    public function alterForm($form)
+    {
+        // inject link into terms agreed label
+        $termsAgreed = $form->get('fields')->get('termsAgreed');
+
+        $label = $this->translationHelper->translateReplace(
+            $termsAgreed->getLabel(),
+            [
+                $this->urlHelper->fromRoute('terms-and-conditions')
+            ]
+        );
+
+        $termsAgreed->setLabel($label);
+
+        return parent::alterForm($form);
     }
 }

--- a/app/selfserve/module/Olcs/src/Controller/WelcomeControllerFactory.php
+++ b/app/selfserve/module/Olcs/src/Controller/WelcomeControllerFactory.php
@@ -6,6 +6,7 @@ namespace Olcs\Controller;
 
 use Common\Service\Helper\FormHelperService;
 use Common\Service\Helper\TranslationHelperService;
+use Common\Service\Helper\UrlHelperService;
 use Common\Service\Table\TableFactory;
 use Psr\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
@@ -19,6 +20,8 @@ class WelcomeControllerFactory implements FactoryInterface
         $formHelper = $container->get(FormHelperService::class);
         $tableBuilder = $container->get(TableFactory::class);
         $mapperManager = $container->get(MapperManager::class);
-        return new WelcomeController($translationHelper, $formHelper, $tableBuilder, $mapperManager);
+        $urlHelper = $container->get(UrlHelperService::class);
+
+        return new WelcomeController($translationHelper, $formHelper, $tableBuilder, $mapperManager, $urlHelper);
     }
 }

--- a/app/selfserve/module/Olcs/src/Form/Model/Form/AgreeTerms.php
+++ b/app/selfserve/module/Olcs/src/Form/Model/Form/AgreeTerms.php
@@ -13,7 +13,7 @@ use Laminas\Form\Annotation as Form;
 class AgreeTerms
 {
     /**
-     * @Form\Name("main")
+     * @Form\Name("fields")
      * @Form\Options({"label":""})
      * @Form\ComposedObject("Olcs\Form\Model\Fieldset\AgreeTerms")
      */


### PR DESCRIPTION
## Description

Terms and conditions links have the URL merged into a translation key, this wasn't happening on the new TC journey.

Related issue: [VOL-5943](https://dvsa.atlassian.net/browse/VOL-5943)
