### PR TITLE
fix: remove </p> being added to end of usernames (tc user registration email)

### DIFF
--- a/app/api/module/Email/view/email/en_GB/plain/user-registered-tc.phtml
+++ b/app/api/module/Email/view/email/en_GB/plain/user-registered-tc.phtml
@@ -2,7 +2,7 @@ Hello,
 
 You've been added to the Vehicle Operator Licensing service for <?php echo $this->orgName; ?>.
 
-Your username is: <?php echo $this->loginId; ?></p>
+Your username is: <?php echo $this->loginId; ?>
 
 You'll receive a second email with a temporary password in the next two hours. If it doesn't arrive email notifications@vehicle-operator-licensing.service.gov.uk
 


### PR DESCRIPTION
## Description

This looks like a copy/paste error where HTML close paragraph tag has been left in the plain text version of the email. Needs removing as it has the effect of being added onto the end of the username.
