### PR TITLE
fix: 5954 liquidate batch job secret arn

### DIFF
--- a/infra/terraform/modules/service/batch-liquibase.tf
+++ b/infra/terraform/modules/service/batch-liquibase.tf
@@ -65,7 +65,7 @@ module "batch-liquibase" {
         secrets = [
           {
             name      = "DB_PASSWORD"
-            valueFrom = "arn:aws:secretsmanager:eu-west-1:${data.aws_caller_identity.current.account_id}:${var.batch-liquibase.secret_file}:olcs_api_rds_password"
+            valueFrom = "arn:aws:secretsmanager:eu-west-1:${data.aws_caller_identity.current.account_id}:secret:${var.batch-liquibase.secret_file}:olcs_api_rds_password"
           },
         ]
 


### PR DESCRIPTION
## Description
Addressing issue in previous terraform apply:
ValueFrom is not an Arn for System Manager Parameter or Secret Manager secret

<!--
Include a summary of the change here.
-->

Related issue: https://dvsa.atlassian.net/browse/VOL-5954

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
