### PR TITLE
fix: relax licence type check when retrieving workshop, query is giving id as a string

### DIFF
--- a/app/api/module/Api/src/Domain/QueryHandler/Workshop/Workshop.php
+++ b/app/api/module/Api/src/Domain/QueryHandler/Workshop/Workshop.php
@@ -26,7 +26,7 @@ class Workshop extends AbstractQueryHandler
         $queryLicenceId = $query->getLicence();
         $queryAppId = $query->getApplication();
 
-        if ($queryLicenceId !== null && $queryLicenceId !== $workshop->getLicence()->getId()) {
+        if (($queryLicenceId !== null && $queryLicenceId != $workshop->getLicence()->getId())) {
             throw new BadRequestException(self::ERR_LICENCE_MISMATCH);
         }
 


### PR DESCRIPTION
Quick addendum, it appears we're being passed the licence id as a string here, so relaxing the type check. Like most of the DTOs, ideally in the long run we'd add a filter on the query itself to always force int or null, but this requires testing everywhere it's used etc.

Related issue: [VOL-5982](https://dvsa.atlassian.net/browse/VOL-5982)
