### PR TITLE
fix: remove param being passed to workflow_call only valid for dispatch

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -298,7 +298,6 @@ jobs:
       account: nonprod
       environment: dev
       dry_run: false
-      submit_job: true
       etl_ref: ${{ needs.release-please.outputs.release_created && needs.release-please.outputs.tag_name || 'main' }}
     permissions:
       contents: read
@@ -368,7 +367,6 @@ jobs:
       account: nonprod
       environment: int
       dry_run: false
-      submit_job: true
       etl_ref: ${{ needs.release-please.outputs.release_created && needs.release-please.outputs.tag_name || 'main' }}
     permissions:
       contents: read
@@ -523,7 +521,6 @@ jobs:
       account: prod
       environment: prep
       dry_run: false
-      submit_job: true
       etl_ref: ${{ needs.release-please.outputs.tag_name }}
     permissions:
       contents: read
@@ -618,7 +615,6 @@ jobs:
       account: prod
       environment: prod
       dry_run: false
-      submit_job: true
       etl_ref: ${{ needs.release-please.outputs.tag_name }}
     permissions:
       contents: read


### PR DESCRIPTION
## Description

submit_job param not present on workflow_call, only dispatch. Removed.

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
