### PR TITLE
fix: specify scheduling params for liquibase batch job

### DIFF
--- a/.github/workflows/run-liquibase.yaml
+++ b/.github/workflows/run-liquibase.yaml
@@ -85,6 +85,7 @@ env:
     }}
 jobs:
   build:
+    environment: ${{ inputs.environment }}
     outputs:
       image_tag: ${{ steps.build-details.outputs.image_tag }}
     runs-on: ubuntu-latest
@@ -170,6 +171,8 @@ jobs:
              {\"name\": \"DRY_RUN\", \"value\": \"${{ inputs.dry_run }}\"}
            ]
           }" \
+          --scheduling-priority-override 1 \
+          --share-identifier "liquibase-migrations" \
           --query 'jobId' \
           --output text)
           echo "job_id=$JOB_ID" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description

batch definition requires share params to be set on job submission.

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
