### PR TITLE
chore: run liquibase if app is built but acct terraform was skipped

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -291,7 +291,6 @@ jobs:
     needs:
       - release-please
       - get-version
-      - terraform-account-nonprod
       - docker
     uses: ./.github/workflows/run-liquibase.yaml
     with:

--- a/app/api/.gitignore
+++ b/app/api/.gitignore
@@ -26,4 +26,4 @@ phpcs.xml
 phpstan.neon
 phpunit.xml
 psalm.xml
-# Trigger CD - 2025-01-23-1330
+# Trigger CD - 2025-01-23-1536

--- a/infra/docker/search/Dockerfile
+++ b/infra/docker/search/Dockerfile
@@ -11,4 +11,4 @@ COPY entrypoint.sh /usr/share/logstash/entrypoint.sh
 COPY build.sh /usr/share/logstash/build.sh
 
 CMD ["/usr/share/logstash/entrypoint.sh"]
-# build 2025-01-23-1330
+# build 2025-01-23-1536


### PR DESCRIPTION
## Description

dont require a nonprod tf run (as it can be skipped) for liquibase migration to run

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
