### PR TITLE
fix: error handling for SS registration

### DIFF
--- a/app/selfserve/module/Olcs/src/Controller/OperatorRegistrationController.php
+++ b/app/selfserve/module/Olcs/src/Controller/OperatorRegistrationController.php
@@ -91,7 +91,6 @@ class OperatorRegistrationController extends AbstractController
         $view = new ViewModel($variables);
         $view->setTemplate($template);
 
-
         if (isset($variables['pageTitle'])) {
             $this->placeholder()->setPlaceholder('pageTitle', $variables['pageTitle']);
         }

--- a/app/selfserve/module/Olcs/src/Controller/OperatorRegistrationController.php
+++ b/app/selfserve/module/Olcs/src/Controller/OperatorRegistrationController.php
@@ -55,12 +55,12 @@ class OperatorRegistrationController extends AbstractController
                 if (!empty($result['messages'])) {
                     $form->setMessages(
                         [
-                            'main' => $result['messages'],
+                            'fields' => $result['messages'],
                         ]
                     );
-                } else {
-                    $this->flashMessengerHelper->addErrorMessage('unknown-error');
                 }
+
+                $this->flashMessengerHelper->addErrorMessage('There was an error registering your account. Please try again.');
 
             }
         }

--- a/app/selfserve/module/Olcs/src/Controller/OperatorRegistrationController.php
+++ b/app/selfserve/module/Olcs/src/Controller/OperatorRegistrationController.php
@@ -58,9 +58,9 @@ class OperatorRegistrationController extends AbstractController
                             'fields' => $result['messages'],
                         ]
                     );
+                } else {
+                    $this->flashMessengerHelper->addErrorMessage('There was an error registering your account. Please try again.');
                 }
-
-                $this->flashMessengerHelper->addErrorMessage('There was an error registering your account. Please try again.');
 
             }
         }

--- a/app/selfserve/module/Olcs/src/Controller/OperatorRegistrationController.php
+++ b/app/selfserve/module/Olcs/src/Controller/OperatorRegistrationController.php
@@ -50,8 +50,18 @@ class OperatorRegistrationController extends AbstractController
                         'pageTitle' => 'user-registration.page.check-email.title'
                     ]);
                 }
+                $result = $response->getResult();
 
-                $this->flashMessengerHelper->addErrorMessage('There was an error registering your account. Please try again.');
+                if (!empty($result['messages'])) {
+                    $form->setMessages(
+                        [
+                            'main' => $result['messages'],
+                        ]
+                    );
+                } else {
+                    $this->flashMessengerHelper->addErrorMessage('unknown-error');
+                }
+
             }
         }
         return $this->prepareView('olcs/user-registration/index', [
@@ -80,6 +90,7 @@ class OperatorRegistrationController extends AbstractController
     {
         $view = new ViewModel($variables);
         $view->setTemplate($template);
+
 
         if (isset($variables['pageTitle'])) {
             $this->placeholder()->setPlaceholder('pageTitle', $variables['pageTitle']);


### PR DESCRIPTION
## Description

Fixed error handling for when a user tries to register on self serve and uses an already existing username.

Related issue: VOL-5994 https://dvsa.atlassian.net/browse/VOL-5994

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
