### PR TITLE
fix: formatting of tm birth date on application overview

### DIFF
--- a/app/selfserve/module/Olcs/view/pages/application-summary.phtml
+++ b/app/selfserve/module/Olcs/view/pages/application-summary.phtml
@@ -119,7 +119,7 @@
                                   <td class="govuk-table__cell">
                                       <?php echo $this->transportManagerApplicationStatus($tmStatus['id'], $tmStatus['description']); ?>
                                   </td>
-                                  <td class="govuk-table__cell"><?php echo $this->escapeHtml(date(strtotime($tmPerson['birthDate']))); ?></td>
+                                  <td class="govuk-table__cell"><?php echo $this->escapeHtml(date("d-m-Y", strtotime($tmPerson['birthDate']))); ?></td>
                                   <td class="govuk-table__cell">
                                       <?php echo $this->link($tmLink, 'approve-tm.table.action.view-details'); ?>
                                   </td>

--- a/app/selfserve/module/Olcs/view/pages/application-summary.phtml
+++ b/app/selfserve/module/Olcs/view/pages/application-summary.phtml
@@ -119,7 +119,7 @@
                                   <td class="govuk-table__cell">
                                       <?php echo $this->transportManagerApplicationStatus($tmStatus['id'], $tmStatus['description']); ?>
                                   </td>
-                                  <td class="govuk-table__cell"><?php echo $this->escapeHtml(date("d-m-Y", strtotime($tmPerson['birthDate']))); ?></td>
+                                  <td class="govuk-table__cell"><?php echo $this->escapeHtml($this->date(strtotime($tmPerson['birthDate']))); ?></td>
                                   <td class="govuk-table__cell">
                                       <?php echo $this->link($tmLink, 'approve-tm.table.action.view-details'); ?>
                                   </td>


### PR DESCRIPTION
## Description

Make sure that the birth date formatting is `DD-MM-YYYY` for transport managers, on an application overview.

Related issue: [6050](https://dvsa.atlassian.net/browse/VOL-6050)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
