### PR TITLE
fix: set job command default option

### DIFF
--- a/infra/terraform/modules/service/batch.tf
+++ b/infra/terraform/modules/service/batch.tf
@@ -105,7 +105,7 @@ locals {
 
     container_properties = jsonencode({
 
-      command = (job.type == null ? concat([
+      command = (job.type == "default" ? concat([
         "/var/www/html/vendor/bin/laminas",
         "--container=/var/www/html/config/container-cli.php"
       ], job.commands) : job.commands)


### PR DESCRIPTION
fix batch job default command so that full command is provided. To fix the error:

/usr/local/bin/docker-php-entrypoint: exec: line 9: queue:process-queue: not found

<!--
Include a summary of the change here.
-->

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
