### PR TITLE
fix: try stop liquibase being skipped despite terraform-env-dev completing

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -319,6 +319,7 @@ jobs:
 
   liquibase-dev:
     name: Liquibase Migrations (dev)
+    if: ${{ always() && !cancelled() && !failure() && needs.terraform_env_dev.result == 'success' }}
     needs:
       - terraform_env_dev
     uses: ./.github/workflows/run-liquibase.yaml


### PR DESCRIPTION
## Description

Attempt to avoid liquibase being skipped after dev terraform

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
