### PR TITLE
feat: use native arm runners for docker builds for performance and avoid segfault error

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -48,7 +48,7 @@ jobs:
 
   build:
     name: Build ${{ inputs.push && 'and push' || '' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/run-liquibase.yaml
+++ b/.github/workflows/run-liquibase.yaml
@@ -90,7 +90,7 @@ jobs:
       image_tag: ${{ steps.build-details.outputs.image_tag }}
       etl_sha: ${{ steps.etl-sha.outputs.sha }}
       etl_ref: ${{ inputs.etl_ref }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
         with:

--- a/app/api/.gitignore
+++ b/app/api/.gitignore
@@ -26,4 +26,4 @@ phpcs.xml
 phpstan.neon
 phpunit.xml
 psalm.xml
-# Trigger CD - 2025-01-28-1607
+# Trigger CD - 2025-02-07-1240


### PR DESCRIPTION
## Description

Use native arm64 github runners for docker build steps 

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
