### PR TITLE
chore: supress twig snyk error - pull correct dep for new runner arch

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -153,7 +153,7 @@ jobs:
         uses: notaryproject/notation-action/sign@v1
         with:
           plugin_name: com.amazonaws.signer.notation.plugin
-          plugin_url: https://d2hvyiie56hcat.cloudfront.net/linux/amd64/plugin/latest/notation-aws-signer-plugin.zip
+          plugin_url: https://d2hvyiie56hcat.cloudfront.net/linux/arm64/plugin/latest/notation-aws-signer-plugin.zip
           plugin_checksum: cccfe8fdcdf853d83fd57ffc80524eddda75ad7ae9d9a257b087007230ec02f9
           key_id: arn:aws:signer:eu-west-1:054614622558:/signing-profiles/vol_app_20240313124948142600000001
           target_artifact_reference: ${{ env.REGISTRY }}/vol-app/${{ inputs.project }}:${{ inputs.version }}

--- a/app/api/.snyk
+++ b/app/api/.snyk
@@ -15,11 +15,11 @@ ignore:
   'SNYK-PHP-TWIGTWIG-8349790':
     - '*':
         reason: Upgrade planned in VOL-5894
-        expires: 2025-01-18T02:01:00.000Z
+        expires: 2025-02-18T02:01:00.000Z
         created: 2024-11-07T02:01:00.000Z
   'SNYK-PHP-TWIGTWIG-8349791':
     - '*':
         reason: Upgrade planned in VOL-5894
-        expires: 2025-01-18T02:01:00.000Z
+        expires: 2025-02-18T02:01:00.000Z
         created: 2024-11-07T02:01:00.000Z
 patch: {}


### PR DESCRIPTION
## Description

Suppres synk error for a little longer, and correct a URI to pull down correct binary for new runner arch.

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
