### PR TITLE
fix: erru case tasks have action date the same as case creation date VOL-5817

### DIFF
--- a/app/api/module/Api/src/Domain/CommandHandler/Cases/Si/ComplianceEpisode.php
+++ b/app/api/module/Api/src/Domain/CommandHandler/Cases/Si/ComplianceEpisode.php
@@ -503,7 +503,7 @@ final class ComplianceEpisode extends AbstractCommandHandler implements Transact
             'category' => CategoryEntity::CATEGORY_COMPLIANCE,
             'subCategory' => CategoryEntity::TASK_SUB_CATEGORY_NR,
             'description' => 'ERRU case has been automatically created',
-            'actionDate' => date('Y-m-d', strtotime('+7 days')),
+            'actionDate' => date('Y-m-d'),
             'urgent' => 'Y',
             'case' => $case->getId(),
             'licence' => $case->getLicence()->getId(),

--- a/app/api/test/module/Api/src/Domain/CommandHandler/Cases/Si/ComplianceEpisodeTest.php
+++ b/app/api/test/module/Api/src/Domain/CommandHandler/Cases/Si/ComplianceEpisodeTest.php
@@ -254,7 +254,7 @@ class ComplianceEpisodeTest extends AbstractCommandHandlerTestCase
             'category' => CategoryEntity::CATEGORY_COMPLIANCE,
             'subCategory' => CategoryEntity::TASK_SUB_CATEGORY_NR,
             'description' => 'ERRU case has been automatically created',
-            'actionDate' => date('Y-m-d', strtotime('+7 days')),
+            'actionDate' => date('Y-m-d'),
             'urgent' => 'Y',
             'case' => null,
             'licence' => $licenceId,


### PR DESCRIPTION
## Description

Tasks for erru cases have always had the action date 7 days in the future. While testing this @culshawn has requested this be changed to the same day the case was created.

Related issue: [VOL-5817](https://dvsa.atlassian.net/browse/VOL-5817)


[VOL-5817]: https://dvsa.atlassian.net/browse/VOL-5817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ