### PR TITLE
fix: application complete date no longer copied to bus variations VOL-6054

### DIFF
--- a/app/api/module/Api/src/Entity/Bus/BusReg.php
+++ b/app/api/module/Api/src/Entity/Bus/BusReg.php
@@ -116,6 +116,7 @@ class BusReg extends AbstractBusReg implements ContextProviderInterface, Organis
         'receivedDate' => null,
         'effectiveDate' => null,
         'endDate' => null,
+        'applicationCompleteDate' => null,
         // These will be set to yes explicitly by the TXC processor, default it to no for the internal app
         'isTxcApp' => 'N',
         'ebsrRefresh' => 'N'


### PR DESCRIPTION
## Description

Quick addendum to this ticket. Bus variation and cancellation records are created by making a copy of the previous version, with some fields cleared. The application complete date is now one of the cleared fields.

Related issue: [VOL-6054](https://dvsa.atlassian.net/browse/VOL-6054)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?


[VOL-6054]: https://dvsa.atlassian.net/browse/VOL-6054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ