### PR TITLE
fix: increase lifecycle policy to prevent images being overwritten

### DIFF
--- a/infra/terraform/modules/account/ecr.tf
+++ b/infra/terraform/modules/account/ecr.tf
@@ -31,12 +31,12 @@ module "ecr" {
     rules = [
       {
         rulePriority = 10,
-        description  = "Keep last 5 release images",
+        description  = "Keep last 20 release images",
         selection = {
           tagStatus      = "tagged",
           tagPatternList = ["*.*.*"],
           countType      = "imageCountMoreThan",
-          countNumber    = 5
+          countNumber    = 20
         },
         action = {
           type = "expire"
@@ -44,12 +44,12 @@ module "ecr" {
       },
       {
         rulePriority = 20,
-        description  = "Keep last 5 non-release images",
+        description  = "Keep last 20 non-release images",
         selection = {
           tagStatus      = "tagged",
           tagPatternList = ["*"],
           countType      = "imageCountMoreThan",
-          countNumber    = 5
+          countNumber    = 20
         },
         action = {
           type = "expire"


### PR DESCRIPTION
… quickly

## Description

Initially the lifecycle policy for the ECR was set to keep the last 5 artefacts however, we create about 5 artefacts each time we create a container meaning there isn't scope for previous container image in the ECR's.

Related issue:

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
