### PR TITLE
fix: run push to prod on ecr on arm64 runner so it grabs/pushes the r…

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -528,7 +528,7 @@ jobs:
       needs.test_int_smoke.result == 'success' &&
       needs.test_int_selfserve.result == 'success' &&
       needs.test_int_internal.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-arm64
     needs:
       - release-please
       - get-version


### PR DESCRIPTION
…ight containers

## Description

Make sure pull/push to prod ect happens on arm64 to avoid missing amd64 image messages

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
