### PR TITLE
fix: delete prod ecr :latest tags before pushing as repos are immutable

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -616,6 +616,11 @@ jobs:
         with:
           registry: ${{ env.PROD_REGISTRY }}
 
+      - name: Remove existing latest tag from PROD ECR
+        run: |
+          echo "Removing existing latest tag from PROD ECR if it exists"
+          aws ecr batch-delete-image --repository-name ${{ matrix.repo }}/${{ matrix.project }} --image-ids imageTag=latest || true
+
       - name: Push image to PROD ECR
         run: |
           if [ "${{ matrix.project }}" == "vft" ]; then


### PR DESCRIPTION
## Description

Removes :latest tagged images in prod ecr prior to pushing new container images to avoid errors on the immutable repos

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
