### PR TITLE
fix: add prep github env to oidc subjects

### DIFF
--- a/infra/terraform/accounts/prod/main.tf
+++ b/infra/terraform/accounts/prod/main.tf
@@ -33,6 +33,7 @@ module "account" {
       "dvsa/vol-app:ref:refs/heads/main", # `.github/workflows/docker.yaml` & `.github/workflows/assets.yaml`.
       "dvsa/vol-app:ref:refs/heads/prerelease",
       "dvsa/vol-app:environment:account-prod",
+      "dvsa/vol-app:environment:prep",
       "dvsa/vol-app:pull_request", # `.github/workflows/deploy-account.yaml`.
     ],
     [


### PR DESCRIPTION
## Description

add "prep" github environment to oidc role subjects list

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
