### PR TITLE
fix: provide single SMTP mailer config for production envirohments

### DIFF
--- a/app/api/config/autoload/config.global.php
+++ b/app/api/config/autoload/config.global.php
@@ -277,7 +277,21 @@ return [
             'sts_regional_endpoints' => 'regional'
         ]
     ]),
-    'mail' => $isProductionAccount ? [] : [
+    'mail' => ($isProductionAccount && \Aws\Credentials\CredentialProvider::shouldUseEcs())
+    ? [
+        'type' => '\Laminas\Mail\Transport\Smtp',
+        'options' => [
+            'name' => '%olcs_email_host%',
+            'host' => '%olcs_email_host%',
+            'port' => '%olcs_email_port%',
+            'connection_config' => [
+                'username' => 'null',
+                'password' => 'null',
+                'port' => '%olcs_email_port%',
+            ],
+        ],
+    ]
+    : ($isProductionAccount ? [] : [
         'type' => \Dvsa\Olcs\Email\Transport\MultiTransport::class,
         'options' => [
             'transport' => [
@@ -285,7 +299,7 @@ return [
                 ['type' => \Dvsa\Olcs\Email\Transport\S3File::class, 'options' => ['bucket' => 'devapp-olcs-pri-olcs-autotest-s3', 'key' => '%domain%/email']],
             ]
         ],
-    ],
+    ]),
 
     'mailboxes' => [
         // IMAP connection to a the mailbox for reading inspection request emails


### PR DESCRIPTION
## Description

Configure ECS production environments mailer to speak directly to the configured SMTP server, removing reliance on local Postfix MTA being present on the API node.

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
