### PR TITLE
fix: amend target group logic to register with load balancer

### DIFF
--- a/infra/terraform/modules/service/ecs.tf
+++ b/infra/terraform/modules/service/ecs.tf
@@ -132,13 +132,13 @@ module "ecs_service" {
       memory_reservation = 100
     }
   }
-  load_balancer = var.services[each.key].listener_rule_enable ? {
+  load_balancer = {
     service = {
       target_group_arn = aws_lb_target_group.this[each.key].arn
       container_name   = each.key
       container_port   = 8080
     }
-  } : {}
+  }
 
   create_security_group = false
   security_group_ids    = var.services[each.key].security_group_ids


### PR DESCRIPTION
## Description

logic to register ECS service with target group regardless of listener_rule_enable boolean.

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
