### PR TITLE
fix: specify nginx client max body to match php upload limit

### DIFF
--- a/infra/docker/api/api.conf
+++ b/infra/docker/api/api.conf
@@ -9,6 +9,9 @@ server {
   listen [::]:8080;
 
   server_name _;
+  
+  # Set maximum allowed size for client request body to match PHP limits
+  client_max_body_size 180M;
 
   root /var/www/html/public;
 

--- a/infra/docker/internal/internal.conf
+++ b/infra/docker/internal/internal.conf
@@ -34,6 +34,9 @@ server {
   listen [::]:8080;
 
   server_name _;
+  
+  # Set maximum allowed size for client request body to match PHP limits
+  client_max_body_size 180M;
 
   root /var/www/html/public;
 

--- a/infra/docker/selfserve/selfserve.conf
+++ b/infra/docker/selfserve/selfserve.conf
@@ -34,6 +34,9 @@ server {
   listen [::]:8080;
 
   server_name _;
+  
+  # Set maximum allowed size for client request body to match PHP limits
+  client_max_body_size 180M;
 
   root /var/www/html/public;
 


### PR DESCRIPTION
## Description

Sets containers ngnix instances max client body size to match PHPs max upload size limit.

Related issue: [VOL-6354](https://dvsa.atlassian.net/browse/VOL-6354)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-6354]: https://dvsa.atlassian.net/browse/VOL-6354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ