### PR TITLE
fix: allow sameorigin frame embeds to fix Split Screen functionality

### DIFF
--- a/infra/docker/internal/internal.conf
+++ b/infra/docker/internal/internal.conf
@@ -26,7 +26,7 @@ map $sent_http_content_type $referrer_policy {
 # Add X-Frame-Options for HTML documents.
 # h5bp/security/x-frame-options.conf
 map $sent_http_content_type $x_frame_options {
-  ~*text/html DENY;
+  ~*text/html SAMEORIGIN;
 }
 
 server {
@@ -34,7 +34,7 @@ server {
   listen [::]:8080;
 
   server_name _;
-  
+
   # Set maximum allowed size for client request body to match PHP limits
   client_max_body_size 180M;
 


### PR DESCRIPTION
## Description

Update internal nginx config to allow split screen embed functionality from SAMEORIGIN

Related issue: [VOL-6356](https://dvsa.atlassian.net/browse/VOL-6356)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-6356]: https://dvsa.atlassian.net/browse/VOL-6356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ