### PR TITLE
fix: specify necessary permission for standalone dispatch

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -34,6 +34,10 @@ on:
         default: true
         required: false
 
+permissions:
+  contents: read
+  id-token: write
+
 concurrency:
   group: assets-${{ inputs.account }}-${{ inputs.branch || 'version' }}
 


### PR DESCRIPTION
## Description

Specify necessary permissions for standalone assets push

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
