### PR TITLE
feat: use lineName instead of ServiceCode to populate VOL serviceNo

### DIFF
--- a/app/api/module/Api/src/Service/Ebsr/Mapping/TransExchangeXmlFactory.php
+++ b/app/api/module/Api/src/Service/Ebsr/Mapping/TransExchangeXmlFactory.php
@@ -87,8 +87,7 @@ class TransExchangeXmlFactory implements FactoryInterface
             'OperatingPeriod' => new Recursion($operatingPeriod),
             'StandardService' => new Recursion($standardService),
             'Description' => new NodeValue('otherDetails'),
-            'ServiceCode' => new NodeValue('serviceNo'),
-            'Lines' => new Recursion('Line', new Recursion('LineName', new MultiNodeValue('otherServiceNumbers'))),
+            'Lines' => new Recursion('Line', new Recursion('LineName', new NodeValue('serviceNo'))),
             'StopRequirements' => new Recursion($stopRequirements),
             'ServiceClassification' => new Recursion($serviceClassification),
             'SchematicMap' => new NodeValue('map')

--- a/app/api/module/Api/src/Service/Ebsr/RulesValidator/ServiceNo.php
+++ b/app/api/module/Api/src/Service/Ebsr/RulesValidator/ServiceNo.php
@@ -15,7 +15,7 @@ class ServiceNo extends AbstractValidator
      * @var array
      */
     protected $messageTemplates = [
-        self::RULES_ERROR => 'Unable to find a main service number, XML field "ServiceCode" must not be empty'
+        self::RULES_ERROR => 'Unable to find a main service number, XML field "LineName" must not be empty'
     ];
 
     /**


### PR DESCRIPTION
## Description

Change xml field mapping for VOL Service No for uploaded EBSR xml files

Related issue: [VOL-6127](https://dvsa.atlassian.net/browse/VOL-6127)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
