### PR TITLE
fix: remove reference to the old update command for vehicles declarations

### DIFF
--- a/app/api/module/Api/config/validation-map/side-effects.config.php
+++ b/app/api/module/Api/config/validation-map/side-effects.config.php
@@ -123,7 +123,6 @@ return [
     AppCompCommandHandler\UpdatePsvSmallConditionsStatus::class                       => IsSideEffect::class,
     AppCompCommandHandler\UpdateUndertakingsStatus::class                             => IsSideEffect::class,
     AppCompCommandHandler\UpdateConditionsUndertakingsStatus::class                   => IsSideEffect::class,
-    AppCompCommandHandler\UpdateVehiclesDeclarationsStatus::class                     => IsSideEffect::class,
     AppCompCommandHandler\UpdateVehiclesPsvStatus::class                              => IsSideEffect::class,
     AppCompCommandHandler\UpdateTransportManagersStatus::class                        => IsSideEffect::class,
     AppCompCommandHandler\UpdateTaxiPhvStatus::class                                  => IsSideEffect::class,

--- a/app/api/module/Api/src/Domain/CommandHandler/Application/UpdateApplicationCompletion.php
+++ b/app/api/module/Api/src/Domain/CommandHandler/Application/UpdateApplicationCompletion.php
@@ -51,7 +51,6 @@ final class UpdateApplicationCompletion extends AbstractCommandHandler implement
         'transportManagers',
         'typeOfLicence',
         'undertakings',
-        'vehiclesDeclarations',
         'vehiclesPsv',
         'vehiclesSize',
         'psvOperateSmall',


### PR DESCRIPTION
Related issue: [VOL-5882](https://dvsa.atlassian.net/browse/VOL-5882)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-5882]: https://dvsa.atlassian.net/browse/VOL-5882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ