### PR TITLE
fix: psv variations no longer show steps required for only restricted licences VOL-6504

### DIFF
--- a/app/api/module/Api/src/Domain/CommandHandler/Application/UpdateVariationCompletion.php
+++ b/app/api/module/Api/src/Domain/CommandHandler/Application/UpdateVariationCompletion.php
@@ -667,7 +667,7 @@ class UpdateVariationCompletion extends AbstractCommandHandler implements
                     'psv_operate_large',
                     'psv_documentary_evidence_small',
                 ];
-            } elseif($this->application->isPsvBothNotOperatingSmallPsvAsPartOfLarge()) {
+            } elseif ($this->application->isPsvBothNotOperatingSmallPsvAsPartOfLarge()) {
                 $relatedSections = [
                     'psv_operate_small',
                     'psv_small_conditions',
@@ -700,12 +700,17 @@ class UpdateVariationCompletion extends AbstractCommandHandler implements
 
         //restricted licences have extra sections - in theory this doesn't matter for variations, but included to future-proof
         if (!$this->application->isRestricted()) {
-            unset (
-                $relatedSections['psv_main_occupation_undertakings'],
-                $relatedSections['psv_documentary_evidence_large'],
-                $ignoredSections['psv_main_occupation_undertakings'],
-                $ignoredSections['psv_documentary_evidence_large'],
-            );
+            $restrictedOnlySections = [
+                'psv_main_occupation_undertakings',
+                'psv_documentary_evidence_large',
+            ];
+
+            foreach ($restrictedOnlySections as $restrictedOnlySection) {
+                if (($key = array_search($restrictedOnlySection, $relatedSections, true)) !== false) {
+                    unset($relatedSections[$key]);
+                    $ignoredSections[] = $restrictedOnlySection;
+                }
+            }
         }
 
         foreach ($relatedSections as $section) {


### PR DESCRIPTION
Related issue: [VOL-6504](https://dvsa.atlassian.net/browse/VOL-6504)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-6504]: https://dvsa.atlassian.net/browse/VOL-6504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ