### PR TITLE
fix: correct allocate permits queue job include type

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -507,7 +507,7 @@ module "service" {
       },
       {
         name     = "process-queue-irhp-allocate",
-        commands = ["queue:process-queue", "--type", "que_typ_run_ecmt_scoring"],
+        commands = ["queue:process-queue", "--type", "que_typ_irhp_permits_allocate"],
         timeout  = 90,
         schedule = "cron(0/2 8-17 * * ? *)",
       },

--- a/infra/terraform/environments/int/main.tf
+++ b/infra/terraform/environments/int/main.tf
@@ -506,7 +506,7 @@ module "service" {
       },
       {
         name     = "process-queue-irhp-allocate",
-        commands = ["queue:process-queue", "--type", "que_typ_run_ecmt_scoring"],
+        commands = ["queue:process-queue", "--type", "que_typ_irhp_permits_allocate"],
         timeout  = 90,
         schedule = "cron(0/2 8-17 * * ? *)",
       },

--- a/infra/terraform/environments/prep/main.tf
+++ b/infra/terraform/environments/prep/main.tf
@@ -490,7 +490,7 @@ module "service" {
       },
       {
         name     = "process-queue-irhp-allocate",
-        commands = ["queue:process-queue", "--type", "que_typ_run_ecmt_scoring"],
+        commands = ["queue:process-queue", "--type", "que_typ_irhp_permits_allocate"],
         timeout  = 90,
         schedule = "cron(0/2 8-17 * * ? *)",
       },

--- a/infra/terraform/environments/prod/main.tf
+++ b/infra/terraform/environments/prod/main.tf
@@ -491,7 +491,7 @@ module "service" {
       },
       {
         name     = "process-queue-irhp-allocate",
-        commands = ["queue:process-queue", "--type", "que_typ_run_ecmt_scoring"],
+        commands = ["queue:process-queue", "--type", "que_typ_irhp_permits_allocate"],
         timeout  = 90,
         #schedule = "cron(0/2 8-17 * * ? *)",
       },


### PR DESCRIPTION
## Description

Fix incorrect mapping of queue job name and queue job include type. Was running scoring job not allocation job.

Related issue: [VOL-6540](https://dvsa.atlassian.net/browse/VOL-6540)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?


[VOL-6540]: https://dvsa.atlassian.net/browse/VOL-6540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ