### PR TITLE
feat: vol-6098 remove usage of laminas-json replace with native php

### DIFF
--- a/app/api/composer.json
+++ b/app/api/composer.json
@@ -44,7 +44,6 @@
     "laminas/laminas-http": "^2.16",
     "laminas/laminas-view": "^2.23",
     "laminas/laminas-i18n": "^2.17",
-    "laminas/laminas-serializer": "^2.13",
     "laminas/laminas-eventmanager": "^3.5",
     "psr/container": "^1.1|^2",
     "laminas/laminas-cli": "^1.5",

--- a/app/api/module/Api/src/Domain/CommandHandler/DvsaReports/GetRedirect.php
+++ b/app/api/module/Api/src/Domain/CommandHandler/DvsaReports/GetRedirect.php
@@ -12,7 +12,6 @@ use Dvsa\Olcs\Api\Domain\Exception\RuntimeException;
 use Dvsa\Olcs\Transfer\Command\CommandInterface;
 use Laminas\Http\Client;
 use Laminas\Http\Client\Adapter\Curl;
-use Laminas\Json\Json;
 use Olcs\Logging\Log\Logger;
 
 /**
@@ -41,7 +40,7 @@ class GetRedirect extends AbstractCommandHandler implements AuthAwareInterface, 
     public function handleCommand(CommandInterface $command)
     {
         $currentUser = $this->getCurrentUser();
-        $postDataJson = Json::encode([
+        $postDataJson = json_encode([
             'operators' => $command->getOlNumbers(),
             'operator_name' => $currentUser->getRelatedOrganisationName(),
             'refresh_token' => $command->getRefreshToken()

--- a/app/api/module/Api/src/Domain/CommandHandler/Email/SendErruErrors.php
+++ b/app/api/module/Api/src/Domain/CommandHandler/Email/SendErruErrors.php
@@ -2,18 +2,16 @@
 
 namespace Dvsa\Olcs\Api\Domain\CommandHandler\Email;
 
-use Doctrine\ORM\Query;
-use Dvsa\Olcs\Api\Domain\Command\Result;
-use Dvsa\Olcs\Transfer\Command\CommandInterface;
-use Dvsa\Olcs\Api\Domain\CommandHandler\AbstractCommandHandler;
-use Dvsa\Olcs\Api\Domain\Repository\ErruRequestFailure as ErruRequestFailureRepo;
-use Dvsa\Olcs\Api\Entity\Si\ErruRequestFailure as ErruRequestFailureEntity;
-use Dvsa\Olcs\Api\Entity\Doc\Document as DocumentEntity;
 use Dvsa\Olcs\Api\Domain\Command\Email\SendErruErrors as SendErruErrorsCmd;
+use Dvsa\Olcs\Api\Domain\Command\Result;
+use Dvsa\Olcs\Api\Domain\CommandHandler\AbstractCommandHandler;
 use Dvsa\Olcs\Api\Domain\EmailAwareInterface;
 use Dvsa\Olcs\Api\Domain\EmailAwareTrait;
+use Dvsa\Olcs\Api\Domain\Repository\ErruRequestFailure as ErruRequestFailureRepo;
+use Dvsa\Olcs\Api\Entity\Doc\Document as DocumentEntity;
+use Dvsa\Olcs\Api\Entity\Si\ErruRequestFailure as ErruRequestFailureEntity;
 use Dvsa\Olcs\Email\Data\Message;
-use Laminas\Json\Json;
+use Dvsa\Olcs\Transfer\Command\CommandInterface;
 
 /**
  * Send Erru Email
@@ -59,14 +57,14 @@ class SendErruErrors extends AbstractCommandHandler implements EmailAwareInterfa
         $erruFailure = $repo->fetchUsingId($command);
 
         //we will always have errors saved
-        $errors = Json::decode($erruFailure->getErrors(), Json::TYPE_ARRAY);
+        $errors = json_decode($erruFailure->getErrors(), true);
 
         //we won't always have input data saved e.g. when the XML file couldn't be parsed
         $jsonInputData = $erruFailure->getInput();
         $input = [];
 
         if (!empty($jsonInputData)) {
-            $input = Json::decode($jsonInputData, Json::TYPE_ARRAY);
+            $input = json_decode($jsonInputData, true);
         }
 
         //get the email message, and assign addresses

--- a/app/api/module/Api/src/Domain/QueueAwareTrait.php
+++ b/app/api/module/Api/src/Domain/QueueAwareTrait.php
@@ -60,7 +60,7 @@ trait QueueAwareTrait
                 'entityId' => $entityId,
                 'type' => $type,
                 'status' => Queue::STATUS_QUEUED,
-                'options' => json_encode($options, JSON_THROW_ON_ERROR),
+                'options' => json_encode($options),
                 'processAfterDate' => $processAfterDate
             ]
         );

--- a/app/api/module/Api/src/Domain/QueueAwareTrait.php
+++ b/app/api/module/Api/src/Domain/QueueAwareTrait.php
@@ -4,7 +4,6 @@ namespace Dvsa\Olcs\Api\Domain;
 
 use Dvsa\Olcs\Api\Domain\Command\Queue\Create as CreateQueue;
 use Dvsa\Olcs\Api\Entity\Queue\Queue;
-use Laminas\Json\Json as LaminasJson;
 
 /**
  * Queue Aware
@@ -61,7 +60,7 @@ trait QueueAwareTrait
                 'entityId' => $entityId,
                 'type' => $type,
                 'status' => Queue::STATUS_QUEUED,
-                'options' => LaminasJson::encode($options),
+                'options' => json_encode($options, JSON_THROW_ON_ERROR),
                 'processAfterDate' => $processAfterDate
             ]
         );

--- a/app/api/module/Api/src/Entity/Ebsr/EbsrSubmission.php
+++ b/app/api/module/Api/src/Entity/Ebsr/EbsrSubmission.php
@@ -213,6 +213,9 @@ class EbsrSubmission extends AbstractEbsrSubmission implements OrganisationProvi
      */
     public function getDecodedSubmissionResult()
     {
+        //This catch will not work because json_decode() without JSON_THROW_ON_ERROR won’t ever throw.
+        //As this is old code and changing too much could cause unforeseen issues,
+        //we leave it as is. All were trying to do is move away laminas-json to native PHP JSON function.
         try {
             $errorInfo = json_decode($this->ebsrSubmissionResult, true);
         } catch (JsonException) {

--- a/app/api/module/Api/src/Entity/Ebsr/EbsrSubmission.php
+++ b/app/api/module/Api/src/Entity/Ebsr/EbsrSubmission.php
@@ -8,7 +8,6 @@ use Dvsa\Olcs\Api\Entity\System\RefData;
 use Dvsa\Olcs\Api\Entity\Doc\Document;
 use Dvsa\Olcs\Api\Entity\Organisation\Organisation;
 use Dvsa\Olcs\Api\Entity\OrganisationProviderInterface;
-use Laminas\Json\Json as LaminasJson;
 use Laminas\Json\Exception\RuntimeException as JsonException;
 
 /**
@@ -129,7 +128,7 @@ class EbsrSubmission extends AbstractEbsrSubmission implements OrganisationProvi
     public function finishValidating(RefData $ebsrSubmissionStatus, array $ebsrSubmissionResult): void
     {
         $this->ebsrSubmissionStatus = $ebsrSubmissionStatus;
-        $this->ebsrSubmissionResult = LaminasJson::encode($ebsrSubmissionResult);
+        $this->ebsrSubmissionResult = json_encode($ebsrSubmissionResult, JSON_THROW_ON_ERROR);
         $this->validationEnd = new \DateTime();
 
         //if the submission hasn't failed (so far - this isn't yet a success) then also populate processStart timestamp
@@ -215,7 +214,7 @@ class EbsrSubmission extends AbstractEbsrSubmission implements OrganisationProvi
     public function getDecodedSubmissionResult()
     {
         try {
-            $errorInfo = LaminasJson::decode($this->ebsrSubmissionResult, LaminasJson::TYPE_ARRAY);
+            $errorInfo = json_decode($this->ebsrSubmissionResult, true, 512, JSON_THROW_ON_ERROR);
         } catch (JsonException) {
             $errorInfo = [];
         }

--- a/app/api/module/Api/src/Entity/Ebsr/EbsrSubmission.php
+++ b/app/api/module/Api/src/Entity/Ebsr/EbsrSubmission.php
@@ -128,7 +128,7 @@ class EbsrSubmission extends AbstractEbsrSubmission implements OrganisationProvi
     public function finishValidating(RefData $ebsrSubmissionStatus, array $ebsrSubmissionResult): void
     {
         $this->ebsrSubmissionStatus = $ebsrSubmissionStatus;
-        $this->ebsrSubmissionResult = json_encode($ebsrSubmissionResult, JSON_THROW_ON_ERROR);
+        $this->ebsrSubmissionResult = json_encode($ebsrSubmissionResult);
         $this->validationEnd = new \DateTime();
 
         //if the submission hasn't failed (so far - this isn't yet a success) then also populate processStart timestamp
@@ -214,7 +214,7 @@ class EbsrSubmission extends AbstractEbsrSubmission implements OrganisationProvi
     public function getDecodedSubmissionResult()
     {
         try {
-            $errorInfo = json_decode($this->ebsrSubmissionResult, true, 512, JSON_THROW_ON_ERROR);
+            $errorInfo = json_decode($this->ebsrSubmissionResult, true);
         } catch (JsonException) {
             $errorInfo = [];
         }

--- a/app/api/module/Api/src/Entity/Si/ErruRequestFailure.php
+++ b/app/api/module/Api/src/Entity/Si/ErruRequestFailure.php
@@ -4,7 +4,6 @@ namespace Dvsa\Olcs\Api\Entity\Si;
 
 use Doctrine\ORM\Mapping as ORM;
 use Dvsa\Olcs\Api\Entity\Doc\Document;
-use Laminas\Serializer\Adapter\Json;
 
 /**
  * ErruRequestFailure Entity
@@ -31,13 +30,12 @@ class ErruRequestFailure extends AbstractErruRequestFailure
      */
     public function __construct(Document $document, array $errors, $input)
     {
-        $json = new Json();
 
         $this->document = $document;
-        $this->errors = $json->serialize($errors);
+        $this->errors = json_encode($errors);
 
         if (is_array($input)) {
-            $this->input = $json->serialize($input);
+            $this->input = json_encode($input);
         }
     }
 }

--- a/app/api/module/Api/src/Service/Nysiis/NysiisRestClient.php
+++ b/app/api/module/Api/src/Service/Nysiis/NysiisRestClient.php
@@ -47,7 +47,7 @@ class NysiisRestClient
 
         $this->restClient->setEncType('application/json; charset=UTF-8');
         $this->restClient->getRequest()->setMethod(HttpRequest::METHOD_POST);
-        $this->restClient->getRequest()->setContent(json_encode($inputData, JSON_THROW_ON_ERROR));
+        $this->restClient->getRequest()->setContent(json_encode($inputData));
 
         try {
             $response = $this->restClient->send();

--- a/app/api/module/Api/src/Service/Nysiis/NysiisRestClient.php
+++ b/app/api/module/Api/src/Service/Nysiis/NysiisRestClient.php
@@ -6,7 +6,6 @@ use Laminas\Http\Client as RestClient;
 use Laminas\Http\Request as HttpRequest;
 use Laminas\Http\Response as HttpResponse;
 use Dvsa\Olcs\Api\Domain\Exception\NysiisException;
-use Laminas\Json\Json as LaminasJson;
 use Olcs\Logging\Log\Logger;
 
 /**
@@ -48,14 +47,14 @@ class NysiisRestClient
 
         $this->restClient->setEncType('application/json; charset=UTF-8');
         $this->restClient->getRequest()->setMethod(HttpRequest::METHOD_POST);
-        $this->restClient->getRequest()->setContent(LaminasJson::encode($inputData));
+        $this->restClient->getRequest()->setContent(json_encode($inputData, JSON_THROW_ON_ERROR));
 
         try {
             $response = $this->restClient->send();
             Logger::info('Nysiis response', ['data' => $response]);
 
             if ($response instanceof HttpResponse && $response->isSuccess()) {
-                return LaminasJson::decode($this->cleanJson($response->getContent()), LaminasJson::TYPE_ARRAY);
+                return json_decode($this->cleanJson($response->getContent()), true, 512, JSON_THROW_ON_ERROR);
             }
         } catch (\Exception $e) {
             Logger::info('Nysiis exception object', ['data' => $e->__toString()]);

--- a/app/api/module/Cli/src/Service/Queue/Consumer/CommandConsumer.php
+++ b/app/api/module/Cli/src/Service/Queue/Consumer/CommandConsumer.php
@@ -7,7 +7,6 @@
 namespace Dvsa\Olcs\Cli\Service\Queue\Consumer;
 
 use Dvsa\Olcs\Api\Entity\Queue\Queue as QueueEntity;
-use Laminas\Serializer\Adapter\Json as LaminasJson;
 
 /**
  * Command Consumer
@@ -20,8 +19,7 @@ class CommandConsumer extends AbstractCommandConsumer
      */
     protected function getCommandName(QueueEntity $item)
     {
-        $json = new LaminasJson();
-        return $json->unserialize($item->getOptions())['commandClass'];
+        return json_decode($item->getOptions(), true)['commandClass'];
     }
 
     /**
@@ -30,7 +28,6 @@ class CommandConsumer extends AbstractCommandConsumer
      */
     public function getCommandData(QueueEntity $item)
     {
-        $json = new LaminasJson();
-        return $json->unserialize($item->getOptions())['commandData'];
+        return json_decode($item->getOptions(), true)['commandData'];
     }
 }

--- a/app/api/module/Cli/src/Service/Queue/Consumer/Ebsr/ProcessPack.php
+++ b/app/api/module/Cli/src/Service/Queue/Consumer/Ebsr/ProcessPack.php
@@ -2,7 +2,6 @@
 
 namespace Dvsa\Olcs\Cli\Service\Queue\Consumer\Ebsr;
 
-use Laminas\Serializer\Adapter\Json as LaminasJson;
 use Dvsa\Olcs\Cli\Service\Queue\Consumer\AbstractCommandConsumer;
 use Dvsa\Olcs\Api\Domain\Command\Bus\Ebsr\ProcessPack as Cmd;
 use Dvsa\Olcs\Api\Entity\Queue\Queue as QueueEntity;
@@ -20,7 +19,6 @@ class ProcessPack extends AbstractCommandConsumer
      */
     public function getCommandData(QueueEntity $item)
     {
-        $json = new LaminasJson();
-        return $json->unserialize($item->getOptions());
+        return json_decode($item->getOptions(), true);
     }
 }

--- a/app/api/module/Cli/src/Service/Queue/Consumer/Ebsr/ProcessPackFailed.php
+++ b/app/api/module/Cli/src/Service/Queue/Consumer/Ebsr/ProcessPackFailed.php
@@ -2,7 +2,6 @@
 
 namespace Dvsa\Olcs\Cli\Service\Queue\Consumer\Ebsr;
 
-use Laminas\Serializer\Adapter\Json as LaminasJson;
 use Dvsa\Olcs\Cli\Service\Queue\Consumer\AbstractCommandConsumer;
 use Dvsa\Olcs\Api\Domain\Command\Bus\Ebsr\ProcessPackFailed as Cmd;
 use Dvsa\Olcs\Api\Entity\Queue\Queue as QueueEntity;
@@ -14,13 +13,8 @@ class ProcessPackFailed extends AbstractCommandConsumer
 {
     protected $commandName = Cmd::class;
 
-    /**
-     * @param QueueEntity $item
-     * @return array
-     */
-    public function getCommandData(QueueEntity $item)
+    public function getCommandData(QueueEntity $item): array
     {
-        $json = new LaminasJson();
-        return $json->unserialize($item->getOptions());
+        return json_decode($item->getOptions(), true);
     }
 }

--- a/app/api/module/Cli/src/Service/Queue/Consumer/Ebsr/RequestMap.php
+++ b/app/api/module/Cli/src/Service/Queue/Consumer/Ebsr/RequestMap.php
@@ -11,7 +11,6 @@ use Dvsa\Olcs\Api\Domain\Command\Task\CreateTask as CreateTaskCmd;
 use Dvsa\Olcs\Api\Entity\Queue\Queue as QueueEntity;
 use Dvsa\Olcs\Api\Entity\Task\Task as TaskEntity;
 use Dvsa\Olcs\Cli\Service\Queue\Consumer\AbstractCommandConsumer;
-use Laminas\Serializer\Adapter\Json as LaminasJson;
 
 /**
  * Request Map
@@ -34,8 +33,10 @@ class RequestMap extends AbstractCommandConsumer
      */
     public function getCommandData(QueueEntity $item)
     {
-        $json = new LaminasJson();
-        return array_merge($json->unserialize($item->getOptions()), ['user' => $item->getCreatedBy()->getId()]);
+        return array_merge(
+            json_decode($item->getOptions(), true),
+            ['user' => $item->getCreatedBy()->getId()]
+        );
     }
 
     /**

--- a/app/api/module/Cli/src/Service/Queue/Consumer/Tm/UpdateTmNysiisName.php
+++ b/app/api/module/Cli/src/Service/Queue/Consumer/Tm/UpdateTmNysiisName.php
@@ -9,7 +9,6 @@ namespace Dvsa\Olcs\Cli\Service\Queue\Consumer\Tm;
 use Dvsa\Olcs\Cli\Service\Queue\Consumer\AbstractCommandConsumer;
 use Dvsa\Olcs\Api\Entity\Queue\Queue as QueueEntity;
 use Dvsa\Olcs\Api\Domain\Command\Tm\UpdateNysiisName as Cmd;
-use Laminas\Serializer\Adapter\Json as LaminasJson;
 
 /**
  * Update TM name with Nysiis data
@@ -28,19 +27,14 @@ class UpdateTmNysiisName extends AbstractCommandConsumer
 
     /**
      * gets command data
-     *
-     * @param QueueEntity $item queue item
-     *
-     * @return array
      */
     public function getCommandData(QueueEntity $item)
     {
-        $json = new LaminasJson();
         return array_merge(
+            json_decode($item->getOptions(), true),
             [
                 'id' => $item->getEntityId()
-            ],
-            $json->unserialize($item->getOptions())
+            ]
         );
     }
 }

--- a/app/api/test/module/Api/src/Domain/CommandHandler/AbstractCommandHandlerTestCase.php
+++ b/app/api/test/module/Api/src/Domain/CommandHandler/AbstractCommandHandlerTestCase.php
@@ -32,7 +32,6 @@ use Dvsa\OlcsTest\Api\Domain\Repository\ValidateMockRepoTypeTrait;
 use Psr\Container\ContainerInterface;
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
-use Laminas\Json\Json as LaminasJson;
 use LmcRbacMvc\Service\AuthorizationService;
 use Olcs\Logging\Log\Logger;
 
@@ -261,7 +260,7 @@ abstract class AbstractCommandHandlerTestCase extends MockeryTestCase
             'entityId' => $entityId,
             'type' => $queueType,
             'status' => QueueEntity::STATUS_QUEUED,
-            'options' => LaminasJson::encode($options),
+            'options' => json_encode($options, JSON_THROW_ON_ERROR),
             'processAfterDate' => $processAfterDate
         ];
 
@@ -293,7 +292,7 @@ abstract class AbstractCommandHandlerTestCase extends MockeryTestCase
             'entityId' => $entityId,
             'type' => QueueEntity::TYPE_EMAIL,
             'status' => QueueEntity::STATUS_QUEUED,
-            'options' => LaminasJson::encode($emailOptions),
+            'options' => json_encode($emailOptions, JSON_THROW_ON_ERROR),
             'processAfterDate' => $processAfterDate
         ];
 

--- a/app/api/test/module/Api/src/Domain/CommandHandler/Email/SendErruErrorsTest.php
+++ b/app/api/test/module/Api/src/Domain/CommandHandler/Email/SendErruErrorsTest.php
@@ -2,20 +2,18 @@
 
 namespace Dvsa\OlcsTest\Api\Domain\CommandHandler\Email;
 
+use Dvsa\Olcs\Api\Domain\Command\Email\SendErruErrors as SendErruErrorsCmd;
 use Dvsa\Olcs\Api\Domain\Command\Result;
+use Dvsa\Olcs\Api\Domain\CommandHandler\Email\SendErruErrors;
+use Dvsa\Olcs\Api\Domain\Repository\ErruRequestFailure as ErruRequestFailureRepo;
 use Dvsa\Olcs\Api\Entity\Doc\Document;
 use Dvsa\Olcs\Api\Entity\Si\ErruRequestFailure;
-use Dvsa\Olcs\Email\Domain\Command\SendEmail;
-use Dvsa\Olcs\Api\Domain\Repository\ErruRequestFailure as ErruRequestFailureRepo;
-use Dvsa\OlcsTest\Api\Domain\CommandHandler\AbstractCommandHandlerTestCase;
-use Dvsa\Olcs\Email\Service\TemplateRenderer;
-use Mockery as m;
-use Doctrine\ORM\Query;
-use Dvsa\Olcs\Transfer\Command\CommandInterface;
-use Dvsa\Olcs\Api\Domain\CommandHandler\Email\SendErruErrors;
-use Dvsa\Olcs\Api\Domain\Command\Email\SendErruErrors as SendErruErrorsCmd;
-use Laminas\Json\Json;
 use Dvsa\Olcs\Email\Data\Message;
+use Dvsa\Olcs\Email\Domain\Command\SendEmail;
+use Dvsa\Olcs\Email\Service\TemplateRenderer;
+use Dvsa\Olcs\Transfer\Command\CommandInterface;
+use Dvsa\OlcsTest\Api\Domain\CommandHandler\AbstractCommandHandlerTestCase;
+use Mockery as m;
 
 /**
  * SendErruErrorsTest
@@ -67,10 +65,10 @@ class SendErruErrorsTest extends AbstractCommandHandlerTestCase
             'originatingAuthority' => $originatingAuthority,
             'sentAt' => $sentAt,
         ];
-        $inputJson = Json::encode($inputData);
+        $inputJson = json_encode($inputData);
 
         $errors = ['error 1', 'error 2'];
-        $errorJson = Json::encode($errors);
+        $errorJson = json_encode($errors);
 
         $command = SendErruErrorsCmd::create(['id' => $requestFailureId]);
 
@@ -131,7 +129,7 @@ class SendErruErrorsTest extends AbstractCommandHandlerTestCase
         $documentId = 5678;
 
         $errors = ['error 1', 'error 2'];
-        $errorJson = Json::encode($errors);
+        $errorJson = json_encode($errors);
 
         $command = SendErruErrorsCmd::create(['id' => $requestFailureId]);
 

--- a/app/api/test/module/Api/src/Domain/CommandHandler/Report/UploadTest.php
+++ b/app/api/test/module/Api/src/Domain/CommandHandler/Report/UploadTest.php
@@ -20,7 +20,6 @@ use Dvsa\Olcs\Transfer\Command\Report\Upload as UploadCmd;
 use Dvsa\OlcsTest\Api\Domain\CommandHandler\AbstractCommandHandlerTestCase;
 use Mockery as m;
 use org\bovigo\vfs\vfsStream;
-use Laminas\Json\Json as LaminasJson;
 use LmcRbacMvc\Service\AuthorizationService;
 
 /**
@@ -115,12 +114,10 @@ class UploadTest extends AbstractCommandHandlerTestCase
                 'entityId' => null,
                 'type' => Queue::TYPE_COMM_LIC_BULK_REPRINT,
                 'status' => Queue::STATUS_QUEUED,
-                'options' => LaminasJson::encode(
-                    [
-                        'identifier' => self::IDENTIFIER,
-                        'user' => self::USER_ID,
-                    ]
-                ),
+                'options' => json_encode([
+                    'identifier' => self::IDENTIFIER,
+                    'user' => self::USER_ID,
+                ], JSON_THROW_ON_ERROR),
                 'processAfterDate' => null,
             ],
             (new Result())->addMessage('Queue item created')
@@ -192,13 +189,11 @@ class UploadTest extends AbstractCommandHandlerTestCase
                 'entityId' => null,
                 'type' => Queue::TYPE_EMAIL_BULK_UPLOAD,
                 'status' => Queue::STATUS_QUEUED,
-                'options' => LaminasJson::encode(
-                    [
-                        'identifier' => self::IDENTIFIER,
-                        'user' => self::USER_ID,
-                        'templateName' => $data['name']
-                    ]
-                ),
+                'options' => json_encode([
+                    'identifier' => self::IDENTIFIER,
+                    'user' => self::USER_ID,
+                    'templateName' => $data['name']
+                ], JSON_THROW_ON_ERROR),
                 'processAfterDate' => null,
             ],
             (new Result())->addMessage('Queue item created')
@@ -270,13 +265,11 @@ class UploadTest extends AbstractCommandHandlerTestCase
                 'entityId' => null,
                 'type' => Queue::TYPE_LETTER_BULK_UPLOAD,
                 'status' => Queue::STATUS_QUEUED,
-                'options' => LaminasJson::encode(
-                    [
-                        'identifier' => self::IDENTIFIER,
-                        'user' => self::USER_ID,
-                        'templateSlug' => $data['templateSlug']
-                    ]
-                ),
+                'options' => json_encode([
+                    'identifier' => self::IDENTIFIER,
+                    'user' => self::USER_ID,
+                    'templateSlug' => $data['templateSlug']
+                ], JSON_THROW_ON_ERROR),
                 'processAfterDate' => null,
             ],
             (new Result())->addMessage('Queue item created')
@@ -338,11 +331,9 @@ class UploadTest extends AbstractCommandHandlerTestCase
                 'entityId' => null,
                 'type' => Queue::TYPE_POST_SCORING_EMAIL,
                 'status' => Queue::STATUS_QUEUED,
-                'options' => LaminasJson::encode(
-                    [
-                        'identifier' => self::IDENTIFIER,
-                    ]
-                ),
+                'options' => json_encode([
+                    'identifier' => self::IDENTIFIER,
+                ], JSON_THROW_ON_ERROR),
                 'processAfterDate' => null,
             ],
             (new Result())->addMessage('Queue item created')

--- a/app/api/test/module/Api/src/Entity/Ebsr/EbsrSubmissionEntityTest.php
+++ b/app/api/test/module/Api/src/Entity/Ebsr/EbsrSubmissionEntityTest.php
@@ -131,7 +131,7 @@ class EbsrSubmissionEntityTest extends EntityTester
         $ebsrSubmissionStatus->setId(Entity::FAILED_STATUS);
 
         $ebsrSubmissionResult = ['submission result'];
-        $encodedSubmissionResult = json_encode($ebsrSubmissionResult, JSON_THROW_ON_ERROR);
+        $encodedSubmissionResult = json_encode($ebsrSubmissionResult);
 
         $entity = $this->instantiate(Entity::class);
 
@@ -150,7 +150,7 @@ class EbsrSubmissionEntityTest extends EntityTester
     {
         $ebsrSubmissionStatus = m::mock(RefData::class)->makePartial();
         $ebsrSubmissionResult = ['submission result'];
-        $encodedSubmissionResult = json_encode($ebsrSubmissionResult, JSON_THROW_ON_ERROR);
+        $encodedSubmissionResult = json_encode($ebsrSubmissionResult);
 
         $entity = $this->instantiate(Entity::class);
 
@@ -366,7 +366,7 @@ class EbsrSubmissionEntityTest extends EntityTester
         $ebsrSubmissionStatus->shouldReceive('getId')->once()->andReturn(Entity::FAILED_STATUS);
 
         $entity->setEbsrSubmissionStatus($ebsrSubmissionStatus);
-        $entity->setEbsrSubmissionResult(json_encode($errors, JSON_THROW_ON_ERROR));
+        $entity->setEbsrSubmissionResult(json_encode($errors));
 
         $this->assertEquals($errorArray, $entity->getErrors());
     }

--- a/app/api/test/module/Api/src/Entity/Ebsr/EbsrSubmissionEntityTest.php
+++ b/app/api/test/module/Api/src/Entity/Ebsr/EbsrSubmissionEntityTest.php
@@ -8,7 +8,6 @@ use Dvsa\Olcs\Api\Entity\Organisation\Organisation as OrganisationEntity;
 use Dvsa\Olcs\Api\Entity\Doc\Document as DocumentEntity;
 use Dvsa\Olcs\Api\Entity\System\RefData;
 use Mockery as m;
-use Laminas\Json\Json as LaminasJson;
 
 /**
  * EbsrSubmission Entity Unit Tests
@@ -132,7 +131,7 @@ class EbsrSubmissionEntityTest extends EntityTester
         $ebsrSubmissionStatus->setId(Entity::FAILED_STATUS);
 
         $ebsrSubmissionResult = ['submission result'];
-        $encodedSubmissionResult = LaminasJson::encode($ebsrSubmissionResult);
+        $encodedSubmissionResult = json_encode($ebsrSubmissionResult, JSON_THROW_ON_ERROR);
 
         $entity = $this->instantiate(Entity::class);
 
@@ -151,7 +150,7 @@ class EbsrSubmissionEntityTest extends EntityTester
     {
         $ebsrSubmissionStatus = m::mock(RefData::class)->makePartial();
         $ebsrSubmissionResult = ['submission result'];
-        $encodedSubmissionResult = LaminasJson::encode($ebsrSubmissionResult);
+        $encodedSubmissionResult = json_encode($ebsrSubmissionResult, JSON_THROW_ON_ERROR);
 
         $entity = $this->instantiate(Entity::class);
 
@@ -367,7 +366,7 @@ class EbsrSubmissionEntityTest extends EntityTester
         $ebsrSubmissionStatus->shouldReceive('getId')->once()->andReturn(Entity::FAILED_STATUS);
 
         $entity->setEbsrSubmissionStatus($ebsrSubmissionStatus);
-        $entity->setEbsrSubmissionResult(LaminasJson::encode($errors));
+        $entity->setEbsrSubmissionResult(json_encode($errors, JSON_THROW_ON_ERROR));
 
         $this->assertEquals($errorArray, $entity->getErrors());
     }

--- a/app/api/test/module/Api/src/Entity/Si/ErruRequestFailureEntityTest.php
+++ b/app/api/test/module/Api/src/Entity/Si/ErruRequestFailureEntityTest.php
@@ -5,7 +5,6 @@ namespace Dvsa\OlcsTest\Api\Entity\Si;
 use Dvsa\OlcsTest\Api\Entity\Abstracts\EntityTester;
 use Dvsa\Olcs\Api\Entity\Si\ErruRequestFailure as Entity;
 use Dvsa\Olcs\Api\Entity\Doc\Document;
-use Laminas\Serializer\Adapter\Json;
 use Mockery as m;
 
 /**
@@ -29,13 +28,11 @@ class ErruRequestFailureEntityTest extends EntityTester
     {
         $document = m::mock(Document::class);
 
-        $json = new Json();
-
         $errors = ['foo' => 'bar'];
-        $errorsJson = $json->serialize($errors);
+        $errorsJson = json_encode($errors);
 
         $input = ['bar' => 'foo'];
-        $inputJson = $json->serialize($input);
+        $inputJson = json_encode($input);
 
         $entity = new Entity($document, $errors, $input);
 
@@ -51,10 +48,9 @@ class ErruRequestFailureEntityTest extends EntityTester
     {
         $document = m::mock(Document::class);
 
-        $json = new Json();
 
         $errors = ['foo' => 'bar'];
-        $errorsJson = $json->serialize($errors);
+        $errorsJson = json_encode($errors);
 
         $input = 'some string';
 

--- a/app/api/test/module/Cli/src/Service/Queue/Consumer/Ebsr/RequestMapTest.php
+++ b/app/api/test/module/Cli/src/Service/Queue/Consumer/Ebsr/RequestMapTest.php
@@ -13,7 +13,6 @@ use Dvsa\Olcs\Api\Entity\Task\Task as TaskEntity;
 use Dvsa\Olcs\Api\Entity\User\User;
 use Dvsa\Olcs\Cli\Service\Queue\Consumer\Ebsr\RequestMap;
 use Dvsa\OlcsTest\Cli\Service\Queue\Consumer\AbstractConsumerTestCase;
-use Laminas\Serializer\Adapter\Json as LaminasJson;
 
 /**
  * @covers \Dvsa\Olcs\Cli\Service\Queue\Consumer\Ebsr\RequestMap
@@ -52,8 +51,6 @@ class RequestMapTest extends AbstractConsumerTestCase
         $user = new User('pid', 'type');
         $user->setId($userId);
 
-        $json = new LaminasJson();
-
         $options = [
             'id' => $busRegId,
             'regNo' => $regNo,
@@ -63,7 +60,7 @@ class RequestMapTest extends AbstractConsumerTestCase
 
         $item = new QueueEntity();
         $item->setId($busRegId);
-        $item->setOptions($json->serialize($options));
+        $item->setOptions(json_encode($options));
         $item->setCreatedBy($user);
 
         $taskData = [

--- a/app/api/test/module/Cli/src/Service/Queue/Consumer/Email/SendTest.php
+++ b/app/api/test/module/Cli/src/Service/Queue/Consumer/Email/SendTest.php
@@ -11,7 +11,6 @@ use Dvsa\Olcs\Api\Entity\Queue\Queue as QueueEntity;
 use Dvsa\Olcs\Cli\Service\Queue\Consumer\Email\Send;
 use Dvsa\Olcs\Email\Exception\EmailNotSentException;
 use Dvsa\OlcsTest\Cli\Service\Queue\Consumer\AbstractConsumerTestCase;
-use Laminas\Serializer\Adapter\Json as LaminasJson;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 
 /**
@@ -27,8 +26,7 @@ class SendTest extends AbstractConsumerTestCase
 
     public function testProcessMessageSuccess()
     {
-        $json = new LaminasJson();
-        $options = $json->serialize(
+        $options = json_encode(
             [
                 'commandClass' => SampleEmail::class,
                 'commandData' => [
@@ -69,8 +67,7 @@ class SendTest extends AbstractConsumerTestCase
 
     public function testProcessMessageHandlesEmailNotSentException()
     {
-        $json = new LaminasJson();
-        $options = $json->serialize(
+        $options = json_encode(
             [
                 'commandClass' => SampleEmail::class,
                 'commandData' => [
@@ -111,8 +108,7 @@ class SendTest extends AbstractConsumerTestCase
 
     public function testProcessMessageHandlesLaminasServiceException()
     {
-        $json = new LaminasJson();
-        $options = $json->serialize(
+        $options = json_encode(
             [
                 'commandClass' => SampleEmail::class,
                 'commandData' => [
@@ -152,8 +148,7 @@ class SendTest extends AbstractConsumerTestCase
 
     public function testProcessMessageHandlesException()
     {
-        $json = new LaminasJson();
-        $options = $json->serialize(
+        $options = json_encode(
             [
                 'commandClass' => SampleEmail::class,
                 'commandData' => [
@@ -193,8 +188,7 @@ class SendTest extends AbstractConsumerTestCase
 
     public function testProcessMessageHandlesMaxAttempts()
     {
-        $json = new LaminasJson();
-        $options = $json->serialize(
+        $options = json_encode(
             [
                 'commandClass' => SampleEmail::class,
                 'commandData' => [

--- a/app/api/test/module/Cli/src/Service/Queue/Consumer/PrintJob/PrintJobTest.php
+++ b/app/api/test/module/Cli/src/Service/Queue/Consumer/PrintJob/PrintJobTest.php
@@ -9,7 +9,6 @@ use Dvsa\Olcs\Api\Domain\Command\Queue\Retry as RetryCmd;
 use Dvsa\Olcs\Api\Domain\Exception\NotReadyException;
 use Dvsa\OlcsTest\Cli\Service\Queue\Consumer\AbstractConsumerTestCase;
 use Dvsa\Olcs\Api\Entity\User\User;
-use Laminas\Serializer\Adapter\Json as LaminasJson;
 
 /**
  * Print job test
@@ -97,8 +96,7 @@ class PrintJobTest extends AbstractConsumerTestCase
             'userId' => $userId,
         ];
 
-        $json = new LaminasJson();
-        $options = $json->serialize($optionsArray);
+        $options = json_encode($optionsArray);
 
         $item = new QueueEntity();
         $item->setId($itemId);

--- a/app/api/test/module/Cli/src/Service/Queue/Consumer/Tm/UpdateTmNysiisNameTest.php
+++ b/app/api/test/module/Cli/src/Service/Queue/Consumer/Tm/UpdateTmNysiisNameTest.php
@@ -5,7 +5,6 @@ namespace Dvsa\OlcsTest\Cli\Service\Queue\Consumer\Tm;
 use Dvsa\Olcs\Api\Entity\Queue\Queue as QueueEntity;
 use Dvsa\Olcs\Cli\Service\Queue\Consumer\Tm\UpdateTmNysiisName as Sut;
 use Dvsa\OlcsTest\Cli\Service\Queue\Consumer\AbstractConsumerTestCase;
-use Laminas\Serializer\Adapter\Json as LaminasJson;
 use Dvsa\Olcs\Api\Domain\Command\Queue\Retry as RetryCmd;
 use Dvsa\Olcs\Api\Entity\User\User;
 use Dvsa\Olcs\Api\Domain\Command\Tm\UpdateNysiisName as UpdateNysiisCmd;
@@ -51,8 +50,7 @@ class UpdateTmNysiisNameTest extends AbstractConsumerTestCase
             'userId' => $userId
         ];
 
-        $json = new LaminasJson();
-        $options = $json->serialize($optionsArray);
+        $options = json_encode($optionsArray);
 
         $item = new QueueEntity();
         $item->setId($itemId);

--- a/app/internal/composer.json
+++ b/app/internal/composer.json
@@ -16,7 +16,6 @@
     "laminas/laminas-http": "^2.5",
     "laminas/laminas-i18n": "^2.5",
     "laminas/laminas-inputfilter": "^2.5",
-    "laminas/laminas-json": "^3.0",
     "laminas/laminas-mvc": "^3.0",
     "laminas/laminas-mvc-i18n": "^1",
     "laminas/laminas-mvc-plugin-flashmessenger": "^1",

--- a/app/selfserve/composer.json
+++ b/app/selfserve/composer.json
@@ -20,7 +20,6 @@
     "laminas/laminas-mvc-plugin-flashmessenger": "^1.8",
     "laminas/laminas-mvc-plugin-prg": "^1.7",
     "laminas/laminas-navigation": "^2.15",
-    "laminas/laminas-serializer": "^2.10",
     "laminas/laminas-servicemanager": "^3.3",
     "laminas/laminas-session": "^2.8",
     "laminas/laminas-stdlib": "^3.0",


### PR DESCRIPTION
## Description

This PR removes the deprecated laminas-json and laminas-serializer packages and replaces their usage with native PHP json_encode() and json_decode() functions. This change is driven by Laminas abandoning these legacy libraries as announced by their technical steering committee.

- Removes laminas/laminas-json and laminas/laminas-serializer dependencies from composer.json files
- Replaces Laminas JSON serialization/deserialization with native PHP JSON functions
- Updates error handling to use native PHP JSON_THROW_ON_ERROR flag for better error management

https://github.com/laminas/technical-steering-committee/blob/main/meetings/minutes/2024-11-04-TSC-Minutes.md#archive--abandon-various-legacy-libraries

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
