### PR TITLE
fix: resolve name mismatch for transxchange consumer role

### DIFF
--- a/infra/terraform/environments/prep/main.tf
+++ b/infra/terraform/environments/prep/main.tf
@@ -30,7 +30,7 @@ locals {
         "sts:AssumeRole"
       ]
       resources = [
-        "arn:aws:iam::000081644369:role/txc-pp-consumer-role"
+        "arn:aws:iam::000081644369:role/txc-prep-consumer-role"
       ]
     },
     {

--- a/infra/terraform/environments/prod/main.tf
+++ b/infra/terraform/environments/prod/main.tf
@@ -31,7 +31,7 @@ locals {
         "sts:AssumeRole"
       ]
       resources = [
-        "arn:aws:iam::000081644369:role/txc-app-consumer-role"
+        "arn:aws:iam::000081644369:role/txc-prod-consumer-role"
       ]
     },
     {


### PR DESCRIPTION
## Description

There exists a naming mismatch in the transxchange consumer role that the vol-app-prep-api-service role is assuming. This was looking to assume a role that did not exist (txc-pp-consumer-role in preprod rather than txc-prep-consumer-role and txc-app-consumer-role in production rather than txc-prod-consumer-role).

This role is hardcoded in vol-app codebase, current guidance and good practice suggests that this should use a data source. Since this is critical i will correct the name but there ought to be a future bug to make this more resilient in the future.

Related issue: [VOL - 6546](https://dvsa.atlassian.net/browse/VOL-6546)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
