### PR TITLE
fix: remove deprecated path param from export cmds

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -304,13 +304,13 @@ module "service" {
       },
       {
         name     = "psv-operator-list-export",
-        commands = ["batch:data-gov-uk-export", "-v", "--report-name=psv-operator-list", "--path=/tmp/"],
+        commands = ["batch:data-gov-uk-export", "-v", "--report-name=psv-operator-list"],
         timeout  = 43200,
         schedule = "cron(00 13 ? * 1 *)",
       },
       {
         name     = "international-goods-export",
-        commands = ["batch:data-gov-uk-export", "-v", "--report-name=international-goods", "--path=/tmp/"],
+        commands = ["batch:data-gov-uk-export", "-v", "--report-name=international-goods"],
         timeout  = 43200,
         schedule = "cron(00 13 ? * 1 *)",
       },

--- a/infra/terraform/environments/int/main.tf
+++ b/infra/terraform/environments/int/main.tf
@@ -303,13 +303,13 @@ module "service" {
       },
       {
         name     = "psv-operator-list-export",
-        commands = ["batch:data-gov-uk-export", "-v", "--report-name=psv-operator-list", "--path=/tmp/"],
+        commands = ["batch:data-gov-uk-export", "-v", "--report-name=psv-operator-list"],
         timeout  = 43200,
         schedule = "cron(00 13 ? * 1 *)",
       },
       {
         name     = "international-goods-export",
-        commands = ["batch:data-gov-uk-export", "-v", "--report-name=international-goods", "--path=/tmp/"],
+        commands = ["batch:data-gov-uk-export", "-v", "--report-name=international-goods"],
         timeout  = 43200,
         schedule = "cron(00 13 ? * 1 *)",
       },

--- a/infra/terraform/environments/prep/main.tf
+++ b/infra/terraform/environments/prep/main.tf
@@ -321,13 +321,13 @@ module "service" {
       },
       {
         name     = "psv-operator-list-export",
-        commands = ["batch:data-gov-uk-export", "-v", "--report-name=psv-operator-list", "--path=/tmp/"],
+        commands = ["batch:data-gov-uk-export", "-v", "--report-name=psv-operator-list"],
         timeout  = 43200,
         schedule = "cron(00 13 ? * 1 *)",
       },
       {
         name     = "international-goods-export",
-        commands = ["batch:data-gov-uk-export", "-v", "--report-name=international-goods", "--path=/tmp/"],
+        commands = ["batch:data-gov-uk-export", "-v", "--report-name=international-goods"],
         timeout  = 43200,
         schedule = "cron(00 13 ? * 1 *)",
       },

--- a/infra/terraform/environments/prod/main.tf
+++ b/infra/terraform/environments/prod/main.tf
@@ -323,13 +323,13 @@ module "service" {
       },
       {
         name     = "psv-operator-list-export",
-        commands = ["batch:data-gov-uk-export", "-v", "--report-name=psv-operator-list", "--path=/tmp/"],
+        commands = ["batch:data-gov-uk-export", "-v", "--report-name=psv-operator-list"],
         timeout  = 43200,
         #schedule = "cron(00 13 ? * 1 *)",
       },
       {
         name     = "international-goods-export",
-        commands = ["batch:data-gov-uk-export", "-v", "--report-name=international-goods", "--path=/tmp/"],
+        commands = ["batch:data-gov-uk-export", "-v", "--report-name=international-goods"],
         timeout  = 43200,
         #schedule = "cron(00 13 ? * 1 *)",
       },


### PR DESCRIPTION
## Description

Remove deprecated path parameter from 2 export commands

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
