### PR TITLE
fix: add a default false for aweOptions->s3->use_path_style_endpoint …

### DIFF
--- a/app/api/config/autoload/config.global.php
+++ b/app/api/config/autoload/config.global.php
@@ -269,6 +269,9 @@ return [
     'awsOptions' => array_filter([
         'region' => '%olcs_aws_region%',
         'version' => '%olcs_aws_version%',
+        's3' => [
+            'use_path_style_endpoint' => false,
+        ],
         's3Options' => $isProductionAccount ? null : [
             'roleArn' => '%olcs_aws_s3_role_arn%',
             'roleSessionName' => '%olcs_aws_s3_role_session_name%'


### PR DESCRIPTION
…config to stop warnings in nonprod and prod

## Description

Resolves a warning sometimes seen in nonprod/prod api logs due to missing config parameter by adding a default of false


## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
