### PR TITLE
fix: bake versions into container images built by the cd pipeline

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -245,6 +245,7 @@ jobs:
       should-upload-artefact: true
       artefact-name: ${{ matrix.project}}
       retention-days: 1
+      version: ${{ needs.get-version.outputs[matrix.project] }}
     permissions:
       contents: read
 

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -20,6 +20,9 @@ on:
         type: number
         required: false
         default: 7
+      version:
+        type: string
+        required: false
 
 jobs:
   warm-cache:
@@ -165,6 +168,9 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
       - name: Install dependencies
         run: composer install --no-progress --prefer-dist --no-dev --optimize-autoloader
+      - name: Write version file
+        if: ${{ inputs.version }}
+        run: echo "${{ inputs.version }}" > config/version
       - name: Archive
         run: tar -czf ${{ inputs.project }}.tar.gz *
       - name: Upload artefact


### PR DESCRIPTION
## Description

Add step to docker/php build process to bake the version number being built into the 3 apps

Related issue: [VOL-6567](https://dvsa.atlassian.net/browse/VOL-6567)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-6567]: https://dvsa.atlassian.net/browse/VOL-6567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ