### PR TITLE
fix: renderer container repo

### DIFF
--- a/app/api/.gitignore
+++ b/app/api/.gitignore
@@ -26,6 +26,6 @@ phpcs.xml
 phpstan.neon
 phpunit.xml
 psalm.xml
-# Trigger CD - 2025-08-22-15:00
+# Trigger CD - 2025-09-04-15:00
 
 

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -1,5 +1,5 @@
 locals {
-  service_names = ["api", "selfserve", "internal", "cli","pdf-converter"]
+  service_names = ["api", "selfserve", "internal", "cli"]
 
   legacy_service_names = ["API", "IUWEB", "SSWEB", "RENDERER"]
 

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -1,5 +1,5 @@
 locals {
-  service_names = ["api", "selfserve", "internal", "cli"]
+  service_names = ["api", "selfserve", "internal", "cli","pdf-converter"]
 
   legacy_service_names = ["API", "IUWEB", "SSWEB", "RENDERER"]
 

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -93,6 +93,10 @@ data "aws_ecr_repository" "sservice" {
   name = "vol-app/${each.key}"
 }
 
+data "aws_ecr_repository" "dockerhub_gotenberg" {
+  name = "docker-hub/gotenberg/gotenberg"
+}
+
 data "aws_security_group" "this" {
   for_each = toset(local.legacy_service_names)
 
@@ -278,7 +282,7 @@ module "service" {
       enable_autoscaling_policies = true
 
       version    = "8"
-      repository = "docker.io/gotenberg/gotenberg"
+      repository = data.aws_ecr_repository.dockerhub_gotenberg.repository_url
 
       listener_rule_enable = true
 

--- a/infra/terraform/environments/int/main.tf
+++ b/infra/terraform/environments/int/main.tf
@@ -1,5 +1,5 @@
 locals {
-  service_names = ["api", "selfserve", "internal", "cli","pdf-converter"]
+  service_names = ["api", "selfserve", "internal", "cli"]
 
   legacy_service_names = ["API", "IUWEB", "SSWEB", "RENDERER"]
 

--- a/infra/terraform/environments/int/main.tf
+++ b/infra/terraform/environments/int/main.tf
@@ -1,5 +1,5 @@
 locals {
-  service_names = ["api", "selfserve", "internal", "cli"]
+  service_names = ["api", "selfserve", "internal", "cli","pdf-converter"]
 
   legacy_service_names = ["API", "IUWEB", "SSWEB", "RENDERER"]
 

--- a/infra/terraform/environments/int/main.tf
+++ b/infra/terraform/environments/int/main.tf
@@ -93,6 +93,10 @@ data "aws_ecr_repository" "sservice" {
   name = "vol-app/${each.key}"
 }
 
+data "aws_ecr_repository" "dockerhub_gotenberg" {
+  name = "docker-hub/gotenberg/gotenberg"
+}
+
 data "aws_security_group" "this" {
   for_each = toset(local.legacy_service_names)
 
@@ -278,7 +282,7 @@ module "service" {
       enable_autoscaling_policies = true
 
       version    = "8"
-      repository = "docker.io/gotenberg/gotenberg"
+      repository = data.aws_ecr_repository.dockerhub_gotenberg.repository_url
 
       listener_rule_enable = true
 

--- a/infra/terraform/environments/prep/main.tf
+++ b/infra/terraform/environments/prep/main.tf
@@ -1,5 +1,5 @@
 locals {
-  service_names = ["api", "selfserve", "internal", "cli"]
+  service_names = ["api", "selfserve", "internal", "cli", "pdf-converter"]
 
   legacy_service_names = ["API", "IUWEB", "SSWEB", "RENDERER"]
 

--- a/infra/terraform/environments/prep/main.tf
+++ b/infra/terraform/environments/prep/main.tf
@@ -93,6 +93,10 @@ data "aws_ecr_repository" "sservice" {
   name = "vol-app/${each.key}"
 }
 
+data "aws_ecr_repository" "dockerhub_gotenberg" {
+  name = "docker-hub/gotenberg/gotenberg"
+}
+
 data "aws_security_group" "this" {
   for_each = toset(local.legacy_service_names)
 
@@ -297,7 +301,7 @@ module "service" {
       enable_autoscaling_policies = true
 
       version    = "8"
-      repository = "docker.io/gotenberg/gotenberg"
+      repository = data.aws_ecr_repository.dockerhub_gotenberg.repository_url
 
       listener_rule_enable = false
 

--- a/infra/terraform/environments/prep/main.tf
+++ b/infra/terraform/environments/prep/main.tf
@@ -1,5 +1,5 @@
 locals {
-  service_names = ["api", "selfserve", "internal", "cli", "pdf-converter"]
+  service_names = ["api", "selfserve", "internal", "cli"]
 
   legacy_service_names = ["API", "IUWEB", "SSWEB", "RENDERER"]
 

--- a/infra/terraform/environments/prod/main.tf
+++ b/infra/terraform/environments/prod/main.tf
@@ -1,6 +1,6 @@
 locals {
   #testing tf plan
-  service_names = ["api", "selfserve", "internal", "cli", "pdf-converter"]
+  service_names = ["api", "selfserve", "internal", "cli"]
 
   legacy_service_names = ["API", "IUWEB", "SSWEB", "RENDERER"]
 

--- a/infra/terraform/environments/prod/main.tf
+++ b/infra/terraform/environments/prod/main.tf
@@ -94,6 +94,10 @@ data "aws_ecr_repository" "sservice" {
   name = "vol-app/${each.key}"
 }
 
+data "aws_ecr_repository" "dockerhub_gotenberg" {
+  name = "docker-hub/gotenberg/gotenberg"
+}
+
 data "aws_security_group" "this" {
   for_each = toset(local.legacy_service_names)
 
@@ -297,7 +301,7 @@ module "service" {
       enable_autoscaling_policies = true
 
       version    = "8"
-      repository = "docker.io/gotenberg/gotenberg"
+      repository = data.aws_ecr_repository.dockerhub_gotenberg.repository_url
 
       listener_rule_enable = false
 

--- a/infra/terraform/environments/prod/main.tf
+++ b/infra/terraform/environments/prod/main.tf
@@ -1,6 +1,6 @@
 locals {
   #testing tf plan
-  service_names = ["api", "selfserve", "internal", "cli"]
+  service_names = ["api", "selfserve", "internal", "cli", "pdf-converter"]
 
   legacy_service_names = ["API", "IUWEB", "SSWEB", "RENDERER"]
 

--- a/infra/terraform/modules/service/ecs.tf
+++ b/infra/terraform/modules/service/ecs.tf
@@ -122,9 +122,8 @@ resource "aws_lb_listener_rule" "renderer-batch" {
 
 resource "aws_lb_listener_rule" "proving" {
   for_each = {
-    for k, v in var.services :
-    k => v
-    if k == "pdf-converter" && v.listener_rule_enable
+    for service, config in var.services : service => config
+    if contains(["prep", "prod"], var.environment)
   }
 
   listener_arn = each.value.lb_listener_arn

--- a/infra/terraform/modules/service/ecs.tf
+++ b/infra/terraform/modules/service/ecs.tf
@@ -94,19 +94,23 @@ resource "aws_lb_listener_rule" "this" {
   }
 }
 resource "aws_lb_listener_rule" "renderer-batch" {
-  count = var.services["pdf-converter"].listener_rule_enable ? 1 : 0
+  for_each = {
+    for k, v in var.services :
+    k => v
+    if k == "pdf-converter" && v.listener_rule_enable
+  }
 
-  listener_arn = var.services["pdf-converter"].lb_listener_arn
+  listener_arn = each.value.lb_listener_arn
   priority     = 87
 
   action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.this["pdf-converter"].arn
+    target_group_arn = aws_lb_target_group.this[each.key].arn
   }
 
   condition {
     host_header {
-      values = var.services["pdf-converter"].listener_rule_host_header
+      values = each.value.listener_rule_host_header
     }
   }
   condition {
@@ -118,8 +122,9 @@ resource "aws_lb_listener_rule" "renderer-batch" {
 
 resource "aws_lb_listener_rule" "proving" {
   for_each = {
-    for service, config in var.services : service => config
-    if contains(["prep", "prod"], var.environment)
+    for k, v in var.services :
+    k => v
+    if k == "pdf-converter" && v.listener_rule_enable
   }
 
   listener_arn = each.value.lb_listener_arn
@@ -154,12 +159,13 @@ resource "aws_lb_listener_rule" "internal-pub-proving" {
   }
 }
 resource "aws_lb_listener_rule" "internal-pub" {
-  count = (
-    contains(["prep", "prod"], var.environment) &&
-    var.services["internal"].listener_rule_enable
-  ) ? 1 : 0
+  for_each = (
+    contains(["prep", "prod"], var.environment) && try(var.services["internal"].listener_rule_enable, false)
+    ) ? {
+    "internal" = var.services["internal"]
+  } : {}
 
-  listener_arn = var.services["internal"].iuweb_pub_listener_arn
+  listener_arn = each.value.iuweb_pub_listener_arn
   priority     = 16
 
   action {


### PR DESCRIPTION
## Description

The pdf-converter references an external source for the container ref which the service/task will not have access to. Corrected to use a pull-through cache in ECR.

I have also bumped .gitignore to trigger a new container build as requested.

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
