### PR TITLE
fix: ensure all editorJS blocks have spellcheck=true attr set to ensu…

### DIFF
--- a/app/cdn/assets/_js/components/editorjs.js
+++ b/app/cdn/assets/_js/components/editorjs.js
@@ -126,7 +126,7 @@ OLCS.editorjs = (function (document, $, undefined) {
           });
 
           // Enable spellcheck on all contenteditable elements
-          var editableElements = editorContainer.querySelectorAll('[contenteditable="true"]');
+          var editableElements = editorContainer.querySelectorAll("[contenteditable=\"true\"]");
           editableElements.forEach(function (element) {
             element.setAttribute("spellcheck", "true");
           });
@@ -142,7 +142,7 @@ OLCS.editorjs = (function (document, $, undefined) {
                       node.setAttribute("spellcheck", "true");
                     }
                     // Also check for contenteditable descendants
-                    var newEditables = node.querySelectorAll('[contenteditable="true"]');
+                    var newEditables = node.querySelectorAll("[contenteditable=\"true\"]");
                     newEditables.forEach(function (element) {
                       element.setAttribute("spellcheck", "true");
                     });


### PR DESCRIPTION
…re browser spellcheck runs

## Description

extra Js to ensure editorJS contenteditable blocks have an explicit spellcheck=true attr added to them to ensure browser spellchecking happens were supported.

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
