### PR TITLE
fix: match session.gc_maxlifetime to match what puppet was setting on…

### DIFF
--- a/infra/docker/internal/php.ini
+++ b/infra/docker/internal/php.ini
@@ -55,6 +55,11 @@ session.save_path=${ELASTICACHE_URL}
 ; https://php.net/session.save-handler
 session.save_handler=redis
 
+; After this number of seconds, stored data will be seen as 'garbage' and
+; cleaned up by the garbage collection process.
+; https://php.net/session.gc-maxlifetime
+session.gc_maxlifetime=5400
+
 [opcache]
 ; The maximum number of keys (and therefore scripts) in the OPcache hash table
 ; The Allowed value is between 200 and 100000.

--- a/infra/docker/selfserve/php.ini
+++ b/infra/docker/selfserve/php.ini
@@ -55,6 +55,11 @@ session.save_path=${ELASTICACHE_URL}
 ; https://php.net/session.save-handler
 session.save_handler=redis
 
+; After this number of seconds, stored data will be seen as 'garbage' and
+; cleaned up by the garbage collection process.
+; https://php.net/session.gc-maxlifetime
+session.gc_maxlifetime=5400
+
 [opcache]
 ; The maximum number of keys (and therefore scripts) in the OPcache hash table
 ; The Allowed value is between 200 and 100000.


### PR DESCRIPTION
… ec2 instances

## Description

Align container php session.gc_maxlifetime to that which puppet was setting on ec2s

Related issue: [VOL-6604](https://dvsa.atlassian.net/browse/VOL-6604)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-6604]: https://dvsa.atlassian.net/browse/VOL-6604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ