### PR TITLE
fix: continuations missing condition or undertaking info, now display correctly VOL-6569

### DIFF
--- a/app/api/module/Snapshot/view/partials/continuation-conditions-undertakings.phtml
+++ b/app/api/module/Snapshot/view/partials/continuation-conditions-undertakings.phtml
@@ -64,7 +64,7 @@
             ?>
         </h4>
 
-        <?php if (count($oc['conditions']) > 0) : ?>
+        <?php if (isset($oc['conditions']) && is_countable($oc['conditions']) && count($oc['conditions']) > 0) : ?>
                 <h5><?php echo $this->translate('continuations.conditions-undertakings.conditions'); ?></h5>
                 <ul class="list--bullet">
                     <?php foreach($oc['conditions'] as $cu) : ?>
@@ -74,7 +74,7 @@
 
         <?php endif; ?>
 
-        <?php if (count($oc['undertakings']) > 0) : ?>
+        <?php if (isset($oc['undertakings']) && is_countable($oc['undertakings']) && count($oc['undertakings']) > 0) : ?>
                 <h5><?php echo $this->translate('continuations.conditions-undertakings.undertakings'); ?></h5>
                 <ul class="list--bullet">
                     <?php foreach($oc['undertakings'] as $cu) : ?>


### PR DESCRIPTION
Related issue: [VOL-6569](https://dvsa.atlassian.net/browse/VOL-6569)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-6569]: https://dvsa.atlassian.net/browse/VOL-6569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ