### PR TITLE
fix: eager load pi, pislaexception, createdby, contactdetails, person

### DIFF
--- a/app/api/module/Api/src/Domain/QueryHandler/Cases/Pi.php
+++ b/app/api/module/Api/src/Domain/QueryHandler/Cases/Pi.php
@@ -35,7 +35,11 @@ final class Pi extends AbstractQueryHandler
         'case',
         'piSlaExceptions' => [
             'slaException',
-            'createdBy'
+            'createdBy' => [
+                'contactDetails' => [
+                    'person',
+                ]
+            ]
         ],
     ];
 


### PR DESCRIPTION
## Description

Eager loads the PI -> PI SLA Exceptions -> CreatedBy -> ContactDetails -> Person allow to get the name of the person who created the PI SLA Exception for display.

Related issue: https://dvsa.atlassian.net/browse/VOL-6501

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
