### PR TITLE
fix: retrigger cd after vft prep fail

### DIFF
--- a/app/api/.gitignore
+++ b/app/api/.gitignore
@@ -26,6 +26,6 @@ phpcs.xml
 phpstan.neon
 phpunit.xml
 psalm.xml
-# Trigger CD - 2025-09-29-13:25
+# Trigger CD - 2025-10-02-15:04
 
 


### PR DESCRIPTION
## Description

Rerun for vft cognito fail

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
