### PR TITLE
Fix vol 7162 duplicate tm letters

### DIFF
--- a/app/api/module/Api/src/Domain/Repository/TransportManagerLicence.php
+++ b/app/api/module/Api/src/Domain/Repository/TransportManagerLicence.php
@@ -61,9 +61,9 @@ class TransportManagerLicence extends AbstractRepository
             $qb->orderBy($this->alias . '.deletedDate', 'DESC');
             $qb->andWhere($qb->expr()->lte($this->alias . '.deletedDate', ':date28DaysAgo'));
             $qb->setParameter('date28DaysAgo', $date28DaysAgo);
-            $qb->setMaxResults(1);
         } else {
             $qb->andWhere($qb->expr()->isNull($this->alias . '.lastTmFirstEmailDate'));
+            $qb->orderBy($this->alias . '.deletedDate', 'DESC');
         }
 
         return $qb->getQuery()->getResult();

--- a/app/api/module/Cli/src/Domain/CommandHandler/FirstTmLetter.php
+++ b/app/api/module/Cli/src/Domain/CommandHandler/FirstTmLetter.php
@@ -69,17 +69,22 @@ final class FirstTmLetter extends AbstractCommandHandler implements EmailAwareIn
             /** @var TransportManagerLicence $tmlRepo */
             $tmlRepo = $this->getRepo('TransportManagerLicence');
             $removedTms = $tmlRepo->fetchRemovedTmForLicence($licence->getId());
+            
+            if (empty($removedTms)) {
+                continue;
+            }
+
+            $lastRemovedTm = reset($removedTms);
+
+            $this->generateDocuments($licence, $lastRemovedTm);
 
             /** @var TmlEntity $removedTm */
             foreach ($removedTms as $removedTm) {
-                $document = $this->generateDocuments($licence, $removedTm);
                 $removedTm->setLastTmFirstEmailDate(new DateTime());
                 $tmlRepo->save($removedTm);
             }
 
-            if (!empty($removedTms)) {
-                $this->sendEmailToOperator($licence);
-            }
+            $this->sendEmailToOperator($licence);
         }
 
         return $this->result;

--- a/app/api/module/Cli/src/Domain/CommandHandler/FirstTmLetter.php
+++ b/app/api/module/Cli/src/Domain/CommandHandler/FirstTmLetter.php
@@ -69,7 +69,7 @@ final class FirstTmLetter extends AbstractCommandHandler implements EmailAwareIn
             /** @var TransportManagerLicence $tmlRepo */
             $tmlRepo = $this->getRepo('TransportManagerLicence');
             $removedTms = $tmlRepo->fetchRemovedTmForLicence($licence->getId());
-            
+
             if (empty($removedTms)) {
                 continue;
             }

--- a/app/api/module/Cli/src/Domain/CommandHandler/LastTmLetter.php
+++ b/app/api/module/Cli/src/Domain/CommandHandler/LastTmLetter.php
@@ -69,17 +69,22 @@ final class LastTmLetter extends AbstractCommandHandler implements EmailAwareInt
             $tmlRepo = $this->getRepo('TransportManagerLicence');
             $removedTms = $tmlRepo->fetchRemovedTmForLicence($licence->getId(), true);
 
+            if (empty($removedTms)) {
+                continue;
+            }
+
+            $lastRemovedTm = reset($removedTms);
+
+            $document = $this->generateDocuments($licence, $lastRemovedTm);
+            $this->printAndEmailDocument($document);
+
              /** @var TmlEntity $removedTm */
             foreach ($removedTms as $removedTm) {
-                $document = $this->generateDocuments($licence, $removedTm);
-                $this->printAndEmailDocument($document);
                 $removedTm->setLastTmLetterDate(new DateTime());
                 $tmlRepo->save($removedTm);
             }
 
-            if (!empty($removedTms)) {
-                $this->sendEmailToOperator($licence);
-            }
+            $this->sendEmailToOperator($licence);
         }
 
         return $this->result;

--- a/app/api/test/module/Api/src/Domain/Repository/TransportManagerLicenceTest.php
+++ b/app/api/test/module/Api/src/Domain/Repository/TransportManagerLicenceTest.php
@@ -57,7 +57,8 @@ class TransportManagerLicenceTest extends RepositoryTestCase
             '[QUERY] AND tml.licence = [[' . $licenceId . ']] ' .
             'AND tml.deletedDate IS NOT NULL ' .
             'AND tml.lastTmLetterDate IS NULL ' .
-            'AND tml.lastTmFirstEmailDate IS NULL';
+            'AND tml.lastTmFirstEmailDate IS NULL ' .
+            'ORDER BY tml.deletedDate DESC';
 
         $this->assertEquals($expectedQuery, $this->query);
     }

--- a/app/api/test/module/Cli/src/Domain/CommandHandler/FirstTmLetterTest.php
+++ b/app/api/test/module/Cli/src/Domain/CommandHandler/FirstTmLetterTest.php
@@ -281,6 +281,78 @@ class FirstTmLetterTest extends AbstractCommandHandlerTestCase
         $this->assertEquals($expectedResult, $response->toArray());
     }
 
+    public function testHandleCommandGeneratesOneDocumentAndUpdatesAllRemovedTms(): void
+    {
+        $licenceRepo = $this->repoMap['Licence'];
+        $tmlRepo = $this->repoMap['TransportManagerLicence'];
+
+        $licence = m::mock(LicenceEntity::class);
+
+        $this->mockLicence($licence, [
+            'licence' => [
+                'id' => 1,
+                'licNo' => 'AB123',
+                'isNi' => false,
+                'isPsv' => false,
+                'translateToWelsh' => 'N',
+                'organisation' => [
+                    'allowEmail' => 'Y',
+                    'name' => 'Test Operator Ltd',
+                ],
+                'correspondenceCd' => null,
+            ],
+        ]);
+
+        $this->mockCorrespondenceCd($licence, [
+            'licence' => [
+                'correspondenceCd' => null,
+            ],
+        ]);
+
+        $licenceRepo->shouldReceive('fetchForLastTmAutoLetter')
+            ->once()
+            ->andReturn([$licence]);
+
+        $tm = m::mock(TransportManager::class);
+        $tm->shouldReceive('getId')->andReturn(1);
+
+        $removedTm1 = m::mock(TransportManagerLicence::class);
+        $removedTm1->shouldReceive('getId')->andReturn(10);
+        $removedTm1->shouldReceive('getTransportManager')->andReturn($tm);
+        $removedTm1->shouldReceive('setLastTmFirstEmailDate')->once();
+
+        $removedTm2 = m::mock(TransportManagerLicence::class);
+        $removedTm2->shouldReceive('getId')->andReturn(11);
+        $removedTm2->shouldReceive('getTransportManager')->andReturn($tm);
+        $removedTm2->shouldReceive('setLastTmFirstEmailDate')->once();
+
+        $tmlRepo->shouldReceive('fetchRemovedTmForLicence')
+        ->with(1)
+        ->once()
+        ->andReturn([$removedTm1, $removedTm2]);
+
+        $tmlRepo->shouldReceive('save')->with($removedTm1)->once();
+        $tmlRepo->shouldReceive('save')->with($removedTm2)->once();
+
+        $generateResult = new Result();
+        $generateResult->addId('document', 123);
+        $this->expectedSideEffect(GenerateAndStore::class, [], $generateResult);
+
+        $this->expectedSideEffect(CreateTask::class, [], new Result());
+
+        $response = $this->sut->handleCommand(\Dvsa\Olcs\Cli\Domain\Command\FirstTmLetter::create([]));
+
+        $this->assertEquals(
+            [
+                'id' => [
+                    'document' => 123,
+                ],
+                'messages' => [],
+            ],
+            $response->toArray()
+        );
+    }
+
     private function mockLicence(m\MockInterface $licence, array $dataProvider): void
     {
         $licenceBundle = ['trafficArea'];

--- a/app/api/test/module/Cli/src/Domain/CommandHandler/FirstTmLetterTest.php
+++ b/app/api/test/module/Cli/src/Domain/CommandHandler/FirstTmLetterTest.php
@@ -327,9 +327,9 @@ class FirstTmLetterTest extends AbstractCommandHandlerTestCase
         $removedTm2->shouldReceive('setLastTmFirstEmailDate')->once();
 
         $tmlRepo->shouldReceive('fetchRemovedTmForLicence')
-        ->with(1)
-        ->once()
-        ->andReturn([$removedTm1, $removedTm2]);
+            ->with(1)
+            ->once()
+            ->andReturn([$removedTm1, $removedTm2]);
 
         $tmlRepo->shouldReceive('save')->with($removedTm1)->once();
         $tmlRepo->shouldReceive('save')->with($removedTm2)->once();

--- a/app/api/test/module/Cli/src/Domain/CommandHandler/LastTmLetterTest.php
+++ b/app/api/test/module/Cli/src/Domain/CommandHandler/LastTmLetterTest.php
@@ -304,6 +304,61 @@ class LastTmLetterTest extends AbstractCommandHandlerTestCase
                         "Document id '123', queued for print",
                     ]
                 ]
+            ],
+            'multiple_removed_tms_only_one_document' => [
+                'dataProvider' => [
+                    'licence' => [
+                        'id' => 1,
+                        'licNo' => 'AB123',
+                        'isNi' => false,
+                        'isPsv' => false,
+                        'organisation' => [
+                            'allowEmail' => 'Y',
+                            'name' => 'Test Operator Ltd',
+                        ],
+                        'correspondenceCd' => [
+                            'emailAddress' => 'test@email.com'
+                        ]
+                    ],
+                    'user' => [
+                        'fetchFirstByEmailOrFalse' => false
+                    ],
+                    'sideEffectResults' => [
+                        'GenerateAndStore' => [
+                            'ids' => [
+                                'documents' => [
+                                    '123' => [
+                                        'metadata' => json_encode([
+                                            'details' => [
+                                                'category' => Category::CATEGORY_TRANSPORT_MANAGER,
+                                                'documentSubCategory' => Category::DOC_SUB_CATEGORY_TRANSPORT_MANAGER_CORRESPONDENCE,
+                                                'documentTemplate' => 1285,
+                                                'allowEmail' => 'Y',
+                                                'sendToAddress' => 'correspondenceAddress',
+                                            ]
+                                        ]),
+                                    ],
+                                ]
+                            ]
+                        ],
+                        'CreateTask' => [
+                            'ids' => []
+
+                        ],
+                    ],
+                    'multipleRemovedTms' => true,
+                ],
+                'expectedResult' => [
+                    'id' => [
+                        'document' => 123,
+                        '' => 123,
+                    ],
+                    'messages' => [
+                        "Document id '123', queued for print",
+                        "Correspondence record created",
+                        "Email sent"
+                    ]
+                ]
             ]
         ];
     }
@@ -375,7 +430,7 @@ class LastTmLetterTest extends AbstractCommandHandlerTestCase
         $result = new Result();
 
         foreach ($documents as $id => $data) {
-            $result->addId($data['address'], $id);
+            $result->addId($data['address'] ?? '', $id);
             $result->addId('document', $id);
         }
 
@@ -469,18 +524,46 @@ class LastTmLetterTest extends AbstractCommandHandlerTestCase
     {
         $tmlRepo = $this->repoMap['TransportManagerLicence'];
         foreach ($eligibleLicences as $eligibleLicence) {
-            $tmlEntity = m::mock(TransportManagerLicence::class);
-            $tmlEntity->shouldReceive('getId')->andReturn(5);
-            $tmlEntity->shouldReceive('setLastTmLetterDate');
-            $tm = m::mock(\Dvsa\Olcs\Api\Entity\Tm\TransportManager::class);
-            $tm->shouldReceive('getId')->andReturn(1);
+            if (!empty($dataProvider['multipleRemovedTms'])) {
+                $tmlEntity1 = m::mock(TransportManagerLicence::class);
+                $tmlEntity1->shouldReceive('getId')->andReturn(5);
+                $tmlEntity1->shouldReceive('setLastTmLetterDate')->once();
 
-            $tmlEntity->shouldReceive('getTransportManager')->andReturn($tm);
-            $tmlRepo
-                ->shouldReceive('fetchRemovedTmForLicence')
-                ->with($eligibleLicence->getId(), true)
-                ->andReturn([$tmlEntity]);
-            $tmlRepo->shouldReceive('save');
+                $tm1 = m::mock(\Dvsa\Olcs\Api\Entity\Tm\TransportManager::class);
+                $tm1->shouldReceive('getId')->andReturn(1);
+                $tmlEntity1->shouldReceive('getTransportManager')->andReturn($tm1);
+
+                $tmlEntity2 = m::mock(TransportManagerLicence::class);
+                $tmlEntity2->shouldReceive('getId')->andReturn(6);
+                $tmlEntity2->shouldReceive('setLastTmLetterDate')->once();
+
+                $tm2 = m::mock(\Dvsa\Olcs\Api\Entity\Tm\TransportManager::class);
+                $tm2->shouldReceive('getId')->andReturn(2);
+                $tmlEntity2->shouldReceive('getTransportManager')->andReturn($tm2);
+
+                $tmlRepo
+                    ->shouldReceive('fetchRemovedTmForLicence')
+                    ->with($eligibleLicence->getId(), true)
+                    ->once()
+                    ->andReturn([$tmlEntity1, $tmlEntity2]);
+
+                $tmlRepo->shouldReceive('save')->with($tmlEntity1)->once();
+                $tmlRepo->shouldReceive('save')->with($tmlEntity2)->once();
+
+            } else {
+                $tmlEntity = m::mock(TransportManagerLicence::class);
+                $tmlEntity->shouldReceive('getId')->andReturn(5);
+                $tmlEntity->shouldReceive('setLastTmLetterDate');
+                $tm = m::mock(\Dvsa\Olcs\Api\Entity\Tm\TransportManager::class);
+                $tm->shouldReceive('getId')->andReturn(1);
+
+                $tmlEntity->shouldReceive('getTransportManager')->andReturn($tm);
+                $tmlRepo
+                    ->shouldReceive('fetchRemovedTmForLicence')
+                    ->with($eligibleLicence->getId(), true)
+                    ->andReturn([$tmlEntity]);
+                $tmlRepo->shouldReceive('save');
+            }
         }
 
         $documentsData = $dataProvider['sideEffectResults']['GenerateAndStore']['ids']['documents'];

--- a/app/api/test/module/Cli/src/Domain/CommandHandler/LastTmLetterTest.php
+++ b/app/api/test/module/Cli/src/Domain/CommandHandler/LastTmLetterTest.php
@@ -68,8 +68,7 @@ class LastTmLetterTest extends AbstractCommandHandlerTestCase
             'CreateTask' => [
                 'ids' => [
                     'assignedToUser' => 111
-                ]
-
+                ],
             ]
         ];
 
@@ -549,7 +548,6 @@ class LastTmLetterTest extends AbstractCommandHandlerTestCase
 
                 $tmlRepo->shouldReceive('save')->with($tmlEntity1)->once();
                 $tmlRepo->shouldReceive('save')->with($tmlEntity2)->once();
-
             } else {
                 $tmlEntity = m::mock(TransportManagerLicence::class);
                 $tmlEntity->shouldReceive('getId')->andReturn(5);


### PR DESCRIPTION
## Description

<!--
Updated the logic to ensure that when multiple removed Transport Managers exist without lastTmLetterDate set (for historic data) all records are updated as processed, while document generation and task creation are executed only once per licence for lastest removed TM to prevent duplicate letters.
-->

Related issue: [VOL-7162](https://dvsa.atlassian.net/browse/VOL-7162)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-7162]: https://dvsa.atlassian.net/browse/VOL-7162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ