### PR TITLE
fix: vol-7060 wrap renderImage output in shppict/picprop

### DIFF
--- a/app/api/module/Api/src/Service/Document/Parser/RtfParser.php
+++ b/app/api/module/Api/src/Service/Document/Parser/RtfParser.php
@@ -94,13 +94,32 @@ class RtfParser implements ParserInterface
     #[\Override]
     public function renderImage($binData, $width, $height, $type)
     {
+        // VOL-7060: Gotenberg's LibreOffice drops a template's existing
+        // `\*\picprop` shape-pictures (e.g. the OTC / NI office logos
+        // embedded in GB and NI licence templates) whenever the document
+        // later contains a bare `\pict` group. Word authors image data as
+        // a shape via `\*\shppict{\*\picprop\shplidN…}`; emitting the same
+        // form, with a `\shplid` that cannot collide with a template's
+        // existing shapes (Word templates start at 1025 and count up), is
+        // enough to stop LibreOffice conflating the injected picture with
+        // an earlier shape. The id is derived from the image bytes so the
+        // output stays deterministic across calls and across test runs.
+        $shplid = 0x20000 + (crc32($binData) & 0xFFFF);
+
         return sprintf(
-            "{\pict\%sblip\picw%d\pich%d\picwgoal%d\pichgoal%d %s}",
-            $type,
+            '{\*\shppict{\pict{\*\picprop\shplid%d'
+            . '{\sp{\sn shapeType}{\sv 75}}'
+            . '{\sp{\sn fLockAspectRatio}{\sv 1}}'
+            . '{\sp{\sn fLayoutInCell}{\sv 1}}}'
+            . '\picscalex100\picscaley100\piccropl0\piccropr0\piccropt0\piccropb0'
+            . '\picw%d\pich%d\picwgoal%d\pichgoal%d'
+            . '\%sblip %s}}',
+            $shplid,
             $width,
             $height,
             $width * self::PIXELS_TO_TWIPS,
             $height * self::PIXELS_TO_TWIPS,
+            $type,
             bin2hex($binData)
         );
     }

--- a/app/api/test/module/Api/src/Service/Document/Parser/RtfParserTest.php
+++ b/app/api/test/module/Api/src/Service/Document/Parser/RtfParserTest.php
@@ -103,10 +103,39 @@ TXT;
     {
         $parser = new RtfParser();
         $result = $parser->renderImage('', 100, 50, 'jpeg');
-        $this->assertEquals(
-            "{\pict\jpegblip\picw100\pich50\picwgoal1500\pichgoal750 }",
-            $result
-        );
+
+        // VOL-7060: output wraps the pict in \*\shppict{\*\picprop\shplidN}
+        // so LibreOffice treats each injected image as its own Word shape.
+        // crc32('') === 0, so the derived shplid for empty input is 131072.
+        $expected = '{\*\shppict{\pict{\*\picprop\shplid131072'
+            . '{\sp{\sn shapeType}{\sv 75}}'
+            . '{\sp{\sn fLockAspectRatio}{\sv 1}}'
+            . '{\sp{\sn fLayoutInCell}{\sv 1}}}'
+            . '\picscalex100\picscaley100\piccropl0\piccropr0\piccropt0\piccropb0'
+            . '\picw100\pich50\picwgoal1500\pichgoal750'
+            . '\jpegblip }}';
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testRenderImageUsesDeterministicShplidFromImageData(): void
+    {
+        $parser = new RtfParser();
+
+        // Same bytes → same shplid across calls (so output is stable for
+        // snapshot-style tests and diff-friendly RTFs).
+        $first  = $parser->renderImage('hello', 10, 20, 'jpeg');
+        $second = $parser->renderImage('hello', 10, 20, 'jpeg');
+        $this->assertEquals($first, $second);
+
+        // Different bytes should usually produce a different shplid (crc32
+        // collisions within a 16-bit window are theoretically possible but
+        // vanishingly unlikely for real image data). What matters is that
+        // the derived id is always ≥ 0x20000 so it can't collide with the
+        // 1025+ shape ids Word emits in templates.
+        $shplid = 0x20000 + (crc32('hello') & 0xFFFF);
+        $this->assertStringContainsString('\shplid' . $shplid, $first);
+        $this->assertGreaterThanOrEqual(0x20000, $shplid);
     }
 
     public function testGetEntitiesAndQuote(): void


### PR DESCRIPTION
## Description

Gotenberg's LibreOffice drops a template's existing shape-pictures (the `{\*\shppict{\*\picprop\shplidN...}}` structures used for the OTC / NI office logos in GB and NI licence templates) whenever the document later contains a bare `\pict` group. 

RtfParser::renderImage was producing a bare `\pict` for every image bookmark (TC_SIGNATURE, BR_LOGO, ...), which caused the office logos to silently disappear from every licence PDF rendered through the new Gotenberg service.

This fixes the RTF Parser to produce LibreOffice compliant RTFs

Related issue: VOL-7060

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
