### PR TITLE
fix: alias CourierPS to Nimbus Mono PS in gotenberg image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,6 +87,7 @@ jobs:
           files_ignore: |
             infra/docker/liquibase/**
             infra/docker/printpit/**
+            infra/docker/gotenberg/**
           # since_last_remote_commit: true
       - uses: tj-actions/changed-files@v47
         id: changed-accounts-terraform-files

--- a/infra/docker/gotenberg/Dockerfile
+++ b/infra/docker/gotenberg/Dockerfile
@@ -8,6 +8,10 @@ USER root
 #   fonts-crosextra-carlito   — metric-compatible substitute for Calibri
 #   fonts-crosextra-caladea   — metric-compatible substitute for Cambria
 #   fonts-liberation*         — fallback metric-compatible substitutes
+#   fonts-urw-base35          — URW++ free clone of the Adobe PostScript
+#                               Base35 set (provides Nimbus Mono PS, used
+#                               via courierps.conf to satisfy "CourierPS"
+#                               in disc-printing RTF templates).
 #   fonts-noto-*              — broad Unicode coverage for other docstore templates
 # hadolint ignore=DL3008,DL4006
 RUN echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" \
@@ -17,6 +21,7 @@ RUN echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula sele
     fonts-liberation \
     fonts-crosextra-carlito \
     fonts-crosextra-caladea \
+    fonts-urw-base35 \
     fonts-noto-core \
     fonts-noto-extra \
     fontconfig \
@@ -28,6 +33,9 @@ COPY LiberationSansNarrow-*.ttf /usr/local/share/fonts/
 
 # Install barcode font
 COPY 3OF9.TTF /usr/local/share/fonts/3OF9.TTF
+
+# CourierPS -> Nimbus Mono PS alias (see courierps.conf).
+COPY courierps.conf /etc/fonts/conf.d/99-courierps.conf
 
 # Rebuild font cache
 RUN fc-cache -fv

--- a/infra/docker/gotenberg/courierps.conf
+++ b/infra/docker/gotenberg/courierps.conf
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<!-- Map CourierPS to Nimbus Mono PS; required by disc-printing RTF templates. -->
+<fontconfig>
+  <alias binding="strong">
+    <family>CourierPS</family>
+    <accept><family>Nimbus Mono PS</family></accept>
+    <default><family>monospace</family></default>
+  </alias>
+</fontconfig>


### PR DESCRIPTION
## Description

PSV (and Goods) disc RTF templates declare \f30/\f28 as CourierPS. The image had no CourierPS and no alias, so LibreOffice substituted Noto Sans (proportional), breaking the snippet's whitespace-based positioning and overflowing the bottom row of discs onto a second page. Install fonts-urw-base35 (Nimbus Mono PS, the URW++ free clone) and route CourierPS to it via fontconfig.

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
