### PR TITLE
feat: add git-secrets pre-commit hook and CI workflow

### DIFF
--- a/.github/workflows/secrets-scan.yaml
+++ b/.github/workflows/secrets-scan.yaml
@@ -1,0 +1,22 @@
+name: Secrets scan
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: 0 0 * * 1
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  secrets:
+    # TEMP — pinned to feature branch while the dvsa/.github PR is open.
+    # Flip back to @main before merging this PR.
+    uses: dvsa/.github/.github/workflows/secrets-scan.yaml@vol-6349-secrets-scan
+    with:
+      # Full-history scan on the weekly cron run; PRs scan working tree only.
+      scan-history: ${{ github.event_name == 'schedule' }}

--- a/.github/workflows/secrets-scan.yaml
+++ b/.github/workflows/secrets-scan.yaml
@@ -14,9 +14,7 @@ permissions:
 
 jobs:
   secrets:
-    # TEMP — pinned to feature branch while the dvsa/.github PR is open.
-    # Flip back to @main before merging this PR.
-    uses: dvsa/.github/.github/workflows/secrets-scan.yaml@vol-6349-secrets-scan
+    uses: dvsa/.github/.github/workflows/secrets-scan.yaml@v5.0.11
     with:
       # Full-history scan on the weekly cron run; PRs scan working tree only.
       scan-history: ${{ github.event_name == 'schedule' }}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,16 @@
 npx --no -- lint-staged
+
+# VOL-6349 — local secrets scan via git-secrets (DVSA standard).
+# Skip cleanly if git-secrets isn't installed locally; CI is the
+# authoritative gate.
+if command -v git-secrets >/dev/null 2>&1; then
+  # Patterns are registered into the repo's git config the first time
+  # this runs; the call is idempotent.
+  git secrets --register-aws --global >/dev/null 2>&1 || true
+  git secrets --pre_commit_hook -- "$@"
+else
+  printf '\033[33mvol-app: git-secrets not on PATH — skipping local secrets scan.\033[0m\n'
+  printf '  Install it to enable pre-commit secret detection:\n'
+  printf '    macOS:  brew install git-secrets\n'
+  printf '    Other:  https://github.com/awslabs/git-secrets#installing-git-secrets\n'
+fi

--- a/docs/secrets-scanning.md
+++ b/docs/secrets-scanning.md
@@ -1,0 +1,33 @@
+# Secrets scanning
+
+We scan for accidentally-committed secrets in two places:
+
+1. **Locally** — `git-secrets` pre-commit hook (via husky).
+2. **In CI** — shared `dvsa/.github` reusable workflow.
+
+Standardised on [`awslabs/git-secrets`](https://github.com/awslabs/git-secrets)
+with the `--register-aws` pattern set, matching the convention used
+across DVSA.
+
+## Install
+
+    brew install git-secrets                  # macOS
+    # https://github.com/awslabs/git-secrets#installing-git-secrets
+
+After cloning vol-app, `npm install` registers the husky pre-commit
+hook automatically. The hook scans staged content per commit. If
+git-secrets isn't on your machine the hook prints a hint and skips —
+CI is the authoritative gate.
+
+## Allow-listing false positives
+
+Add a regex per line to `.gitallowed` at the repo root; git-secrets
+reads it automatically. Prefer this over `git config --add
+secrets.allowed` so the rest of the team gets the same rule.
+
+## When a real secret slips through
+
+1. **Rotate the credential first** — assume it has been read.
+2. Open a security ticket.
+3. Purge from history with `git filter-repo`. Coordinate with
+   anyone holding open branches before force-pushing.


### PR DESCRIPTION
## Description

Husky hook bits and github actions workflow to trigger git-secrets. Local git hooks have also been implemented, adding to pipelines as a seconadary check/backstop.

Related issue: VOL-6479

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
