### PR TITLE
fix: remove validation for verify mandate when print sign and return fall back is selected VOL-6555

### DIFF
--- a/app/selfserve/module/Olcs/src/Controller/Lva/AbstractUndertakingsController.php
+++ b/app/selfserve/module/Olcs/src/Controller/Lva/AbstractUndertakingsController.php
@@ -96,6 +96,16 @@ abstract class AbstractUndertakingsController extends AbstractController
 
             $data = (array) $request->getPost();
             $form->setData($data);
+
+            $fieldset = $form->getInputFilter()->get('declarationsAndUndertakings');
+
+            if (
+                isset($data['declarationsAndUndertakings']['printSignReturnFallBack']) &&
+                $fieldset->has('signatureVerifyMandate')
+            ) {
+                $fieldset->remove('signatureVerifyMandate');
+            }
+
             if ($form->isValid()) {
                 if ($this->isButtonPressed('submitAndPay') || $this->isButtonPressed('submit')) {
                     $shouldCompleteSection = true;

--- a/app/selfserve/module/Olcs/src/Controller/Lva/AbstractUndertakingsController.php
+++ b/app/selfserve/module/Olcs/src/Controller/Lva/AbstractUndertakingsController.php
@@ -95,7 +95,6 @@ abstract class AbstractUndertakingsController extends AbstractController
             }
 
             $data = (array) $request->getPost();
-            $form->setData($data);
 
             $fieldset = $form->getInputFilter()->get('declarationsAndUndertakings');
 
@@ -106,6 +105,7 @@ abstract class AbstractUndertakingsController extends AbstractController
                 $fieldset->remove('signatureVerifyMandate');
             }
 
+            $form->setData($data);
             if ($form->isValid()) {
                 if ($this->isButtonPressed('submitAndPay') || $this->isButtonPressed('submit')) {
                     $shouldCompleteSection = true;


### PR DESCRIPTION
## Description

<!--
If fallback (Print, sign and return) is selected, remove validation for verify (Gov login) mandate
-->

Related issue: [VOL-6555](https://dvsa.atlassian.net/browse/VOL-6555)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-6555]: https://dvsa.atlassian.net/browse/VOL-6555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ