### PR TITLE
fix: impoundings for N&P now published correctly VOL-3820

### DIFF
--- a/app/api/module/Api/src/Domain/CommandHandler/Publication/Impounding.php
+++ b/app/api/module/Api/src/Domain/CommandHandler/Publication/Impounding.php
@@ -93,7 +93,10 @@ class Impounding extends AbstractCommandHandler implements TransactionedInterfac
 
         //no N&P for Northern Ireland, this is already defaulted to published, no need to record it twice below
         if (
-            ($trafficArea->getId() !== TrafficAreaEntity::NORTHERN_IRELAND_TRAFFIC_AREA_CODE)
+            !(
+                $trafficArea->getId() === TrafficAreaEntity::NORTHERN_IRELAND_TRAFFIC_AREA_CODE &&
+                $pubType === 'N&P'
+            )
         ) {
             //record that we've dealt with this traffic area and pub type combination
             $publishedAreas[$trafficArea->getId()][$pubType] = true;

--- a/app/api/module/Api/src/Domain/CommandHandler/Publication/Impounding.php
+++ b/app/api/module/Api/src/Domain/CommandHandler/Publication/Impounding.php
@@ -93,8 +93,7 @@ class Impounding extends AbstractCommandHandler implements TransactionedInterfac
 
         //no N&P for Northern Ireland, this is already defaulted to published, no need to record it twice below
         if (
-            ($trafficArea->getId() !== TrafficAreaEntity::NORTHERN_IRELAND_TRAFFIC_AREA_CODE) &&
-            ($pubType !== 'N&P')
+            ($trafficArea->getId() !== TrafficAreaEntity::NORTHERN_IRELAND_TRAFFIC_AREA_CODE)
         ) {
             //record that we've dealt with this traffic area and pub type combination
             $publishedAreas[$trafficArea->getId()][$pubType] = true;

--- a/app/api/test/module/Api/src/Domain/CommandHandler/Publication/ImpoundingTest.php
+++ b/app/api/test/module/Api/src/Domain/CommandHandler/Publication/ImpoundingTest.php
@@ -29,6 +29,7 @@ use Dvsa\Olcs\Api\Entity\Publication\PublicationPoliceData as PoliceEntity;
 use Dvsa\Olcs\Api\Service\Publication\PublicationGenerator;
 use Dvsa\Olcs\Api\Domain\Command\Result as ResultCmd;
 use Dvsa\Olcs\Api\Domain\Query\Bookmark\UnpublishedImpounding as UnpublishedImpoundingQry;
+use Dvsa\Olcs\Api\Entity\Venue as VenuEntity;
 
 /**
  * Publish Impounding Test
@@ -121,6 +122,13 @@ class ImpoundingTest extends AbstractCommandHandlerTestCase
         $impoundingMock->shouldReceive('getCase')->andReturn($caseMock);
         $impoundingMock->shouldReceive('getId')->andReturn($impoundingId);
 
+        $venueMock = m::mock(VenueEntity::class);
+        $venueMock->shouldReceive('getId')->andReturn(1);
+
+        $impoundingMock->shouldReceive('getVenue')->once()->andReturn($venueMock);
+        $impoundingMock->shouldReceive('getHearingDate')->once()->andReturn(null);
+        $impoundingMock->shouldReceive('getVenueOther')->andReturn(null);
+
         $publicationMock = $this->getPublicationMock($publicationId);
 
         $publicationLinkMock = m::mock(PublicationLinkEntity::class)->makePartial();
@@ -154,11 +162,18 @@ class ImpoundingTest extends AbstractCommandHandlerTestCase
         $this->repoMap['PublicationLink']
             ->shouldReceive('fetchSingleUnpublished')
             ->with(m::type(UnpublishedImpoundingQry::class))
-            ->andReturn($publicationLinkMock)
+            ->andReturn($publicationLinkMock);
+
+        $this->repoMap['PublicationLink']
             ->shouldReceive('save')
-            ->with(m::type(PublicationLinkEntity::class))
-            ->shouldReceive('delete')
-            ->with(m::type(PublicationLinkEntity::class));
+            ->withAnyArgs()
+            ->once();
+
+        $this->mockedSmServices[PublicationGenerator::class]
+            ->shouldReceive('createPublication')
+            ->once()
+            ->withAnyArgs()
+            ->andReturn($publicationMock);
 
         $result = $this->sut->handleCommand($command);
 
@@ -200,6 +215,13 @@ class ImpoundingTest extends AbstractCommandHandlerTestCase
         $impoundingMock->shouldReceive('getCase')->andReturn($caseMock);
         $impoundingMock->shouldReceive('getId')->andReturn($impoundingId);
 
+        $venueMock = m::mock(VenueEntity::class);
+        $venueMock->shouldReceive('getId')->andReturn(1);
+
+        $impoundingMock->shouldReceive('getVenue')->once()->andReturn($venueMock);
+        $impoundingMock->shouldReceive('getHearingDate')->once()->andReturn(null);
+        $impoundingMock->shouldReceive('getVenueOther')->andReturn(null);
+
         $publicationMock = $this->getPublicationMock($publicationId);
 
         $publicationLinkMock = m::mock(PublicationLinkEntity::class)->makePartial();
@@ -233,11 +255,18 @@ class ImpoundingTest extends AbstractCommandHandlerTestCase
         $this->repoMap['PublicationLink']
             ->shouldReceive('fetchSingleUnpublished')
             ->with(m::type(UnpublishedImpoundingQry::class))
-            ->andReturn($publicationLinkMock)
+            ->andReturn($publicationLinkMock);
+
+        $this->repoMap['PublicationLink']
             ->shouldReceive('save')
-            ->with(m::type(PublicationLinkEntity::class))
-            ->shouldReceive('delete')
-            ->with(m::type(PublicationLinkEntity::class));
+            ->withAnyArgs()
+            ->once();
+
+        $this->mockedSmServices[PublicationGenerator::class]
+            ->shouldReceive('createPublication')
+            ->once()
+            ->withAnyArgs()
+            ->andReturn($publicationMock);
 
         $result = $this->sut->handleCommand($command);
 
@@ -280,11 +309,18 @@ class ImpoundingTest extends AbstractCommandHandlerTestCase
         $impoundingMock->shouldReceive('getCase')->andReturn($caseMock);
         $impoundingMock->shouldReceive('getId')->andReturn($impoundingId);
 
+        $venueMock = m::mock(VenueEntity::class);
+        $venueMock->shouldReceive('getId')->andReturn(1);
+
+        $impoundingMock->shouldReceive('getVenue')->once()->andReturn($venueMock);
+        $impoundingMock->shouldReceive('getHearingDate')->once()->andReturn(null);
+        $impoundingMock->shouldReceive('getVenueOther')->andReturn(null);
+
         $publicationMock = $this->getPublicationMock($publicationId);
 
         $publicationLinkMock = m::mock(PublicationLinkEntity::class)->makePartial();
         $publicationLinkMock->shouldReceive('getId')->andReturn(1);
-        $publicationLinkMock->shouldReceive('getPoliceDatas->clear')->times(5)->andReturnSelf();
+        $publicationLinkMock->shouldReceive('getPoliceDatas->clear')->times(4)->andReturnSelf();
 
         $this->references[ApplicationEntity::class][1]->shouldReceive('getLicence')
             ->andReturn($this->references[LicenceEntity::class][7]);
@@ -315,9 +351,23 @@ class ImpoundingTest extends AbstractCommandHandlerTestCase
         $this->repoMap['PublicationLink']
             ->shouldReceive('fetchSingleUnpublished')
             ->with(m::type(UnpublishedImpoundingQry::class))
-            ->andReturn($publicationLinkMock)
+            ->andReturn($publicationLinkMock);
+
+        $this->repoMap['PublicationLink']
+            ->shouldReceive('save')
+            ->withAnyArgs()
+            ->once();
+
+        $this->repoMap['PublicationLink']
             ->shouldReceive('delete')
-            ->with(m::type(PublicationLinkEntity::class));
+            ->with(m::type(PublicationLinkEntity::class))
+            ->times(4);
+
+        $this->mockedSmServices[PublicationGenerator::class]
+            ->shouldReceive('createPublication')
+            ->once()
+            ->withAnyArgs()
+            ->andReturn($publicationMock);
 
         $result = $this->sut->handleCommand($command);
 

--- a/app/api/test/module/Api/src/Domain/CommandHandler/Publication/ImpoundingTest.php
+++ b/app/api/test/module/Api/src/Domain/CommandHandler/Publication/ImpoundingTest.php
@@ -29,7 +29,7 @@ use Dvsa\Olcs\Api\Entity\Publication\PublicationPoliceData as PoliceEntity;
 use Dvsa\Olcs\Api\Service\Publication\PublicationGenerator;
 use Dvsa\Olcs\Api\Domain\Command\Result as ResultCmd;
 use Dvsa\Olcs\Api\Domain\Query\Bookmark\UnpublishedImpounding as UnpublishedImpoundingQry;
-use Dvsa\Olcs\Api\Entity\Venue as VenuEntity;
+use Dvsa\Olcs\Api\Entity\Venue as VenueEntity;
 
 /**
  * Publish Impounding Test


### PR DESCRIPTION
## Description

<!--
Creating publication for PSV impounding hearings cases (which use publication type ‘N&P’). This was not previously handled correctly, whereas Goods cases already work as expected since they use publication type ‘A&D’.
-->

Related issue: [VOL-3820](https://dvsa.atlassian.net/browse/VOL-3820)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-3820]: https://dvsa.atlassian.net/browse/VOL-3820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ