### PR TITLE
fix: typo in base64 command

### DIFF
--- a/infra/docker/cli/scripts/data_refresh/resetServicePassword.sh
+++ b/infra/docker/cli/scripts/data_refresh/resetServicePassword.sh
@@ -64,7 +64,7 @@ tail -n +2 "$conf_file"  | head -n -1 | while read -r line || [[ -n "$line" ]]; 
         --ciphertext-blob fileb://"$blob_file"  \
         --query Plaintext \
         --output text \
-        --region "$awsRegion" | base64 --d)
+        --region "$awsRegion" | base64 -d)
 
     # Escape single quotes for SQL safety
     rdsUserEscaped=${rdsUser//\'/\'\'}


### PR DESCRIPTION
## Description

Corrects base64 syntax for Alpine compatibility and fixes a flag typo in the decryption loop.

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
