### PR TITLE
chore: bumped phpseclib to 3.0.52, fixes security advisory VOL-7251

### DIFF
--- a/app/api/composer.lock
+++ b/app/api/composer.lock
@@ -6486,16 +6486,16 @@
     },
     {
       "name": "phpseclib/phpseclib",
-      "version": "3.0.51",
+      "version": "3.0.52",
       "source": {
         "type": "git",
         "url": "https://github.com/phpseclib/phpseclib.git",
-        "reference": "d59c94077f9c9915abb51ddb52ce85188ece1748"
+        "reference": "2adaefc83df2ec548558307690f376dd7d4f4fce"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/d59c94077f9c9915abb51ddb52ce85188ece1748",
-        "reference": "d59c94077f9c9915abb51ddb52ce85188ece1748",
+        "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/2adaefc83df2ec548558307690f376dd7d4f4fce",
+        "reference": "2adaefc83df2ec548558307690f376dd7d4f4fce",
         "shasum": ""
       },
       "require": {
@@ -6572,7 +6572,7 @@
       ],
       "support": {
         "issues": "https://github.com/phpseclib/phpseclib/issues",
-        "source": "https://github.com/phpseclib/phpseclib/tree/3.0.51"
+        "source": "https://github.com/phpseclib/phpseclib/tree/3.0.52"
       },
       "funding": [
         {
@@ -6588,7 +6588,7 @@
           "type": "tidelift"
         }
       ],
-      "time": "2026-04-10T01:33:53+00:00"
+      "time": "2026-04-27T07:02:15+00:00"
     },
     {
       "name": "psr/cache",
@@ -14645,5 +14645,5 @@
   "platform-overrides": {
     "ext-redis": "6.2.6"
   },
-  "plugin-api-version": "2.9.0"
+  "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## Description

<!--
Include a summary of the change here.
-->

Related issue: [VOL-7251](https://dvsa.atlassian.net/browse/VOL-7251)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-7251]: https://dvsa.atlassian.net/browse/VOL-7251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ