### PR TITLE
feat: 6663 added infra secrets to batch job

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -12,7 +12,8 @@ locals {
         "secretsmanager:GetSecretValue"
       ]
       resources = [
-        data.aws_secretsmanager_secret.this["api"].arn
+        data.aws_secretsmanager_secret.this["api"].arn,
+        data.aws_secretsmanager_secret.infra.arn
       ]
     },
   ]
@@ -199,6 +200,10 @@ data "aws_secretsmanager_secret" "this" {
   for_each = toset(setsubtract(local.service_names, ["cli"]))
 
   name = "DEVAPPDEV-BASE-SM-APPLICATION-${upper(each.key)}"
+}
+
+data "aws_secretsmanager_secret" "infra" {
+  name = "DEVAPPDEV-BASE-SM-INFRA"
 }
 
 data "aws_cognito_user_pools" "this" {

--- a/infra/terraform/environments/int/main.tf
+++ b/infra/terraform/environments/int/main.tf
@@ -12,7 +12,8 @@ locals {
         "secretsmanager:GetSecretValue"
       ]
       resources = [
-        data.aws_secretsmanager_secret.this["api"].arn
+        data.aws_secretsmanager_secret.this["api"].arn,
+        data.aws_secretsmanager_secret.infra.arn
       ]
     },
   ]
@@ -131,6 +132,10 @@ data "aws_secretsmanager_secret" "this" {
   for_each = toset(setsubtract(local.service_names, ["cli"]))
 
   name = "DEVAPPQA-BASE-SM-APPLICATION-${upper(each.key)}"
+}
+
+data "aws_secretsmanager_secret" "infra" {
+  name = "DEVAPPQA-BASE-SM-INFRA"
 }
 
 data "aws_cognito_user_pools" "this" {

--- a/infra/terraform/environments/prep/main.tf
+++ b/infra/terraform/environments/prep/main.tf
@@ -12,7 +12,8 @@ locals {
         "secretsmanager:GetSecretValue"
       ]
       resources = [
-        data.aws_secretsmanager_secret.this["api"].arn
+        data.aws_secretsmanager_secret.this["api"].arn,
+        data.aws_secretsmanager_secret.infra.arn
       ]
     },
   ]
@@ -134,6 +135,9 @@ data "aws_secretsmanager_secret" "this" {
   name = "APPPP-BASE-SM-APPLICATION-${upper(each.key)}"
 }
 
+data "aws_secretsmanager_secret" "infra" {
+  name = "APPPP-BASE-SM-INFRA"
+}
 data "aws_cognito_user_pools" "this" {
   name = "DVSA-APPPP-COGNITO-USERS"
 }

--- a/infra/terraform/environments/prod/main.tf
+++ b/infra/terraform/environments/prod/main.tf
@@ -13,7 +13,8 @@ locals {
         "secretsmanager:GetSecretValue"
       ]
       resources = [
-        data.aws_secretsmanager_secret.this["api"].arn
+        data.aws_secretsmanager_secret.this["api"].arn,
+        data.aws_secretsmanager_secret.infra.arn
       ]
     },
   ]
@@ -200,6 +201,10 @@ data "aws_secretsmanager_secret" "this" {
   for_each = toset(setsubtract(local.service_names, ["cli"]))
 
   name = "APP-BASE-SM-APPLICATION-${upper(each.key)}"
+}
+
+data "aws_secretsmanager_secret" "infra" {
+  name = "APP-BASE-SM-INFRA"
 }
 
 data "aws_cognito_user_pools" "this" {

--- a/infra/terraform/modules/service/README.md
+++ b/infra/terraform/modules/service/README.md
@@ -52,6 +52,7 @@
 | [aws_route53_zone.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [aws_s3_bucket.assets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 | [aws_secretsmanager_secret.application_api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
+| [aws_secretsmanager_secret.infra](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
 | [aws_subnet.api_subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 | [aws_subnet.batch_subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 

--- a/infra/terraform/modules/service/batch.tf
+++ b/infra/terraform/modules/service/batch.tf
@@ -4,6 +4,10 @@ data "aws_secretsmanager_secret" "application_api" {
   name = "${local.account_prefix}${local.env_prefix}-BASE-SM-APPLICATION-API"
 }
 
+data "aws_secretsmanager_secret" "infra" {
+  name = "${local.account_prefix}${local.env_prefix}-BASE-SM-INFRA"
+}
+
 locals {
 
   account_prefix = contains(["DEV", "QA"], var.legacy_environment) ? "DEV" : ""
@@ -126,6 +130,10 @@ locals {
           valueFrom = "${data.aws_secretsmanager_secret.application_api.arn}:olcs_batch_rds_password::"
         },
         {
+          name      = "M_DB_PASSWORD"
+          valueFrom = "${data.aws_secretsmanager_secret.infra.arn}:master_rds_password::"
+        },
+        {
           name      = "PRODTODEV_ASSUME_ROLE_ID"
           valueFrom = "${data.aws_secretsmanager_secret.application_api.arn}:nonprod_assume_external_id::"
         },
@@ -185,6 +193,10 @@ locals {
         {
           name      = "BATCH_DB_PASSWORD"
           valueFrom = "${data.aws_secretsmanager_secret.application_api.arn}:olcs_batch_rds_password::"
+        },
+        {
+          name      = "M_DB_PASSWORD"
+          valueFrom = "${data.aws_secretsmanager_secret.infra.arn}:master_rds_password::"
         },
         {
           name      = "PRODTODEV_ASSUME_ROLE_ID"


### PR DESCRIPTION
## Description

This PR gives the batch jobs the ability to pul secrets from the new infra secrets manager secrets only at startup.

<!--
Include a summary of the change here.
-->

Related issue: https://dvsa.atlassian.net/browse/VOL-6663

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
