### PR TITLE
fix: use addIndicesByName to avoid Elastica 7.2 deprecation breaking …

### DIFF
--- a/app/api/module/Db/src/Service/Search/Search.php
+++ b/app/api/module/Db/src/Service/Search/Search.php
@@ -178,7 +178,7 @@ class Search implements AuthAwareInterface
         $es = new \Elastica\Search($this->getClient());
 
         // Add indices, otherwise search is executed against all indices
-        $es->addIndices($indexes);
+        $es->addIndicesByName($indexes);
 
         $response = [];
         $resultSet = $es->search($elasticaQuery);


### PR DESCRIPTION
…search

## Description

`Elastica\Search::addIndices()` with an array of strings has been deprecated since ruflin/elastica 7.2 and now triggers a deprecation that gets serialised onto the API response body after the valid JSON envelope, leaving the client unable to parse the response and causing a TypeError in `Common\Service\Data\Search\Search::setFilterOptionValues()` when $data['Filters'] ends up null. Switching to `addIndicesByName`, the documented replacement for string[] input, restores a clean JSON response.

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
