### PR TITLE
fix: handle errors similarly to laminas-log but write a tag

### DIFF
--- a/app/api/module/Api/src/Entity/Types/YesNoType.php
+++ b/app/api/module/Api/src/Entity/Types/YesNoType.php
@@ -56,7 +56,12 @@ class YesNoType extends Type
     {
         unset($platform);
 
-        return (strtoupper($value) == 'Y' || strtoupper($value) == 'YES') ? 1 : 0;
+        if ($value === null) {
+            return 0;
+        }
+
+        $upper = strtoupper((string) $value);
+        return ($upper === 'Y' || $upper === 'YES') ? 1 : 0;
     }
 
     #[\Override]

--- a/app/api/module/Snapshot/src/Service/Snapshots/ApplicationReview/Section/VehiclesSizeReviewService.php
+++ b/app/api/module/Snapshot/src/Service/Snapshots/ApplicationReview/Section/VehiclesSizeReviewService.php
@@ -14,7 +14,7 @@ class VehiclesSizeReviewService extends AbstractReviewService
                 [
                     [
                         'label' => 'application-review-vehicles-declarations-vs',
-                        'value' => $data['psvWhichVehicleSizes']['description'],
+                        'value' => $data['psvWhichVehicleSizes']['description'] ?? null,
                     ],
                 ],
             ],

--- a/app/api/public/index.php
+++ b/app/api/public/index.php
@@ -18,25 +18,51 @@ register_shutdown_function('handleFatal');
 function handleFatal()
 {
     $error = error_get_last();
-    if ($error) {
-        http_response_code(500);
+    if ($error === null) {
+        return;
+    }
 
-        if (ob_get_length() !== false) {
-            ob_clean();
+    // Levels PHP itself treats as terminal. Matches Monolog\ErrorHandler::FATAL_ERRORS.
+    $fatalMask = E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR;
+
+    if (($error['type'] & $fatalMask) === 0) {
+        // Non-fatal (warning / deprecation / notice). Pre-monolog, laminas-log's
+        // error handler returned true for every level, so error_get_last() was
+        // null at shutdown and we exited cleanly. Monolog returns false for
+        // non-fatal levels, leaving error_get_last() populated. Surface a single
+        // tagged log entry per request so these are easy to triage in CloudWatch.
+        if (class_exists(\Olcs\Logging\Log\Logger::class)) {
+            \Olcs\Logging\Log\Logger::warn(
+                'NON_FATAL_AT_SHUTDOWN: ' . $error['message'],
+                [
+                    'tag' => 'non-fatal-at-shutdown',
+                    'errno' => $error['type'],
+                    'file' => $error['file'],
+                    'line' => $error['line'],
+                    'url' => $_SERVER['REQUEST_URI'] ?? null,
+                ]
+            );
         }
+        return;
+    }
 
-        echo json_encode(
-            [
-                'messages' => [
-                    'An unexpected fatal error occurred' => [
-                        $error['message'],
-                        $error['file'] . ': ' . $error['line']
-                    ]
+    http_response_code(500);
+
+    if (ob_get_length() !== false) {
+        ob_clean();
+    }
+
+    echo json_encode(
+        [
+            'messages' => [
+                'An unexpected fatal error occurred' => [
+                    $error['message'],
+                    $error['file'] . ': ' . $error['line']
                 ]
             ]
-        );
-        exit;
-    }
+        ]
+    );
+    exit;
 }
 
 // Decline static file requests back to the PHP built-in webserver

--- a/app/api/test/module/Api/src/Entity/Types/YesNoTypeTest.php
+++ b/app/api/test/module/Api/src/Entity/Types/YesNoTypeTest.php
@@ -82,7 +82,8 @@ class YesNoTypeTest extends \PHPUnit\Framework\TestCase
             ['N', 0],
             ['No', 0],
             ['NO', 0],
-            ['no', 0]
+            ['no', 0],
+            [null, 0],
         ];
     }
 


### PR DESCRIPTION
## Description

Update app to handle some non-fatal errors same way as laminas-log, but log them with a tag for triage/fix asap.

Fix two bugs surfaced by monolog errors (YesNo type and VehicleSizeReviewService

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
