### PR TITLE
feat: remove laminas-mvc-i18n package VOL-7235

### DIFF
--- a/app/api/composer.json
+++ b/app/api/composer.json
@@ -38,7 +38,6 @@
     "twig/twig": "^3.21",
     "lm-commons/lmc-rbac-mvc": "^3.5",
     "laminas/laminas-mvc": "^3.8",
-    "laminas/laminas-mvc-i18n": "^1.9",
     "laminas/laminas-servicemanager": "^3.24",
     "laminas/laminas-http": "^2.22",
     "laminas/laminas-view": "^2.43",

--- a/app/api/composer.lock
+++ b/app/api/composer.lock
@@ -7824,16 +7824,16 @@
     },
     {
       "name": "symfony/cache",
-      "version": "v5.4.46",
+      "version": "v5.4.52",
       "source": {
         "type": "git",
         "url": "https://github.com/symfony/cache.git",
-        "reference": "0fe08ee32cec2748fbfea10c52d3ee02049e0f6b"
+        "reference": "03b191dda148c490b5b3929eaac827ee64f1d421"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/symfony/cache/zipball/0fe08ee32cec2748fbfea10c52d3ee02049e0f6b",
-        "reference": "0fe08ee32cec2748fbfea10c52d3ee02049e0f6b",
+        "url": "https://api.github.com/repos/symfony/cache/zipball/03b191dda148c490b5b3929eaac827ee64f1d421",
+        "reference": "03b191dda148c490b5b3929eaac827ee64f1d421",
         "shasum": ""
       },
       "require": {
@@ -7894,7 +7894,7 @@
       "homepage": "https://symfony.com",
       "keywords": ["caching", "psr6"],
       "support": {
-        "source": "https://github.com/symfony/cache/tree/v5.4.46"
+        "source": "https://github.com/symfony/cache/tree/v5.4.52"
       },
       "funding": [
         {
@@ -7906,11 +7906,15 @@
           "type": "github"
         },
         {
+          "url": "https://github.com/nicolas-grekas",
+          "type": "github"
+        },
+        {
           "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
           "type": "tidelift"
         }
       ],
-      "time": "2024-11-04T11:43:55+00:00"
+      "time": "2026-05-15T06:40:15+00:00"
     },
     {
       "name": "symfony/cache-contracts",
@@ -8578,16 +8582,16 @@
     },
     {
       "name": "symfony/mailer",
-      "version": "v7.4.4",
+      "version": "v7.4.12",
       "source": {
         "type": "git",
         "url": "https://github.com/symfony/mailer.git",
-        "reference": "7b750074c40c694ceb34cb926d6dffee231c5cd6"
+        "reference": "5cefb712a25f320579615ba9e1942abaeade7dff"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/symfony/mailer/zipball/7b750074c40c694ceb34cb926d6dffee231c5cd6",
-        "reference": "7b750074c40c694ceb34cb926d6dffee231c5cd6",
+        "url": "https://api.github.com/repos/symfony/mailer/zipball/5cefb712a25f320579615ba9e1942abaeade7dff",
+        "reference": "5cefb712a25f320579615ba9e1942abaeade7dff",
         "shasum": ""
       },
       "require": {
@@ -8634,7 +8638,7 @@
       "description": "Helps sending emails",
       "homepage": "https://symfony.com",
       "support": {
-        "source": "https://github.com/symfony/mailer/tree/v7.4.4"
+        "source": "https://github.com/symfony/mailer/tree/v7.4.12"
       },
       "funding": [
         {
@@ -8654,20 +8658,20 @@
           "type": "tidelift"
         }
       ],
-      "time": "2026-01-08T08:25:11+00:00"
+      "time": "2026-05-20T07:20:23+00:00"
     },
     {
       "name": "symfony/mime",
-      "version": "v7.4.5",
+      "version": "v7.4.12",
       "source": {
         "type": "git",
         "url": "https://github.com/symfony/mime.git",
-        "reference": "b18c7e6e9eee1e19958138df10412f3c4c316148"
+        "reference": "b198dd66c211c97119bcaaff7c13431dbbb5e470"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/symfony/mime/zipball/b18c7e6e9eee1e19958138df10412f3c4c316148",
-        "reference": "b18c7e6e9eee1e19958138df10412f3c4c316148",
+        "url": "https://api.github.com/repos/symfony/mime/zipball/b198dd66c211c97119bcaaff7c13431dbbb5e470",
+        "reference": "b198dd66c211c97119bcaaff7c13431dbbb5e470",
         "shasum": ""
       },
       "require": {
@@ -8678,7 +8682,7 @@
       },
       "conflict": {
         "egulias/email-validator": "~3.0.0",
-        "phpdocumentor/reflection-docblock": "<5.2|>=6",
+        "phpdocumentor/reflection-docblock": "<5.2|>=7",
         "phpdocumentor/type-resolver": "<1.5.1",
         "symfony/mailer": "<6.4",
         "symfony/serializer": "<6.4.3|>7.0,<7.0.3"
@@ -8686,7 +8690,7 @@
       "require-dev": {
         "egulias/email-validator": "^2.1.10|^3.1|^4",
         "league/html-to-markdown": "^5.0",
-        "phpdocumentor/reflection-docblock": "^5.2",
+        "phpdocumentor/reflection-docblock": "^5.2|^6.0",
         "symfony/dependency-injection": "^6.4|^7.0|^8.0",
         "symfony/process": "^6.4|^7.0|^8.0",
         "symfony/property-access": "^6.4|^7.0|^8.0",
@@ -8716,7 +8720,7 @@
       "homepage": "https://symfony.com",
       "keywords": ["mime", "mime-type"],
       "support": {
-        "source": "https://github.com/symfony/mime/tree/v7.4.5"
+        "source": "https://github.com/symfony/mime/tree/v7.4.12"
       },
       "funding": [
         {
@@ -8736,7 +8740,7 @@
           "type": "tidelift"
         }
       ],
-      "time": "2026-01-27T08:59:58+00:00"
+      "time": "2026-05-20T07:20:23+00:00"
     },
     {
       "name": "symfony/options-resolver",
@@ -9991,16 +9995,16 @@
     },
     {
       "name": "twig/twig",
-      "version": "v3.23.0",
+      "version": "v3.26.0",
       "source": {
         "type": "git",
         "url": "https://github.com/twigphp/Twig.git",
-        "reference": "a64dc5d2cc7d6cafb9347f6cd802d0d06d0351c9"
+        "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/twigphp/Twig/zipball/a64dc5d2cc7d6cafb9347f6cd802d0d06d0351c9",
-        "reference": "a64dc5d2cc7d6cafb9347f6cd802d0d06d0351c9",
+        "url": "https://api.github.com/repos/twigphp/Twig/zipball/1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
+        "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
         "shasum": ""
       },
       "require": {
@@ -10010,7 +10014,8 @@
         "symfony/polyfill-mbstring": "^1.3"
       },
       "require-dev": {
-        "phpstan/phpstan": "^2.0",
+        "php-cs-fixer/shim": "^3.0@stable",
+        "phpstan/phpstan": "^2.0@stable",
         "psr/container": "^1.0|^2.0",
         "symfony/phpunit-bridge": "^5.4.9|^6.4|^7.0"
       },
@@ -10050,7 +10055,7 @@
       "keywords": ["templating"],
       "support": {
         "issues": "https://github.com/twigphp/Twig/issues",
-        "source": "https://github.com/twigphp/Twig/tree/v3.23.0"
+        "source": "https://github.com/twigphp/Twig/tree/v3.26.0"
       },
       "funding": [
         {
@@ -10062,7 +10067,7 @@
           "type": "tidelift"
         }
       ],
-      "time": "2026-01-23T21:00:41+00:00"
+      "time": "2026-05-20T07:31:59+00:00"
     },
     {
       "name": "webimpress/safe-writer",

--- a/app/api/composer.lock
+++ b/app/api/composer.lock
@@ -4,7 +4,7 @@
     "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
     "This file is @generated automatically"
   ],
-  "content-hash": "7b168d17a042eb87d33617bf1093126a",
+  "content-hash": "4da1eaedb58532ce633c25a1c6a9776d",
   "packages": [
     {
       "name": "aws/aws-crt-php",
@@ -4360,78 +4360,6 @@
       "time": "2024-11-18T00:14:29+00:00"
     },
     {
-      "name": "laminas/laminas-mvc-i18n",
-      "version": "1.9.0",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/laminas/laminas-mvc-i18n.git",
-        "reference": "433e71e949438239cce814536711914a37544c42"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/laminas/laminas-mvc-i18n/zipball/433e71e949438239cce814536711914a37544c42",
-        "reference": "433e71e949438239cce814536711914a37544c42",
-        "shasum": ""
-      },
-      "require": {
-        "container-interop/container-interop": "^1.1",
-        "ext-intl": "*",
-        "laminas/laminas-i18n": "^2.13.0",
-        "laminas/laminas-router": "^3.5.0",
-        "laminas/laminas-servicemanager": "^3.15.1",
-        "laminas/laminas-stdlib": "^3.10.1",
-        "laminas/laminas-validator": "^2.19.0",
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
-      },
-      "conflict": {
-        "laminas/laminas-mvc": "<3.0.0",
-        "phpspec/prophecy": "<1.8.0",
-        "zendframework/zend-mvc-i18n": "*"
-      },
-      "require-dev": {
-        "laminas/laminas-coding-standard": "~2.5.0",
-        "phpspec/prophecy-phpunit": "^2.0.2",
-        "phpunit/phpunit": "^9.6.13",
-        "psalm/plugin-phpunit": "^0.19.0",
-        "vimeo/psalm": "^5.15"
-      },
-      "suggest": {
-        "laminas/laminas-cache": "To enable caching of translation strings"
-      },
-      "type": "library",
-      "extra": {
-        "laminas": {
-          "component": "Laminas\\Mvc\\I18n",
-          "config-provider": "Laminas\\Mvc\\I18n\\ConfigProvider"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "Laminas\\Mvc\\I18n\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": ["BSD-3-Clause"],
-      "description": "Integration between laminas-mvc and laminas-i18n",
-      "homepage": "https://laminas.dev",
-      "keywords": ["i18n", "laminas", "mvc"],
-      "support": {
-        "chat": "https://laminas.dev/chat",
-        "docs": "https://docs.laminas.dev/laminas-mvc-i18n/",
-        "forum": "https://discourse.laminas.dev",
-        "issues": "https://github.com/laminas/laminas-mvc-i18n/issues",
-        "rss": "https://github.com/laminas/laminas-mvc-i18n/releases.atom",
-        "source": "https://github.com/laminas/laminas-mvc-i18n"
-      },
-      "funding": [
-        {
-          "url": "https://funding.communitybridge.org/projects/laminas-project",
-          "type": "community_bridge"
-        }
-      ],
-      "time": "2024-10-11T09:36:44+00:00"
-    },
-    {
       "name": "laminas/laminas-paginator",
       "version": "2.22.0",
       "source": {
@@ -5889,25 +5817,24 @@
     },
     {
       "name": "olcs/olcs-utils",
-      "version": "v7.1.0",
+      "version": "v7.2.0",
       "source": {
         "type": "git",
         "url": "https://github.com/dvsa/olcs-utils.git",
-        "reference": "fd13f22e69c641472d0d027f6aa5c40282e24f60"
+        "reference": "3841ba670dacf036a869504dcab0fb25b4917e2a"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/dvsa/olcs-utils/zipball/fd13f22e69c641472d0d027f6aa5c40282e24f60",
-        "reference": "fd13f22e69c641472d0d027f6aa5c40282e24f60",
+        "url": "https://api.github.com/repos/dvsa/olcs-utils/zipball/3841ba670dacf036a869504dcab0fb25b4917e2a",
+        "reference": "3841ba670dacf036a869504dcab0fb25b4917e2a",
         "shasum": ""
       },
       "require": {
         "laminas/laminas-eventmanager": "^3.14",
         "laminas/laminas-http": "^2.22",
         "laminas/laminas-i18n": "^2.30",
-        "laminas/laminas-mvc": "^3.8",
-        "laminas/laminas-mvc-i18n": "^1.9",
         "laminas/laminas-servicemanager": "^3.23",
+        "laminas/laminas-validator": "^2.64",
         "laminas/laminas-view": "^2.41",
         "php": "~8.2.0 || ~8.3.0",
         "psr/container": "^1.1|^2.0"
@@ -5933,9 +5860,9 @@
       "notification-url": "https://packagist.org/downloads/",
       "description": "OLCS Utils",
       "support": {
-        "source": "https://github.com/dvsa/olcs-utils/tree/v7.1.0"
+        "source": "https://github.com/dvsa/olcs-utils/tree/v7.2.0"
       },
-      "time": "2026-05-05T21:46:20+00:00"
+      "time": "2026-05-20T19:24:07+00:00"
     },
     {
       "name": "olcs/olcs-xmltools",

--- a/app/api/config/application.config.php
+++ b/app/api/config/application.config.php
@@ -10,7 +10,6 @@ return [
         'Laminas\Cache\Storage\Adapter\Redis',
         'Laminas\Filter\Module',
         'Laminas\Validator\Module',
-        'Laminas\Mvc\I18n\Module',
         'Laminas\I18n\Module',
         'Dvsa\Olcs\Utils',
         'Dvsa\Olcs\Auth',

--- a/app/api/module/Snapshot/src/Module.php
+++ b/app/api/module/Snapshot/src/Module.php
@@ -8,7 +8,6 @@
 
 namespace Dvsa\Olcs\Snapshot;
 
-use Dvsa\Olcs\Utils\Translation\MissingTranslationProcessor;
 use Laminas\Cache\Storage\Adapter\Redis;
 use Laminas\I18n\Translator\Translator;
 
@@ -30,15 +29,6 @@ class Module
         $cache = $sm->get('default-cache');
         $translator = $sm->get('translator');
         $translator->setCache($cache);
-
-        $events = $e->getApplication()->getEventManager();
-
-        /** @var  MissingTranslationProcessor $missingTranslationProcessor */
-        $missingTranslationProcessor = $sm->get('Utils\MissingTranslationProcessor');
-        $missingTranslationProcessor->attach($events);
-
-        $translator->enableEventManager();
-        $translator->setEventManager($events);
     }
 
     public function getConfig()

--- a/app/api/test/module/Api/src/Domain/CommandHandler/TranslationKey/GenerateCacheTest.php
+++ b/app/api/test/module/Api/src/Domain/CommandHandler/TranslationKey/GenerateCacheTest.php
@@ -12,7 +12,7 @@ use Dvsa\Olcs\Transfer\Command\TranslationKey\GenerateCache as Cmd;
 use Dvsa\Olcs\Api\Domain\CommandHandler\TranslationKey\GenerateCache as Handler;
 use Dvsa\Olcs\Api\Service\Translator\TranslationLoader;
 use Mockery as m;
-use Laminas\Mvc\I18n\Translator;
+use Laminas\I18n\Translator\Translator;
 
 /**
  * Test cache generation for each locale

--- a/app/internal/composer.json
+++ b/app/internal/composer.json
@@ -17,7 +17,6 @@
     "laminas/laminas-i18n": "^2.32",
     "laminas/laminas-inputfilter": "^2.35",
     "laminas/laminas-mvc": "^3.8",
-    "laminas/laminas-mvc-i18n": "^1.9",
     "laminas/laminas-mvc-plugin-flashmessenger": "^1.11",
     "laminas/laminas-navigation": "^2.22",
     "laminas/laminas-servicemanager": "^3.4",

--- a/app/internal/composer.lock
+++ b/app/internal/composer.lock
@@ -4,7 +4,7 @@
     "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
     "This file is @generated automatically"
   ],
-  "content-hash": "2eaaf436af70e8f8c324acace17c8ada",
+  "content-hash": "f660dda42b67ec67e022e985d8c43f45",
   "packages": [
     {
       "name": "aws/aws-crt-php",
@@ -2880,78 +2880,6 @@
       "time": "2024-11-18T00:14:29+00:00"
     },
     {
-      "name": "laminas/laminas-mvc-i18n",
-      "version": "1.9.0",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/laminas/laminas-mvc-i18n.git",
-        "reference": "433e71e949438239cce814536711914a37544c42"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/laminas/laminas-mvc-i18n/zipball/433e71e949438239cce814536711914a37544c42",
-        "reference": "433e71e949438239cce814536711914a37544c42",
-        "shasum": ""
-      },
-      "require": {
-        "container-interop/container-interop": "^1.1",
-        "ext-intl": "*",
-        "laminas/laminas-i18n": "^2.13.0",
-        "laminas/laminas-router": "^3.5.0",
-        "laminas/laminas-servicemanager": "^3.15.1",
-        "laminas/laminas-stdlib": "^3.10.1",
-        "laminas/laminas-validator": "^2.19.0",
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
-      },
-      "conflict": {
-        "laminas/laminas-mvc": "<3.0.0",
-        "phpspec/prophecy": "<1.8.0",
-        "zendframework/zend-mvc-i18n": "*"
-      },
-      "require-dev": {
-        "laminas/laminas-coding-standard": "~2.5.0",
-        "phpspec/prophecy-phpunit": "^2.0.2",
-        "phpunit/phpunit": "^9.6.13",
-        "psalm/plugin-phpunit": "^0.19.0",
-        "vimeo/psalm": "^5.15"
-      },
-      "suggest": {
-        "laminas/laminas-cache": "To enable caching of translation strings"
-      },
-      "type": "library",
-      "extra": {
-        "laminas": {
-          "component": "Laminas\\Mvc\\I18n",
-          "config-provider": "Laminas\\Mvc\\I18n\\ConfigProvider"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "Laminas\\Mvc\\I18n\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": ["BSD-3-Clause"],
-      "description": "Integration between laminas-mvc and laminas-i18n",
-      "homepage": "https://laminas.dev",
-      "keywords": ["i18n", "laminas", "mvc"],
-      "support": {
-        "chat": "https://laminas.dev/chat",
-        "docs": "https://docs.laminas.dev/laminas-mvc-i18n/",
-        "forum": "https://discourse.laminas.dev",
-        "issues": "https://github.com/laminas/laminas-mvc-i18n/issues",
-        "rss": "https://github.com/laminas/laminas-mvc-i18n/releases.atom",
-        "source": "https://github.com/laminas/laminas-mvc-i18n"
-      },
-      "funding": [
-        {
-          "url": "https://funding.communitybridge.org/projects/laminas-project",
-          "type": "community_bridge"
-        }
-      ],
-      "time": "2024-10-11T09:36:44+00:00"
-    },
-    {
       "name": "laminas/laminas-mvc-plugin-flashmessenger",
       "version": "1.11.0",
       "source": {
@@ -4244,16 +4172,16 @@
     },
     {
       "name": "olcs/olcs-common",
-      "version": "v9.18.0",
+      "version": "v9.19.0",
       "source": {
         "type": "git",
         "url": "https://github.com/dvsa/olcs-common.git",
-        "reference": "9bcea2e510abb61aaddff074ec7ed76667482171"
+        "reference": "e77af082d0dd562f1e5bc884fbc16fbc98d44663"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/dvsa/olcs-common/zipball/9bcea2e510abb61aaddff074ec7ed76667482171",
-        "reference": "9bcea2e510abb61aaddff074ec7ed76667482171",
+        "url": "https://api.github.com/repos/dvsa/olcs-common/zipball/e77af082d0dd562f1e5bc884fbc16fbc98d44663",
+        "reference": "e77af082d0dd562f1e5bc884fbc16fbc98d44663",
         "shasum": ""
       },
       "require": {
@@ -4310,9 +4238,9 @@
       "notification-url": "https://packagist.org/downloads/",
       "description": "Common library for the OLCS Project",
       "support": {
-        "source": "https://github.com/dvsa/olcs-common/tree/v9.18.0"
+        "source": "https://github.com/dvsa/olcs-common/tree/v9.19.0"
       },
-      "time": "2026-05-19T09:21:17+00:00"
+      "time": "2026-05-20T19:24:26+00:00"
     },
     {
       "name": "olcs/olcs-logging",
@@ -4427,25 +4355,24 @@
     },
     {
       "name": "olcs/olcs-utils",
-      "version": "v7.1.0",
+      "version": "v7.2.0",
       "source": {
         "type": "git",
         "url": "https://github.com/dvsa/olcs-utils.git",
-        "reference": "fd13f22e69c641472d0d027f6aa5c40282e24f60"
+        "reference": "3841ba670dacf036a869504dcab0fb25b4917e2a"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/dvsa/olcs-utils/zipball/fd13f22e69c641472d0d027f6aa5c40282e24f60",
-        "reference": "fd13f22e69c641472d0d027f6aa5c40282e24f60",
+        "url": "https://api.github.com/repos/dvsa/olcs-utils/zipball/3841ba670dacf036a869504dcab0fb25b4917e2a",
+        "reference": "3841ba670dacf036a869504dcab0fb25b4917e2a",
         "shasum": ""
       },
       "require": {
         "laminas/laminas-eventmanager": "^3.14",
         "laminas/laminas-http": "^2.22",
         "laminas/laminas-i18n": "^2.30",
-        "laminas/laminas-mvc": "^3.8",
-        "laminas/laminas-mvc-i18n": "^1.9",
         "laminas/laminas-servicemanager": "^3.23",
+        "laminas/laminas-validator": "^2.64",
         "laminas/laminas-view": "^2.41",
         "php": "~8.2.0 || ~8.3.0",
         "psr/container": "^1.1|^2.0"
@@ -4471,9 +4398,9 @@
       "notification-url": "https://packagist.org/downloads/",
       "description": "OLCS Utils",
       "support": {
-        "source": "https://github.com/dvsa/olcs-utils/tree/v7.1.0"
+        "source": "https://github.com/dvsa/olcs-utils/tree/v7.2.0"
       },
-      "time": "2026-05-05T21:46:20+00:00"
+      "time": "2026-05-20T19:24:07+00:00"
     },
     {
       "name": "paragonie/constant_time_encoding",

--- a/app/selfserve/composer.lock
+++ b/app/selfserve/composer.lock
@@ -2822,78 +2822,6 @@
       "time": "2024-11-18T00:14:29+00:00"
     },
     {
-      "name": "laminas/laminas-mvc-i18n",
-      "version": "1.9.0",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/laminas/laminas-mvc-i18n.git",
-        "reference": "433e71e949438239cce814536711914a37544c42"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/laminas/laminas-mvc-i18n/zipball/433e71e949438239cce814536711914a37544c42",
-        "reference": "433e71e949438239cce814536711914a37544c42",
-        "shasum": ""
-      },
-      "require": {
-        "container-interop/container-interop": "^1.1",
-        "ext-intl": "*",
-        "laminas/laminas-i18n": "^2.13.0",
-        "laminas/laminas-router": "^3.5.0",
-        "laminas/laminas-servicemanager": "^3.15.1",
-        "laminas/laminas-stdlib": "^3.10.1",
-        "laminas/laminas-validator": "^2.19.0",
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
-      },
-      "conflict": {
-        "laminas/laminas-mvc": "<3.0.0",
-        "phpspec/prophecy": "<1.8.0",
-        "zendframework/zend-mvc-i18n": "*"
-      },
-      "require-dev": {
-        "laminas/laminas-coding-standard": "~2.5.0",
-        "phpspec/prophecy-phpunit": "^2.0.2",
-        "phpunit/phpunit": "^9.6.13",
-        "psalm/plugin-phpunit": "^0.19.0",
-        "vimeo/psalm": "^5.15"
-      },
-      "suggest": {
-        "laminas/laminas-cache": "To enable caching of translation strings"
-      },
-      "type": "library",
-      "extra": {
-        "laminas": {
-          "component": "Laminas\\Mvc\\I18n",
-          "config-provider": "Laminas\\Mvc\\I18n\\ConfigProvider"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "Laminas\\Mvc\\I18n\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": ["BSD-3-Clause"],
-      "description": "Integration between laminas-mvc and laminas-i18n",
-      "homepage": "https://laminas.dev",
-      "keywords": ["i18n", "laminas", "mvc"],
-      "support": {
-        "chat": "https://laminas.dev/chat",
-        "docs": "https://docs.laminas.dev/laminas-mvc-i18n/",
-        "forum": "https://discourse.laminas.dev",
-        "issues": "https://github.com/laminas/laminas-mvc-i18n/issues",
-        "rss": "https://github.com/laminas/laminas-mvc-i18n/releases.atom",
-        "source": "https://github.com/laminas/laminas-mvc-i18n"
-      },
-      "funding": [
-        {
-          "url": "https://funding.communitybridge.org/projects/laminas-project",
-          "type": "community_bridge"
-        }
-      ],
-      "time": "2024-10-11T09:36:44+00:00"
-    },
-    {
       "name": "laminas/laminas-mvc-plugin-flashmessenger",
       "version": "1.11.0",
       "source": {
@@ -4186,16 +4114,16 @@
     },
     {
       "name": "olcs/olcs-common",
-      "version": "v9.18.0",
+      "version": "v9.19.0",
       "source": {
         "type": "git",
         "url": "https://github.com/dvsa/olcs-common.git",
-        "reference": "9bcea2e510abb61aaddff074ec7ed76667482171"
+        "reference": "e77af082d0dd562f1e5bc884fbc16fbc98d44663"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/dvsa/olcs-common/zipball/9bcea2e510abb61aaddff074ec7ed76667482171",
-        "reference": "9bcea2e510abb61aaddff074ec7ed76667482171",
+        "url": "https://api.github.com/repos/dvsa/olcs-common/zipball/e77af082d0dd562f1e5bc884fbc16fbc98d44663",
+        "reference": "e77af082d0dd562f1e5bc884fbc16fbc98d44663",
         "shasum": ""
       },
       "require": {
@@ -4252,9 +4180,9 @@
       "notification-url": "https://packagist.org/downloads/",
       "description": "Common library for the OLCS Project",
       "support": {
-        "source": "https://github.com/dvsa/olcs-common/tree/v9.18.0"
+        "source": "https://github.com/dvsa/olcs-common/tree/v9.19.0"
       },
-      "time": "2026-05-19T09:21:17+00:00"
+      "time": "2026-05-20T19:24:26+00:00"
     },
     {
       "name": "olcs/olcs-logging",
@@ -4369,25 +4297,24 @@
     },
     {
       "name": "olcs/olcs-utils",
-      "version": "v7.1.0",
+      "version": "v7.2.0",
       "source": {
         "type": "git",
         "url": "https://github.com/dvsa/olcs-utils.git",
-        "reference": "fd13f22e69c641472d0d027f6aa5c40282e24f60"
+        "reference": "3841ba670dacf036a869504dcab0fb25b4917e2a"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/dvsa/olcs-utils/zipball/fd13f22e69c641472d0d027f6aa5c40282e24f60",
-        "reference": "fd13f22e69c641472d0d027f6aa5c40282e24f60",
+        "url": "https://api.github.com/repos/dvsa/olcs-utils/zipball/3841ba670dacf036a869504dcab0fb25b4917e2a",
+        "reference": "3841ba670dacf036a869504dcab0fb25b4917e2a",
         "shasum": ""
       },
       "require": {
         "laminas/laminas-eventmanager": "^3.14",
         "laminas/laminas-http": "^2.22",
         "laminas/laminas-i18n": "^2.30",
-        "laminas/laminas-mvc": "^3.8",
-        "laminas/laminas-mvc-i18n": "^1.9",
         "laminas/laminas-servicemanager": "^3.23",
+        "laminas/laminas-validator": "^2.64",
         "laminas/laminas-view": "^2.41",
         "php": "~8.2.0 || ~8.3.0",
         "psr/container": "^1.1|^2.0"
@@ -4413,9 +4340,9 @@
       "notification-url": "https://packagist.org/downloads/",
       "description": "OLCS Utils",
       "support": {
-        "source": "https://github.com/dvsa/olcs-utils/tree/v7.1.0"
+        "source": "https://github.com/dvsa/olcs-utils/tree/v7.2.0"
       },
-      "time": "2026-05-05T21:46:20+00:00"
+      "time": "2026-05-20T19:24:07+00:00"
     },
     {
       "name": "paragonie/constant_time_encoding",


### PR DESCRIPTION
## Description

Removes the abandoned laminas-mvc-i18n by introducing olcs-utils and olcs-common packages.

Note: have also bumped symfony/mailer, symfony/mime, symfony/cache and the twig package, as all 4 had security advisories.

Related issue: [VOL-7235](https://dvsa.atlassian.net/browse/VOL-7235)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-7235]: https://dvsa.atlassian.net/browse/VOL-7235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ