### PR TITLE
fix: vol 6117 restricted psv validation error message bug

### DIFF
--- a/app/api/module/Api/src/Domain/Service/OperatingCentreHelper.php
+++ b/app/api/module/Api/src/Domain/Service/OperatingCentreHelper.php
@@ -39,7 +39,7 @@ class OperatingCentreHelper implements FactoryInterface
     public const ERR_OC_AD_FI_1 = 'ERR_OC_AD_FI_1';
     public const ERR_OC_VR_1A = 'ERR_OC_VR_1A'; // with trailers
     public const ERR_OC_VR_1B = 'ERR_OC_VR_1B'; // without trailers
-    public const ERR_OR_R_TOO_MANY = 'ERR_OR_R_TOO_MANY';
+    public const ERR_OC_R_1 = 'ERR_OC_R_1';
     public const ERR_OC_PC_TA_NI = 'ERR_OC_PC_TA_NI';
     public const ERR_OC_PC_TA_GB = 'ERR_OC_PC_TA_GB';
     public const ERR_OC_PERMISSION = 'ERR_OC_PERMISSION';
@@ -82,7 +82,7 @@ class OperatingCentreHelper implements FactoryInterface
         $this->validateTrafficArea($entity, $command);
 
         if ($entity->isPsv() && $entity->isRestricted() && (int)$command->getNoOfVehiclesRequired() > 2) {
-            $this->addMessage('noOfVehiclesRequired', self::ERR_OR_R_TOO_MANY);
+            $this->addMessage('noOfVehiclesRequired', self::ERR_OC_R_1);
         }
 
         if ($entity->isPsv() && (int)$command->getNoOfVehiclesRequired() < 1) {

--- a/app/api/test/module/Api/src/Domain/Service/OperatingCentreHelperTest.php
+++ b/app/api/test/module/Api/src/Domain/Service/OperatingCentreHelperTest.php
@@ -676,7 +676,7 @@ class OperatingCentreHelperTest extends MockeryTestCase
                 [
                     'noOfVehiclesRequired' => [
                         [
-                            'ERR_OR_R_1' => 'ERR_OR_R_1'
+                            'ERR_OC_R_1' => 'ERR_OC_R_1'
                         ]
                     ],
                     'permission' => [

--- a/app/api/test/module/Api/src/Domain/Service/OperatingCentreHelperTest.php
+++ b/app/api/test/module/Api/src/Domain/Service/OperatingCentreHelperTest.php
@@ -580,7 +580,7 @@ class OperatingCentreHelperTest extends MockeryTestCase
                 [
                     'noOfVehiclesRequired' => [
                         [
-                            'ERR_OR_R_TOO_MANY' => 'ERR_OR_R_TOO_MANY'
+                            'ERR_OC_R_1' => 'ERR_OC_R_1'
                         ]
                     ]
                 ]
@@ -676,7 +676,7 @@ class OperatingCentreHelperTest extends MockeryTestCase
                 [
                     'noOfVehiclesRequired' => [
                         [
-                            'ERR_OR_R_TOO_MANY' => 'ERR_OR_R_TOO_MANY'
+                            'ERR_OR_R_1' => 'ERR_OR_R_1'
                         ]
                     ],
                     'permission' => [


### PR DESCRIPTION
## Description

Fixes the error message shown when too many vehicles are added on a restricted licence, which was displaying a hardcoded string instead of the translated message from the database. Updated the translation key grabbed from database to the correct message.

Related issue: [VOL-6117](https://dvsa.atlassian.net/browse/VOL-6117)
Related ticket: [OLCS-COMMON #313](https://github.com/dvsa/olcs-common/compare/vol-6117-restricted-psv-error-bug?expand=1)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-6117]: https://dvsa.atlassian.net/browse/VOL-6117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ