### PR TITLE
fix: provider issues with batch

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -396,7 +396,7 @@ module "service" {
 
     cli_repository       = data.aws_ecr_repository.this["cli"].repository_url
     liquibase_repository = data.aws_ecr_repository.sservice["liquibase"].repository_url
-    api_secret_file      = data.aws_secretsmanager_secret.this["api"].arn                         
+    api_secret_file      = data.aws_secretsmanager_secret.this["api"].arn
 
     task_iam_role_statements = local.task_iam_role_statements
 

--- a/infra/terraform/environments/int/main.tf
+++ b/infra/terraform/environments/int/main.tf
@@ -515,6 +515,7 @@ module "service" {
       {
         name     = "permits-reset-test-data",
         commands = ["permits:reset-test-data"],
+        type     = "default",
         timeout  = 1800
       },
       {

--- a/infra/terraform/modules/service/batch.tf
+++ b/infra/terraform/modules/service/batch.tf
@@ -42,7 +42,7 @@ locals {
         },
       ]
 
-      secrets = []
+      secrets = null
     }
     liquibase = {
       image = "${var.batch.liquibase_repository}:latest"

--- a/infra/terraform/modules/service/batch.tf
+++ b/infra/terraform/modules/service/batch.tf
@@ -214,17 +214,17 @@ locals {
 
     container_properties = jsonencode({
 
-      command = (job.type == "default" ? concat([
+      command = (try(job.type, "default") == "default" ? concat([
         "/var/www/html/vendor/bin/laminas",
         "--container=/var/www/html/config/container-cli.php",
         "-v"
       ], job.commands) : job.commands)
 
-      image = lookup(local.job_types, job.type, local.job_types.default).image
+      image = lookup(local.job_types, try(job.type, "default"), local.job_types.default).image
 
-      environment = lookup(local.job_types, job.type, local.job_types.default).environment
+      environment = lookup(local.job_types, try(job.type, "default"), local.job_types.default).environment != null ? lookup(local.job_types, try(job.type, "default"), local.job_types.default).environment : []
 
-      secrets = lookup(local.job_types, job.type, local.job_types.default).secrets
+      secrets = lookup(local.job_types, try(job.type, "default"), local.job_types.default).secrets != null ? lookup(local.job_types, try(job.type, "default"), local.job_types.default).secrets : null
 
       runtimePlatform = {
         operatingSystemFamily = "LINUX",


### PR DESCRIPTION
## Description

This is due to a combination of factors.

1. We don’t manage providers effectively in vol-app for terraform so there is a significant mismatch here. There is a hidden provider dependency triggered by an open source module used.
2. When the new job permits-reset-test-data was added this did not have a type attribute defined which it should have had but previously the code was accepting this until it hit a provider update recently.
3. The initial code input for the batch service module did not either manage the provider as require but also wasn’t resilient enough with “try” operators to catch issues like this.

I have update the TF to handle this in the future should a type operator be missed but i have also added it to the permits-reset-test-data job as well.

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
