### PR TITLE
feat: added 8 missing welsh translated email templates

### DIFF
--- a/app/api/module/Email/view/email/cy_GB/html/continuation-not-sought.phtml
+++ b/app/api/module/Email/view/email/cy_GB/html/continuation-not-sought.phtml
@@ -1,0 +1,13 @@
+<p>
+  Mae'r trwyddedau canlynol sydd â ffioedd yn ddyledus rhwng <?php echo $this->escapeHtml($this->startDate); ?>
+  a <?php echo $this->escapeHtml($this->endDate) ?> wedi'u gosod i CNS:
+</p>
+
+<table>
+  <?php foreach ($this->licences as $licence): ?>
+    <tr>
+      <td width="125"><?php echo $this->escapeHtml($licence['licNo']); ?></td>
+      <td><?php echo $this->escapeHtml($licence['taName']); ?></td>
+    </tr>
+  <?php endforeach; ?>
+</table>

--- a/app/api/module/Email/view/email/cy_GB/html/ebsr-data-error-list.phtml
+++ b/app/api/module/Email/view/email/cy_GB/html/ebsr-data-error-list.phtml
@@ -1,0 +1,5 @@
+<ul>
+    <?php foreach ($this->submissionErrors as $error) { ?>
+        <li><?php echo $this->escapeHtml($error); ?></li>
+    <?php } ?>
+</ul>

--- a/app/api/module/Email/view/email/cy_GB/html/email-duplicate-vehicles-removal.phtml
+++ b/app/api/module/Email/view/email/cy_GB/html/email-duplicate-vehicles-removal.phtml
@@ -1,0 +1,12 @@
+<table>
+    <tr>
+        <th>VRM</th>
+        <th>Rhif Trwydded</th>
+    </tr>
+    <?php foreach ($this->removedVehicles as $vehicle): ?>
+        <tr>
+            <td><?php echo $vehicle['vrm']; ?></td>
+            <td><?php echo $vehicle['licNo']; ?></td>
+        </tr>
+    <?php endforeach; ?>
+</table>

--- a/app/api/module/Email/view/email/cy_GB/html/last-tm-operator-notification.phtml
+++ b/app/api/module/Email/view/email/cy_GB/html/last-tm-operator-notification.phtml
@@ -1,0 +1,27 @@
+<p>Annwyl weithredwr,</p>
+<p>
+    Mae dogfennaeth bwysig ynghylch eich Trwydded Gweithredwr <?php echo $this->escapeHtml($this->licNo); ?> wedi'i
+    hanfon drwy'r post danfon cofnodedig i'ch cyfeiriad gohebiaeth. Mae hyn yn dilyn tynnu eich Rheolwr Trafnidiaeth olaf;
+    sicrhewch eich bod yn ymateb cyn y dyddiad cau a nodwyd.
+</p>
+<p>
+    SYLWER. Bydd methu ag ymateb i'r llythyr hwn yn arwain at ddirymu eich trwydded. Byddai dirymu'r
+    drwydded yn gwneud gweithredu cerbydau y mae angen trwydded gweithredwr ar eu cyfer yn
+    anghyfreithlon.
+</p>
+<?php if (!$this->registeredToSelfserve) : ?>
+    <p>Gallwch ddiweddaru eich trwydded gweithredwr ar-lein, er enghraifft gallwch:
+    <ul>
+        <li>ychwanegu neu dynnu rheolwr trafnidiaeth</li>
+        <li>ychwanegu mwy o gerbydau at eich trwydded</li>
+        <li>cynyddu'r terfyn cerbydau ar eich trwydded</li>
+        <li>newid math eich trwydded</li>
+    </ul>
+    I gofrestru ar gyfer y gwasanaeth ar-lein, defnyddiwch y ddolen ganlynol:
+    <p>
+        <a href="https://www.vehicle-operator-licensing.service.gov.uk/auth/login/">https://www.vehicle-operator-licensing.service.gov.uk/auth/login/</a>
+    <p>
+        Mae'r gwasanaeth ar-lein yn syml ac yn hawdd i'w ddefnyddio. Mae'n lleihau'r amser sydd ei angen i fwrw ymlaen â'r
+        rhan fwyaf o newidiadau i drwyddedau. Mae newidiadau i gerbydau yn dod i rym ar unwaith.
+    </p>
+<?php endif; ?>

--- a/app/api/module/Email/view/email/cy_GB/html/report-international-goods.phtml
+++ b/app/api/module/Email/view/email/cy_GB/html/report-international-goods.phtml
@@ -1,0 +1,1 @@
+<p>Gweler yr adroddiad nwyddau rhyngwladol atodedig.</p>

--- a/app/api/module/Email/view/email/cy_GB/html/report-psv-operator-list.phtml
+++ b/app/api/module/Email/view/email/cy_GB/html/report-psv-operator-list.phtml
@@ -1,0 +1,1 @@
+<p>Gweler yr adroddiad Gweithredwyr PSV atodedig.</p>

--- a/app/api/module/Email/view/email/cy_GB/html/transport-manager-amend-digital-form.phtml
+++ b/app/api/module/Email/view/email/cy_GB/html/transport-manager-amend-digital-form.phtml
@@ -1,0 +1,22 @@
+<p>Helô,</p>
+<p>
+Mae <?php echo $this->escapeHtml($this->organisation); ?> wedi'ch enwi fel Rheolwr Trafnidiaeth ar Drwydded Gweithredwr
+Cerbydau <?php echo $this->escapeHtml($this->reference); ?>.
+</p>
+<p>
+    Maent wedi adolygu'ch cais ac mae angen ichi ddiwygio neu wirio'ch manylion. Bydd angen ichi lofnodi'r datganiad eto ar ôl ichi adolygu neu ddiwygio'ch cais.
+</p>
+<p>
+    I adolygu'r cais, <a href="<?php echo $this->escapeHtml($this->signInLink); ?>">mewngofnodwch ar-lein</a> gyda'ch enw defnyddiwr
+    (<?php echo $this->escapeHtml($this->username); ?>) a'ch cyfrinair.
+</p>
+<p>
+    <b>Profi problemau?</b><br>
+<?php
+$url = ($this->isNi) ?
+    'http://www.doeni.gov.uk/index/information/foi/recent-releases/publications-details.htm?docid=9994' :
+    'https://www.gov.uk/government/publications/application-to-add-a-transport-manager-to-a-licence-tm1';
+?>
+Am gyngor gwelwch y <a href="<?php echo $this->escapeHtml($url); ?>">Canllaw cymorth ar gyfer Rheolwyr Trafnidiaeth</a> neu
+<a href="mailto:notifications@vehicle-operator-licensing.service.gov.uk">e-bostiwch ni</a>.
+</p>

--- a/app/api/module/Email/view/email/cy_GB/html/user-registered-tc.phtml
+++ b/app/api/module/Email/view/email/cy_GB/html/user-registered-tc.phtml
@@ -1,0 +1,11 @@
+<p>Helô,</p>
+
+<p>Fe'ch ychwanegwyd at y gwasanaeth Trwyddedu Gweithredwyr Cerbydau ar gyfer <?php echo $this->escapeHtml($this->orgName); ?>.</p>
+
+<p>Eich enw defnyddiwr yw: <?php echo $this->escapeHtml($this->loginId); ?></p>
+
+<p>Byddwch yn derbyn ail e-bost gyda chyfrinair dros dro yn y ddwy awr nesaf. Os na fydd yn cyrraedd e-bostiwch notifications@vehicle-operator-licensing.service.gov.uk</p>
+
+<p>
+    <a href="<?php echo $this->escapeHtml($this->url); ?>">Mewngofnodi</a>
+</p>

--- a/app/api/module/Email/view/email/cy_GB/plain/continuation-not-sought.phtml
+++ b/app/api/module/Email/view/email/cy_GB/plain/continuation-not-sought.phtml
@@ -1,0 +1,7 @@
+Mae'r trwyddedau canlynol sydd â ffioedd yn ddyledus rhwng <?php echo $this->startDate ?> a <?php echo $this->endDate ?> wedi'u gosod i CNS:
+
+<?php
+foreach ($this->licences as $licence){
+    echo $licence['licNo'] . ' ' . $licence['taName'] . "\n";
+}
+?>

--- a/app/api/module/Email/view/email/cy_GB/plain/ebsr-data-error-list.phtml
+++ b/app/api/module/Email/view/email/cy_GB/plain/ebsr-data-error-list.phtml
@@ -1,0 +1,3 @@
+<?php foreach ($this->submissionErrors as $error) { ?>
+    <?php echo '*' . $error . "\n"; ?>
+<?php }

--- a/app/api/module/Email/view/email/cy_GB/plain/email-duplicate-vehicles-removal.phtml
+++ b/app/api/module/Email/view/email/cy_GB/plain/email-duplicate-vehicles-removal.phtml
@@ -1,0 +1,7 @@
+VRM, Rhif Trwydded
+
+<?php
+    foreach ($this->removedVehicles as $vehicle) {
+        echo $vehicle['vrm'] . ', ' . $vehicle['licNo'] . PHP_EOL;
+    }
+?>

--- a/app/api/module/Email/view/email/cy_GB/plain/last-tm-operator-notification.phtml
+++ b/app/api/module/Email/view/email/cy_GB/plain/last-tm-operator-notification.phtml
@@ -1,0 +1,18 @@
+Annwyl weithredwr,
+Mae dogfennaeth bwysig ynghylch eich Trwydded Gweithredwr <?php echo $this->escapeHtml($this->licNo); ?> wedi'i hanfon drwy'r post danfon cofnodedig i'ch cyfeiriad gohebiaeth. Mae hyn yn dilyn tynnu eich Rheolwr Trafnidiaeth olaf; sicrhewch eich bod yn ymateb cyn y dyddiad cau a nodwyd.
+ SYLWER. Bydd methu ag ymateb i'r llythyr hwn yn arwain at ddirymu eich trwydded. Byddai dirymu'r drwydded yn gwneud gweithredu cerbydau y mae angen trwydded gweithredwr ar eu cyfer yn anghyfreithlon.
+<?php if (!$this->registeredToSelfserve) : ?>
+
+Gallwch ddiweddaru eich trwydded gweithredwr ar-lein, er enghraifft gallwch:
+    • ychwanegu neu dynnu rheolwr trafnidiaeth
+    • ychwanegu mwy o gerbydau at eich trwydded
+    • cynyddu'r terfyn cerbydau ar eich trwydded
+    • newid math eich trwydded
+
+I gofrestru ar gyfer y gwasanaeth ar-lein, defnyddiwch y ddolen ganlynol:
+
+https://www.vehicle-operator-licensing.service.gov.uk/auth/login/
+
+Mae'r gwasanaeth ar-lein yn syml ac yn hawdd i'w ddefnyddio. Mae'n lleihau'r amser sydd ei angen i fwrw ymlaen â'r rhan fwyaf o newidiadau i drwyddedau. Mae newidiadau i gerbydau yn dod i rym ar unwaith.
+
+<?php endif; ?>

--- a/app/api/module/Email/view/email/cy_GB/plain/report-international-goods.phtml
+++ b/app/api/module/Email/view/email/cy_GB/plain/report-international-goods.phtml
@@ -1,0 +1,1 @@
+Gweler yr adroddiad nwyddau rhyngwladol atodedig.

--- a/app/api/module/Email/view/email/cy_GB/plain/report-psv-operator-list.phtml
+++ b/app/api/module/Email/view/email/cy_GB/plain/report-psv-operator-list.phtml
@@ -1,0 +1,1 @@
+Gweler yr adroddiad Gweithredwyr PSV atodedig.

--- a/app/api/module/Email/view/email/cy_GB/plain/transport-manager-amend-digital-form.phtml
+++ b/app/api/module/Email/view/email/cy_GB/plain/transport-manager-amend-digital-form.phtml
@@ -1,0 +1,17 @@
+Helô,
+
+Mae <?php echo $this->organisation ?> wedi'ch enwi fel Rheolwr Trafnidiaeth ar Drwydded Gweithredwr Cerbydau <?php echo $this->reference ?>.
+
+Maent wedi adolygu'ch cais ac mae angen ichi ddiwygio neu wirio'ch manylion. Bydd angen ichi lofnodi'r datganiad eto ar ôl ichi adolygu neu ddiwygio'ch cais.
+
+I adolygu'r cais, mewngofnodwch ar-lein <?php echo $this->signInLink ?> gyda'ch enw defnyddiwr (<?php echo $this->username ?>) a'ch cyfrinair.
+
+Profi problemau?
+
+<?php
+$url = ($this->isNi) ?
+    'http://www.doeni.gov.uk/index/information/foi/recent-releases/publications-details.htm?docid=9994' :
+    'https://www.gov.uk/government/publications/application-to-add-a-transport-manager-to-a-licence-tm1';
+?>
+
+Am gyngor gwelwch y Canllaw cymorth ar gyfer Rheolwyr Trafnidiaeth <?php echo $url ?> neu e-bostiwch ni notifications@vehicle-operator-licensing.service.gov.uk.

--- a/app/api/module/Email/view/email/cy_GB/plain/user-registered-tc.phtml
+++ b/app/api/module/Email/view/email/cy_GB/plain/user-registered-tc.phtml
@@ -1,0 +1,9 @@
+Helô,
+
+Fe'ch ychwanegwyd at y gwasanaeth Trwyddedu Gweithredwyr Cerbydau ar gyfer <?php echo $this->orgName; ?>.
+
+Eich enw defnyddiwr yw: <?php echo $this->loginId; ?>
+
+Byddwch yn derbyn ail e-bost gyda chyfrinair dros dro yn y ddwy awr nesaf. Os na fydd yn cyrraedd e-bostiwch notifications@vehicle-operator-licensing.service.gov.uk
+
+Mewngofnodi <?php echo $this->url; ?>


### PR DESCRIPTION
## Description

The new Welsh versions are exact copies of the English versions, but with the text translated. It's noted that many of these aren't great from an escaping point of view, and that's something we'll fix in the notify work that's about to drop.

Related issue: [VOL-7348](https://dvsa.atlassian.net/browse/VOL-7348)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-7348]: https://dvsa.atlassian.net/browse/VOL-7348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ