### PR TITLE
feat: prevent last TM letter batch failures on invalid email addresses

### DIFF
--- a/app/api/module/Cli/src/Domain/CommandHandler/FirstTmLetter.php
+++ b/app/api/module/Cli/src/Domain/CommandHandler/FirstTmLetter.php
@@ -20,6 +20,7 @@ use Dvsa\Olcs\Api\Domain\Repository\TransportManagerLicence;
 use Dvsa\Olcs\Api\Domain\EmailAwareInterface;
 use Dvsa\Olcs\Api\Domain\EmailAwareTrait;
 use Dvsa\Olcs\Email\Data\Message;
+use Dvsa\Olcs\Email\Exception\EmailNotSentException;
 
 final class FirstTmLetter extends AbstractCommandHandler implements EmailAwareInterface
 {
@@ -84,7 +85,15 @@ final class FirstTmLetter extends AbstractCommandHandler implements EmailAwareIn
                 $tmlRepo->save($removedTm);
             }
 
-            $this->sendEmailToOperator($licence);
+            try {
+                $this->sendEmailToOperator($licence);
+            } catch (EmailNotSentException $e) {
+                $this->result->merge(
+                    $this->handleSideEffect(
+                        $this->createMissingEmailTaskSideEffect($licence)
+                    )
+                );
+            }
         }
 
         return $this->result;
@@ -228,5 +237,20 @@ final class FirstTmLetter extends AbstractCommandHandler implements EmailAwareIn
         ];
 
         return CreateTask::create($params);
+    }
+
+    /**
+     * Creates a missing email task side-effect for the given licence.
+     */
+    private function createMissingEmailTaskSideEffect(LicenceEntity $licence): CreateTask
+    {
+        return CreateTask::create([
+            'category' => Category::CATEGORY_APPLICATION,
+            'subCategory' => SubCategory::TM_SUB_CATEGORY_TM1_REMOVAL,
+            'description' => 'Unable to send First TM operator notification email due to missing or invalid email address',
+            'actionDate'  => (new DateTime())->format('Y-m-d'),
+            'licence' => $licence->getId(),
+            'urgent' => 'Y',
+        ]);
     }
 }

--- a/app/api/module/Cli/src/Domain/CommandHandler/LastTmLetter.php
+++ b/app/api/module/Cli/src/Domain/CommandHandler/LastTmLetter.php
@@ -19,6 +19,7 @@ use Dvsa\Olcs\Api\Domain\Repository\TransportManagerLicence;
 use Dvsa\Olcs\Api\Domain\EmailAwareInterface;
 use Dvsa\Olcs\Api\Domain\EmailAwareTrait;
 use Dvsa\Olcs\Email\Data\Message;
+use Dvsa\Olcs\Email\Exception\EmailNotSentException;
 
 final class LastTmLetter extends AbstractCommandHandler implements EmailAwareInterface
 {
@@ -89,7 +90,15 @@ final class LastTmLetter extends AbstractCommandHandler implements EmailAwareInt
                 $tmlRepo->save($removedTm);
             }
 
-            $this->sendEmailToOperator($licence);
+            try {
+                    $this->sendEmailToOperator($licence);
+            } catch (EmailNotSentException $e) {
+                $this->result->merge(
+                    $this->handleSideEffect(
+                        $this->createMissingEmailTaskSideEffect($licence)
+                    )
+                );
+            }
         }
 
         return $this->result;
@@ -295,5 +304,20 @@ final class LastTmLetter extends AbstractCommandHandler implements EmailAwareInt
         ];
 
         return CreateTask::create($params);
+    }
+
+    /**
+     * Creates a missing email task side-effect for the given licence.
+     */
+    private function createMissingEmailTaskSideEffect(LicenceEntity $licence): CreateTask
+    {
+        return CreateTask::create([
+            'category' => Category::CATEGORY_TRANSPORT_MANAGER,
+            'subCategory' => SubCategory::TM_SUB_CATEGORY_GENERAL_TASK,
+            'description' => 'Unable to send Last TM operator notification email due to missing or invalid email address',
+            'actionDate'  => (new DateTime())->format('Y-m-d'),
+            'licence' => $licence->getId(),
+            'urgent' => 'Y',
+        ]);
     }
 }

--- a/app/api/test/module/Cli/src/Domain/CommandHandler/FirstTmLetterTest.php
+++ b/app/api/test/module/Cli/src/Domain/CommandHandler/FirstTmLetterTest.php
@@ -20,6 +20,7 @@ use Dvsa\Olcs\Transfer\Command\Task\CreateTask;
 use Dvsa\OlcsTest\Api\Domain\CommandHandler\AbstractCommandHandlerTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Mockery as m;
+use Dvsa\Olcs\Email\Exception\EmailNotSentException;
 
 class FirstTmLetterTest extends AbstractCommandHandlerTestCase
 {
@@ -490,5 +491,94 @@ class FirstTmLetterTest extends AbstractCommandHandlerTestCase
         $result = new Result();
 
         return $result;
+    }
+
+    public function testHandleCommandCreatesTaskWhenOperatorNotificationEmailFails(): void
+    {
+        $licenceRepo = $this->repoMap['Licence'];
+        $tmlRepo = $this->repoMap['TransportManagerLicence'];
+
+        $licence = m::mock(LicenceEntity::class);
+
+        $this->mockLicence($licence, [
+            'licence' => [
+                'id' => 1,
+                'licNo' => 'AB123',
+                'isNi' => false,
+                'isPsv' => false,
+                'translateToWelsh' => 'N',
+                'organisation' => [
+                    'allowEmail' => 'Y',
+                    'name' => 'Test Operator Ltd',
+                ],
+                'correspondenceCd' => [
+                    'emailAddress' => 'abc',
+                ],
+            ],
+        ]);
+
+        $this->mockCorrespondenceCd($licence, [
+            'licence' => [
+                'correspondenceCd' => [
+                    'emailAddress' => 'abc',
+                ],
+            ],
+        ]);
+
+        $licenceRepo->shouldReceive('fetchForLastTmAutoLetter')
+            ->once()
+            ->andReturn([$licence]);
+
+        $tm = m::mock(TransportManager::class);
+        $tm->shouldReceive('getId')->andReturn(1);
+
+        $removedTm = m::mock(TransportManagerLicence::class);
+        $removedTm->shouldReceive('getId')->andReturn(10);
+        $removedTm->shouldReceive('getTransportManager')->andReturn($tm);
+        $removedTm->shouldReceive('setLastTmFirstEmailDate')->once();
+
+        $tmlRepo->shouldReceive('fetchRemovedTmForLicence')
+            ->with(1)
+            ->once()
+            ->andReturn([$removedTm]);
+
+        $tmlRepo->shouldReceive('save')
+            ->with($removedTm)
+            ->once();
+
+        $generateResult = new Result();
+        $generateResult->addId('document', 123);
+
+        $this->expectedSideEffect(GenerateAndStore::class, [], $generateResult);
+
+        $this->expectedSideEffect(CreateTask::class, [], new Result());
+
+        $this->repoMap['User']
+            ->shouldReceive('fetchFirstByEmailOrFalse')
+            ->once()
+            ->with('abc')
+            ->andReturn(false);
+
+        $this->commandHandler
+            ->shouldReceive('handleCommand')
+            ->with(m::type(SendEmail::class), false)
+            ->once()
+            ->andThrow(new EmailNotSentException('Email is missing a valid to address'));
+
+        $this->expectedSideEffect(CreateTask::class, [], new Result());
+
+        $response = $this->sut->handleCommand(
+            \Dvsa\Olcs\Cli\Domain\Command\FirstTmLetter::create([])
+        );
+
+        $this->assertEquals(
+            [
+                'id' => [
+                    'document' => 123,
+                ],
+                'messages' => [],
+            ],
+            $response->toArray()
+        );
     }
 }

--- a/app/api/test/module/Cli/src/Domain/CommandHandler/LastTmLetterTest.php
+++ b/app/api/test/module/Cli/src/Domain/CommandHandler/LastTmLetterTest.php
@@ -22,6 +22,7 @@ use Dvsa\Olcs\Api\Entity\User\User as UserEntity;
 use Dvsa\Olcs\Api\Entity\Doc\Document as DocumentEntity;
 use Dvsa\Olcs\Email\Service\TemplateRenderer;
 use Laminas\Mail\Transport\Sendmail;
+use Dvsa\Olcs\Email\Exception\EmailNotSentException;
 
 class LastTmLetterTest extends AbstractCommandHandlerTestCase
 {
@@ -663,5 +664,143 @@ class LastTmLetterTest extends AbstractCommandHandlerTestCase
             $userRepo->shouldReceive('fetchFirstByEmailOrFalse')->andReturn($fetchedUser);
             $this->expectedSideEffect(SendEmail::class, [], new Result());
         }
+    }
+
+    public function testHandleCommandCreatesTaskWhenOperatorNotificationEmailFails(): void
+    {
+        $licenceRepo = $this->repoMap['Licence'];
+        $tmlRepo = $this->repoMap['TransportManagerLicence'];
+
+        $licence = m::mock(LicenceEntity::class);
+
+        $dataProvider = [
+            'licence' => [
+                'id' => 1,
+                'licNo' => 'AB123',
+                'isNi' => false,
+                'isPsv' => false,
+                'organisation' => [
+                    'allowEmail' => 'Y',
+                    'name' => 'Test Operator Ltd',
+                ],
+                'correspondenceCd' => [
+                    'emailAddress' => 'abc',
+                ],
+            ],
+            'user' => [
+                'fetchFirstByEmailOrFalse' => false,
+            ],
+            'sideEffectResults' => [
+                'GenerateAndStore' => [
+                    'ids' => [
+                        'documents' => [
+                            '123' => [
+                                'metadata' => json_encode([
+                                    'details' => [
+                                        'category' => Category::CATEGORY_TRANSPORT_MANAGER,
+                                        'documentSubCategory' => Category::DOC_SUB_CATEGORY_TRANSPORT_MANAGER_CORRESPONDENCE,
+                                        'documentTemplate' => 919,
+                                        'allowEmail' => 'N',
+                                        'sendToAddress' => 'correspondenceAddress',
+                                    ],
+                                ]),
+                                'address' => 'correspondenceAddress',
+                            ],
+                        ],
+                    ],
+                ],
+                'CreateTask' => [
+                    'ids' => [],
+                ],
+            ],
+        ];
+
+        $this->mockLicence($licence, $dataProvider);
+
+        $licence->shouldReceive('getActiveVariations')
+            ->once()
+            ->andReturn([]);
+
+        $this->mockCorrespondenceCd($licence, $dataProvider);
+
+        $licenceRepo->shouldReceive('fetchForLastTmAutoLetter')
+            ->once()
+            ->andReturn([$licence]);
+
+        $tmlEntity = m::mock(TransportManagerLicence::class);
+        $tmlEntity->shouldReceive('getId')->andReturn(5);
+        $tmlEntity->shouldReceive('setLastTmLetterDate')->once();
+
+        $tm = m::mock(\Dvsa\Olcs\Api\Entity\Tm\TransportManager::class);
+        $tm->shouldReceive('getId')->andReturn(1);
+        $tmlEntity->shouldReceive('getTransportManager')->andReturn($tm);
+
+        $tmlRepo->shouldReceive('fetchRemovedTmForLicence')
+            ->with(1, true)
+            ->once()
+            ->andReturn([$tmlEntity]);
+
+        $tmlRepo->shouldReceive('save')
+            ->with($tmlEntity)
+            ->once();
+
+        $generateResult = $this->getGenerateAndStoreResult(
+            $dataProvider['sideEffectResults']['GenerateAndStore']['ids']['documents']
+        );
+
+        $this->expectedSideEffect(GenerateAndStore::class, [], $generateResult);
+
+        // Existing Last TM task
+        $this->expectedSideEffect(CreateTask::class, [], new Result());
+
+        // Print document
+        $this->expectedSideEffect(
+            PrintLetter::class,
+            [],
+            $this->getPrintLetterResult(123)
+        );
+
+        $document = m::mock(DocumentEntity::class);
+        $document->shouldReceive('getMetadata')
+            ->once()
+            ->andReturn($dataProvider['sideEffectResults']['GenerateAndStore']['ids']['documents']['123']['metadata']);
+
+        $this->repoMap['Document']
+            ->shouldReceive('fetchById')
+            ->with(123)
+            ->once()
+            ->andReturn($document);
+
+        $this->repoMap['User']
+            ->shouldReceive('fetchFirstByEmailOrFalse')
+            ->once()
+            ->with('abc')
+            ->andReturn(false);
+
+        $this->commandHandler
+            ->shouldReceive('handleCommand')
+            ->with(m::type(SendEmail::class), false)
+            ->once()
+            ->andThrow(new EmailNotSentException('Email is missing a valid to address'));
+
+        // New missing/invalid email follow-up task
+        $this->expectedSideEffect(CreateTask::class, [], new Result());
+
+        $response = $this->sut->handleCommand(
+            \Dvsa\Olcs\Cli\Domain\Command\LastTmLetter::create([])
+        );
+
+        $this->assertEquals(
+            [
+                'id' => [
+                    'correspondenceAddress' => '123',
+                    'document' => 123,
+                ],
+                'messages' => [
+                    "Document id '123', queued for print",
+                ],
+            ],
+            $response->toArray()
+        );
     }
 }


### PR DESCRIPTION
## Description

<!--
Prevent Last TM letter batch failures on invalid email addresses or missing emails
-->

Related issue: [VOL-7347](https://dvsa.atlassian.net/browse/VOL-7347)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-7347]: https://dvsa.atlassian.net/browse/VOL-7347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ