### PR TITLE
fix: optimise anon scripts

### DIFF
--- a/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_address.sh
+++ b/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_address.sh
@@ -99,7 +99,7 @@ SET @DISABLE_TRIGGERS = 1;
 truncate table address;
 SET FOREIGN_KEY_CHECKS = 1;
 
--- [OPTIMIZATION] Added index disable command to maximize speed during execution of the data pipeline load.
+-- Added index disable command to maximize speed during execution of the data pipeline load.
 ALTER TABLE address DISABLE KEYS;
 
 LOAD DATA LOCAL INFILE '$ANON_DATA_DIR/$ADDRESS_ANON_DATA_FILE' INTO table address FIELDS TERMINATED BY '\t'
@@ -148,7 +148,7 @@ SET uprn=nullif(@uprn,'')
 ,olbs_key=nullif(@olbs_key,'')
 ,olbs_type=nullif(@olbs_type,'');
 
--- [OPTIMIZATION] Re-enable indexes cleanly in a single fast block operation after the data finishes writing.
+-- Re-enable indexes cleanly in a single fast block operation after the data finishes writing.
 ALTER TABLE address ENABLE KEYS;
 
 SET @DISABLE_TRIGGERS = null;" || log_error "reload_address FAILED!"

--- a/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_address.sh
+++ b/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_address.sh
@@ -38,7 +38,7 @@ anonymise_address () {
 #county -> locality : 10
 #street -> null ( OLCS-13670 )
 #town -> town : 11
-#postcode -> poatcode : 12
+#postcode -> postcode : 12
 
 [ -e $ANON_DATA_DIR/$ADDRESS_ANON_DATA_FILE ] && rm $ANON_DATA_DIR/$ADDRESS_ANON_DATA_FILE
 

--- a/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_address.sh
+++ b/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_address.sh
@@ -2,7 +2,7 @@
 
 #####################################################################
 #                                                                   #
-# anonymise address table.					    #
+# anonymise address table.                                          #
 #                                                                   #
 #####################################################################
 
@@ -30,71 +30,61 @@ mysql --local-infile=1 -sNB $conn -e "SELECT * FROM $ANON_DB.address ;" | tr '^'
 
 anonymise_address () {
 
-declare -A addressLineOne
-declare -A addressLineTwo
-declare -A town
-declare -A county
-declare -A postcode
-declare -i count
-count=1
+# Removed all slow Bash associative array declarations
 
-while read line; do
-    addressLineOne[$count]=$(echo $line | awk -F',' '{ print $2}')
-    addressLineTwo[$count]=$(echo $line | awk -F',' '{ print $3}')
-    town[$count]=$(echo $line | awk -F',' '{ print $4}')
-    county[$count]=$(echo $line | awk -F',' '{ print $5}')
-    postcode[$count]=$(echo $line | awk -F',' '{ print $6}')
-    (( count++ ))
-done < $ADDRESS_CSV_FILE
-
+# Retained mapping tracking reference for documentation:
 #addressLineOne -> paon_desc : 5
 #addressLineTwo -> saon_desc : 8
 #county -> locality : 10
 #street -> null ( OLCS-13670 )
 #town -> town : 11
 #postcode -> poatcode : 12
-Street=
 
 [ -e $ANON_DATA_DIR/$ADDRESS_ANON_DATA_FILE ] && rm $ANON_DATA_DIR/$ADDRESS_ANON_DATA_FILE
 
-OLDIFS=$IFS
+# Replaced slow Bash loop with high-speed awk.
 
-while IFS=$'^' read id uprn paon_start paon_end paon_desc saon_start saon_end saon_desc street locality town postcode admin_area country_code created_by last_modified_by deleted_date created_on last_modified_on version olbs_key olbs_type ; do
+awk -F'^' '
+BEGIN {
+    srand(); # Seed the random number generator
+}
+# Pass 1: Read the Comma-Separated Reference File (NR==FNR applies only to the first file parameter passed)
+NR==FNR {
+    # Dynamically split comma-separated columns into a temporary array
+    split($0, csv, ",");
+    addr1[FNR]  = csv[2];
+    addr2[FNR]  = csv[3];
+    twn[FNR]    = csv[4];
+    cnt[FNR]    = csv[5];
+    pcode[FNR]  = csv[6];
+    total_ref = FNR; # Tracks how many total reference records exist
+    next;
+}
+# Pass 2: Stream through the Caret-Separated Database Data File
+{
+    # Generate independent, unbiased random indices bounded by the total size of your CSV reference data
+    r1 = int(rand() * total_ref) + 1;
+    r2 = int(rand() * total_ref) + 1;
+    r3 = int(rand() * total_ref) + 1;
+    r4 = int(rand() * total_ref) + 1;
+    r5 = int(rand() * total_ref) + 1;
 
-Paon_desc=
-Saon_desc=
-Locality=
-Town=
-Postcode=
+    # Conditional mask substitution matching your original logic (Field index numbers correlate to your read list)
+    # $5=paon_desc, $8=saon_desc, $9=street, $10=locality, $11=town, $12=postcode
+    if ($5  != "") $5  = addr1[r1];
+    if ($8  != "") $8  = addr2[r2];
+    $9  = ""; 
+    if ($10 != "") $10 = cnt[r4];
+    if ($11 != "") $11 = twn[r3];
+    if ($12 != "") $12 = pcode[r5];
 
-if [[ ! -z $paon_desc ]]; then
-    Paon_desc="${addressLineOne[$((RANDOM%${#addressLineOne[@]}))]}"
-fi
-
-if [[ ! -z $saon_desc ]]; then
-    Saon_desc="${addressLineTwo[$((RANDOM%${#addressLineTwo[@]}))]}"
-fi
-
-if [[ ! -z $town ]]; then
-    Town="${town[$((RANDOM%${#town[@]}))]}"
-fi
-
-if [[ ! -z $locality ]]; then
-    Locality="${county[$((RANDOM%${#county[@]}))]}"
-fi
-
-if [[ ! -z $postcode ]]; then
-    Postcode="${postcode[$((RANDOM%${#postcode[@]}))]}"
-fi
-
-printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" "$id" "$uprn" "$paon_start" "$paon_end" "$Paon_desc" "$saon_start" "$saon_end" "$Saon_desc" "$Street" "$Locality" "$Town" "$Postcode" "$admin_area" "$country_code" "$created_by" "$last_modified_by" "$deleted_date" "$created_on" "$last_modified_on" "$version" "$olbs_key" "$olbs_type"
-
-done < $ANON_DATA_DIR/$ADDRESS_DATA_FILE >> $ANON_DATA_DIR/$ADDRESS_ANON_DATA_FILE || log_error "anonymise_address FAILED!"
+    # Directly outputs the modified record using tabs (\t) as the field output separator
+    print $0;
+}' OFS='\t' "$ADDRESS_CSV_FILE" "$ANON_DATA_DIR/$ADDRESS_DATA_FILE" >> $ANON_DATA_DIR/$ADDRESS_ANON_DATA_FILE || log_error "anonymise_address FAILED!"
 
 iconv -f utf-8 -t utf-8 -c  $ANON_DATA_DIR/$ADDRESS_ANON_DATA_FILE >  $ANON_DATA_DIR/tmp-$ADDRESS_ANON_DATA_FILE
 mv $ANON_DATA_DIR/tmp-$ADDRESS_ANON_DATA_FILE  $ANON_DATA_DIR/$ADDRESS_ANON_DATA_FILE
 
-IFS=$OLDIFS
 }
 
 reload_address ()
@@ -108,6 +98,9 @@ SET FOREIGN_KEY_CHECKS = 0;
 SET @DISABLE_TRIGGERS = 1;
 truncate table address;
 SET FOREIGN_KEY_CHECKS = 1;
+
+-- [OPTIMIZATION] Added index disable command to maximize speed during execution of the data pipeline load.
+ALTER TABLE address DISABLE KEYS;
 
 LOAD DATA LOCAL INFILE '$ANON_DATA_DIR/$ADDRESS_ANON_DATA_FILE' INTO table address FIELDS TERMINATED BY '\t'
 ( id
@@ -154,6 +147,9 @@ SET uprn=nullif(@uprn,'')
 ,version=nullif(@version,'')
 ,olbs_key=nullif(@olbs_key,'')
 ,olbs_type=nullif(@olbs_type,'');
+
+-- [OPTIMIZATION] Re-enable indexes cleanly in a single fast block operation after the data finishes writing.
+ALTER TABLE address ENABLE KEYS;
 
 SET @DISABLE_TRIGGERS = null;" || log_error "reload_address FAILED!"
 

--- a/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_companies_house_company.sh
+++ b/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_companies_house_company.sh
@@ -2,7 +2,7 @@
 #set -n
 #####################################################################
 #                                                                   #
-# anonymise companies_house_company table.		            #
+# anonymise companies_house_company table.                          #
 #                                                                   #
 #####################################################################
 
@@ -13,14 +13,7 @@ COMPANIES_DATA_FILE=$4
 COMPANIES_ANON_DATA_FILE=$5
 COMPANIES_CSV_FILE=$6
 
-declare -A name
-declare -A addressLineOne
-declare -A addressLineTwo
-declare -A region
-declare -A country
-declare -A postcode
-declare -A _status
-
+# Removed global Bash associative array declarations (declare -A)
 
 log () {
 printf "\n%s %s\n" "$(date "+%Y-%m-%d %H:%M:%S")" "$1"
@@ -37,26 +30,7 @@ conn=$1
 mysql --local-infile=1 -sNB $conn -e "SELECT * FROM $ANON_DB.companies_house_company ;" | tr '\t' '^' | sed -e 's/NULL//g' > $ANON_DATA_DIR/$COMPANIES_DATA_FILE
 }
 
-read_company_data ()
-{
-
-declare -i count=1
-
-while read line; do
-
-    name[$count]="$(echo $line | awk -F',' '{ print $2 }')"
-    _status[$count]=$(echo $line | awk -F',' ' { print $4 }')
-    addressLineOne[$count]=$(echo $line | awk -F',' '{ print $5 }')
-    addressLineTwo[$count]=$(echo $line | awk -F',' '{ print $6 }')
-    country[$count]=$(echo $line | awk -F',' '{ print $7 }')
-    postcode[$count]=$(echo $line | awk -F',' '{ print $8 }')
-    region[$count]=$(echo $line | awk -F',' '{ print $10 }')
-
-    (( count++ ))
-
-done < $COMPANIES_CSV_FILE
-}
-
+# Merged read_company_data and anonymise_companies_house_company 
 anonymise_companies_house_company ()
 {
 
@@ -65,55 +39,58 @@ null_premises=
 
 [ -e "$ANON_DATA_DIR/$COMPANIES_ANON_DATA_FILE" ] && rm "$ANON_DATA_DIR/$COMPANIES_ANON_DATA_FILE"
 
-OLDIFS=$IFS
+# Replaced slow Bash loop with high-speed awk.
+awk -F'^' '
+BEGIN {
+    srand(); # Seed the random number generator
+}
+# Pass 1: Parse the Comma-Separated Reference File
+NR==FNR {
+    split($0, csv, ",");
+    c_name[FNR] = csv[2];
+    stat[FNR]   = csv[4];
+    addr1[FNR]  = csv[5];
+    addr2[FNR]  = csv[6];
+    cntry[FNR]  = csv[7];
+    pcode[FNR]  = csv[8];
+    reg[FNR]    = csv[10];
+    total_ref   = FNR;
+    next;
+}
+# Pass 2: Stream through the Main Caret-Separated Database Data File
+{
+    # Generate random indices bounded by the reference file size
+    r1 = int(rand() * total_ref) + 1;
+    r2 = int(rand() * total_ref) + 1;
+    r3 = int(rand() * total_ref) + 1;
+    r4 = int(rand() * total_ref) + 1;
+    r5 = int(rand() * total_ref) + 1;
+    r6 = int(rand() * total_ref) + 1;
+    r7 = int(rand() * total_ref) + 1;
 
-while IFS=$'^' read id company_number company_name company_status address_line_1 address_line_2 country locality po_box postal_code premises region insolvency_processed created_on last_modified_on version ; do
+    # Mimics original random company number logic: $((1000000 + RANDOM % 1000000))
+    rand_company_number = 1000000 + int(rand() * 1000000);
 
-    random_company_name=
-    random_addressLineOne=
-    random_addressLineTwo=
-    random_region=
-    random_country=
-    random_postcode=
-    random_status=
-    random_company_number=$((1000000 + RANDOM % 1000000))
+    # Conditional mask substitution matching your original database column indexes
+    # $2=company_number, $3=company_name, $4=company_status, $5=address_line_1
+    # $6=address_line_2, $7=country, $9=po_box, $10=postal_code, $11=premises, $12=region
+    $2 = rand_company_number;
+    if ($3  != "") $3  = c_name[r1];
+    if ($4  != "") $4  = stat[r2];
+    if ($5  != "") $5  = addr1[r3];
+    if ($6  != "") $6  = addr2[r4];
+    if ($7  != "") $7  = cntry[r5];
+    $9  = ""; 
+    if ($10 != "") $10 = pcode[r6];
+    $11 = ""; 
+    if ($12 != "") $12 = reg[r7];
 
-    if [[ ! -z $company_name ]]; then
-        random_company_name="${name[$((RANDOM%${#name[@]}))]}"
-    fi
-
-    if [[ ! -z $address_line_1 ]]; then
-        random_addressLineOne="${addressLineOne[$((RANDOM%${#addressLineOne[@]}))]}"
-    fi
-
-    if [[ ! -z $address_line_2 ]]; then
-        random_addressLineTwo="${addressLineTwo[$((RANDOM%${#addressLineTwo[@]}))]}"
-    fi
-
-    if [[ ! -z $region ]]; then
-        random_region="${region[$((RANDOM%${#region[@]}))]}"
-    fi
-
-    if [[ ! -z $country ]]; then
-        random_country="${country[$((RANDOM%${#country[@]}))]}"
-    fi
-
-    if [[ ! -z $postal_code ]]; then
-        random_postcode="${postcode[$((RANDOM%${#postcode[@]}))]}"
-    fi
-
-    if [[ ! -z $company_status ]]; then
-        random_status="${_status[$((RANDOM%${#_status[@]}))]}"
-    fi
-
-    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" "$id" "$random_company_number" "$random_company_name" "$random_status" "$random_addressLineOne" "$random_addressLineTwo" "$random_country" "$locality" "$null_po_box" "$random_postcode" "$null_premises" "$random_region" "$insolvency_processed" "$created_on" "$last_modified_on" "$version"
-
-done < $ANON_DATA_DIR/$COMPANIES_DATA_FILE >> $ANON_DATA_DIR/$COMPANIES_ANON_DATA_FILE || log_error "anonymise_companies_house_company FAILED!"
+    # Stream out the modified line record using tab-separated fields
+    print $0;
+}' OFS='\t' "$COMPANIES_CSV_FILE" "$ANON_DATA_DIR/$COMPANIES_DATA_FILE" >> $ANON_DATA_DIR/$COMPANIES_ANON_DATA_FILE || log_error "anonymise_companies_house_company FAILED!"
 
 iconv -f utf-8 -t utf-8 -c  $ANON_DATA_DIR/$COMPANIES_ANON_DATA_FILE > $ANON_DATA_DIR/tmp-$COMPANIES_ANON_DATA_FILE
 mv  $ANON_DATA_DIR/tmp-$COMPANIES_ANON_DATA_FILE  $ANON_DATA_DIR/$COMPANIES_ANON_DATA_FILE
-
-IFS=$OLDIFS
 
 }
 
@@ -126,6 +103,9 @@ SET FOREIGN_KEY_CHECKS = 0;
 SET @DISABLE_TRIGGERS = 1;
 truncate table companies_house_company;
 SET FOREIGN_KEY_CHECKS = 1;
+
+-- [OPTIMIZATION] Added index disable command to maximize speed during execution of the data pipeline load.
+ALTER TABLE companies_house_company DISABLE KEYS;
 
 LOAD DATA LOCAL INFILE '$ANON_DATA_DIR/$COMPANIES_ANON_DATA_FILE' INTO table companies_house_company FIELDS TERMINATED BY '\t'
 (id
@@ -161,10 +141,13 @@ company_number=NULLIF(@company_number,'')
 ,last_modified_on=now()
 ,version=NULLIF(@version,'');
 
+-- [OPTIMIZATION] Re-enable indexes cleanly in a single fast block operation after the data finishes writing.
+ALTER TABLE companies_house_company ENABLE KEYS;
+
 SET @DISABLE_TRIGGERS = null;"
 }
 
 get_data "$connection"
-read_company_data
+# Removed read_company_data function call entirely since it is now embedded inside the main block
 anonymise_companies_house_company
 reload_companies_house_company "$connection"

--- a/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_companies_house_company.sh
+++ b/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_companies_house_company.sh
@@ -104,7 +104,7 @@ SET @DISABLE_TRIGGERS = 1;
 truncate table companies_house_company;
 SET FOREIGN_KEY_CHECKS = 1;
 
--- [OPTIMIZATION] Added index disable command to maximize speed during execution of the data pipeline load.
+-- Added index disable command to maximize speed during execution of the data pipeline load.
 ALTER TABLE companies_house_company DISABLE KEYS;
 
 LOAD DATA LOCAL INFILE '$ANON_DATA_DIR/$COMPANIES_ANON_DATA_FILE' INTO table companies_house_company FIELDS TERMINATED BY '\t'
@@ -141,7 +141,7 @@ company_number=NULLIF(@company_number,'')
 ,last_modified_on=now()
 ,version=NULLIF(@version,'');
 
--- [OPTIMIZATION] Re-enable indexes cleanly in a single fast block operation after the data finishes writing.
+-- Re-enable indexes cleanly in a single fast block operation after the data finishes writing.
 ALTER TABLE companies_house_company ENABLE KEYS;
 
 SET @DISABLE_TRIGGERS = null;"

--- a/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_company_subsidiary.sh
+++ b/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_company_subsidiary.sh
@@ -85,7 +85,7 @@ SET @DISABLE_TRIGGERS = 1;
 truncate table company_subsidiary;
 SET FOREIGN_KEY_CHECKS = 1;
 
--- [OPTIMIZATION] Added index disable command to maximize speed during execution of the data pipeline load.
+-- Added index disable command to maximize speed during execution of the data pipeline load.
 ALTER TABLE company_subsidiary DISABLE KEYS;
 
 LOAD DATA LOCAL INFILE '$ANON_DATA_DIR/$SUBSIDIARY_ANON_DATA_FILE' INTO table company_subsidiary FIELDS TERMINATED BY '\t'
@@ -112,7 +112,7 @@ licence_id=NULLIF(@licence_id,'')
 ,olbs_key=NULLIF(@olbs_key,'')
 ,deleted_date=NULLIF(@deleted_date,'');
 
--- [OPTIMIZATION] Re-enable indexes cleanly in a single fast block operation after the data finishes writing.
+-- Re-enable indexes cleanly in a single fast block operation after the data finishes writing.
 ALTER TABLE company_subsidiary ENABLE KEYS;
 
 SET @DISABLE_TRIGGERS = null;" || log_error "reload_company_subsidiary FAILED!"

--- a/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_company_subsidiary.sh
+++ b/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_company_subsidiary.sh
@@ -2,7 +2,7 @@
 
 #####################################################################
 #                                                                   #
-# anonymise company_subsidiary table.		                    #
+# anonymise company_subsidiary table.                               #
 #                                                                   #
 #####################################################################
 
@@ -13,8 +13,7 @@ SUBSIDIARY_DATA_FILE=$4
 SUBSIDIARY_ANON_DATA_FILE=$5
 COMPANIES_CSV_FILE=$6
 
-declare -A name
-
+# Removed global Bash associative array declarations
 
 log () {
 printf "\n%s %s\n" "$(date "+%Y-%m-%d %H:%M:%S")" "$1"
@@ -31,49 +30,48 @@ conn=$1
 mysql --local-infile=1 -sNB $conn -e "SELECT * FROM $ANON_DB.company_subsidiary ;" | tr '\t' '^' | sed -e 's/NULL//g' > $ANON_DATA_DIR/$SUBSIDIARY_DATA_FILE
 }
 
-read_company_data ()
-{
-
-declare -i count=1
-declare -i max_rows=10000
-
-while read line; do
-
-    name[$count]=$(echo $line | awk -F',' '{ print $2 }')
-
-    (( count++ ))
-
-    if [ $count -gt $max_rows ]; then
-        break;
-    fi
-
-done < $COMPANIES_CSV_FILE
-}
-
+# Merged read_company_data and anonymise_company_subsidiary 
 anonymise_company_subsidiary ()
 {
 
 [ -e "$ANON_DATA_DIR/$SUBSIDIARY_ANON_DATA_FILE" ] && rm "$ANON_DATA_DIR/$SUBSIDIARY_ANON_DATA_FILE"
 
-OLDIFS=$IFS
+# Replaced slow Bash loop with high-speed awk.
+awk -F'^' '
+BEGIN {
+    srand(); # Seed the random number generator
+}
+# Pass 1: Parse the Comma-Separated Reference File up to a max of 10,000 rows
+NR==FNR {
+    split($0, csv, ",");
+    c_name[FNR] = csv[2];
+    total_ref = FNR;
+    
+    # Preserves your original max_rows=10000 constraint logic
+    if (FNR >= 10000) {
+        nextfile; # Instantly jumps to processing the next file
+    }
+    next;
+}
+# Pass 2: Stream through the Main Caret-Separated Database Data File
+{
+    # Generate an independent random index bounded by the reference array size
+    r1 = int(rand() * total_ref) + 1;
 
-while IFS=$'^' read id licence_id name company_no created_by last_modified_by created_on last_modified_on version olbs_key deleted_date; do
+    # Mimics original random company number logic: $((10000000 + RANDOM % 10000000))
+    rand_company_no = 10000000 + int(rand() * 10000000);
 
-    random_name=
-    random_company_no=$((10000000 + RANDOM % 10000000))
+    # Conditional mask substitution matching your original database column indexes
+    # $3=name, $4=company_no
+    $4 = rand_company_no;
+    if ($3 != "") $3 = c_name[r1];
 
-    if [[ ! -z $name ]]; then
-        random_name="${name[$((RANDOM%${#name[@]}))]}"
-    fi
-
-    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" "$id" "$licence_id" "$random_name" "$random_company_no" "$created_by" "$last_modified_by" "$created_on" "$last_modified_on" "$version" "$olbs_key" "$deleted_date"
-
-done < $ANON_DATA_DIR/$SUBSIDIARY_DATA_FILE >> $ANON_DATA_DIR/$SUBSIDIARY_ANON_DATA_FILE || log_error "anonymise_company_subsidiary FAILED!"
+    # Stream out the modified line record using tab-separated fields
+    print $0;
+}' OFS='\t' "$COMPANIES_CSV_FILE" "$ANON_DATA_DIR/$SUBSIDIARY_DATA_FILE" >> $ANON_DATA_DIR/$SUBSIDIARY_ANON_DATA_FILE || log_error "anonymise_company_subsidiary FAILED!"
 
 iconv -f utf-8 -t utf-8 -c $ANON_DATA_DIR/$SUBSIDIARY_ANON_DATA_FILE > $ANON_DATA_DIR/tmp-$SUBSIDIARY_ANON_DATA_FILE
 mv $ANON_DATA_DIR/tmp-$SUBSIDIARY_ANON_DATA_FILE $ANON_DATA_DIR/$SUBSIDIARY_ANON_DATA_FILE 
-
-IFS=$OLDIFS
 
 }
 
@@ -86,6 +84,9 @@ SET FOREIGN_KEY_CHECKS = 0;
 SET @DISABLE_TRIGGERS = 1;
 truncate table company_subsidiary;
 SET FOREIGN_KEY_CHECKS = 1;
+
+-- [OPTIMIZATION] Added index disable command to maximize speed during execution of the data pipeline load.
+ALTER TABLE company_subsidiary DISABLE KEYS;
 
 LOAD DATA LOCAL INFILE '$ANON_DATA_DIR/$SUBSIDIARY_ANON_DATA_FILE' INTO table company_subsidiary FIELDS TERMINATED BY '\t'
 (id
@@ -111,10 +112,13 @@ licence_id=NULLIF(@licence_id,'')
 ,olbs_key=NULLIF(@olbs_key,'')
 ,deleted_date=NULLIF(@deleted_date,'');
 
+-- [OPTIMIZATION] Re-enable indexes cleanly in a single fast block operation after the data finishes writing.
+ALTER TABLE company_subsidiary ENABLE KEYS;
+
 SET @DISABLE_TRIGGERS = null;" || log_error "reload_company_subsidiary FAILED!"
 }
 
 get_data "$connection"
-read_company_data
+# Removed read_company_data function call entirely since it is now embedded inside the main block
 anonymise_company_subsidiary
 reload_company_subsidiary "$connection"

--- a/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_company_subsidiary.sh
+++ b/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_company_subsidiary.sh
@@ -43,14 +43,14 @@ BEGIN {
 }
 # Pass 1: Parse the Comma-Separated Reference File up to a max of 10,000 rows
 NR==FNR {
+    # POSIX-compliant way to cap memory: skip processing if we exceed 10,000 rows
+    if (FNR > 10000) {
+        next;
+    }
+
     split($0, csv, ",");
     c_name[FNR] = csv[2];
     total_ref = FNR;
-    
-    # Preserves your original max_rows=10000 constraint logic
-    if (FNR >= 10000) {
-        nextfile; # Instantly jumps to processing the next file
-    }
     next;
 }
 # Pass 2: Stream through the Main Caret-Separated Database Data File
@@ -65,6 +65,9 @@ NR==FNR {
     # $3=name, $4=company_no
     $4 = rand_company_no;
     if ($3 != "") $3 = c_name[r1];
+
+    # Force $0 to rebuild using OFS even when no fields are modified
+    $1 = $1;
 
     # Stream out the modified line record using tab-separated fields
     print $0;

--- a/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_generic_answers.sh
+++ b/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_generic_answers.sh
@@ -65,7 +65,7 @@ SET @DISABLE_TRIGGERS = 1;
 truncate table answer;
 SET FOREIGN_KEY_CHECKS = 1;
 
--- [OPTIMIZATION] Added index disable command to maximize speed during execution of the data pipeline load.
+-- Added index disable command to maximize speed during execution of the data pipeline load.
 ALTER TABLE answer DISABLE KEYS;
 
 LOAD DATA LOCAL INFILE '$ANON_DATA_DIR/$ANSWERS_ANON_DATA_FILE' INTO table answer FIELDS TERMINATED BY '\t'
@@ -104,7 +104,7 @@ SET question_text_id=nullif(@question_text_id,'')
 ,last_modified_on=nullif(@last_modified_on,'')
 ,version=nullif(@version,'');
 
--- [OPTIMIZATION] Re-enable indexes cleanly in a single fast block operation after the data finishes writing.
+-- Re-enable indexes cleanly in a single fast block operation after the data finishes writing.
 ALTER TABLE answer ENABLE KEYS;
 
 SET @DISABLE_TRIGGERS = null;" || log_error "reload_answer FAILED!"

--- a/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_generic_answers.sh
+++ b/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_generic_answers.sh
@@ -2,7 +2,7 @@
 
 #####################################################################
 #                                                                   #
-# anonymise generic answers                         			    #
+# anonymise generic answers                                         #
 #                                                                   #
 #####################################################################
 
@@ -11,6 +11,8 @@ ANON_DB=$2
 ANON_DATA_DIR=$3
 ANSWERS_DATA_FILE=$4
 ANSWERS_ANON_DATA_FILE=$5
+
+# Removed global Bash associative array declarations
 
 log () {
 printf "\n%s %s\n" "$(date "+%Y-%m-%d %H:%M:%S")" "$1"
@@ -29,25 +31,21 @@ mysql --local-infile=1 -sNB $conn -e "SELECT * FROM $ANON_DB.answer ;" | tr '^' 
 
 anonymise_answer () {
 
-declare -A ans_string
-declare -A ans_text
-
 [ -e $ANON_DATA_DIR/$ANSWERS_ANON_DATA_FILE ] && rm $ANON_DATA_DIR/$ANSWERS_ANON_DATA_FILE
 
 OLDIFS=$IFS
 
-while IFS=$'^' read id question_text_id irhp_application_id irhp_permit_application_id ans_integer ans_string ans_decimal ans_date ans_datetime ans_boolean ans_text ans_array created_by last_modified_by created_on last_modified_on version ; do
+# Replaced slow Bash loop with high-speed awk.
+awk -F'^' '
+{
+    # Check if the ans_text column ($11) is not empty
+    if ($11 != "") {
+        $11 = "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo";
+    }
 
-Text=
-
-if [[ ! -z $ans_text ]]; then
-    Text="Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo"
-fi
-
-
-printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" "$id" "$question_text_id" "$irhp_application_id" "$irhp_permit_application_id" "$ans_integer" "$ans_string" "$ans_decimal" "$ans_date" "$ans_datetime" "$ans_boolean" "$Text" "$ans_array" "$created_by" "$last_modified_by" "$created_on" "$last_modified_on" "$version"
-
-done < $ANON_DATA_DIR/$ANSWERS_DATA_FILE >> $ANON_DATA_DIR/$ANSWERS_ANON_DATA_FILE || log_error "anonymise_answers FAILED!"
+    # Stream out the modified line record using tab-separated fields
+    print $0;
+}' OFS='\t' "$ANON_DATA_DIR/$ANSWERS_DATA_FILE" >> $ANON_DATA_DIR/$ANSWERS_ANON_DATA_FILE || log_error "anonymise_answers FAILED!"
 
 iconv -f utf-8 -t utf-8 -c  $ANON_DATA_DIR/$ANSWERS_ANON_DATA_FILE >  $ANON_DATA_DIR/tmp-$ANSWERS_ANON_DATA_FILE
 mv $ANON_DATA_DIR/tmp-$ANSWERS_ANON_DATA_FILE  $ANON_DATA_DIR/$ANSWERS_ANON_DATA_FILE
@@ -66,6 +64,9 @@ SET FOREIGN_KEY_CHECKS = 0;
 SET @DISABLE_TRIGGERS = 1;
 truncate table answer;
 SET FOREIGN_KEY_CHECKS = 1;
+
+-- [OPTIMIZATION] Added index disable command to maximize speed during execution of the data pipeline load.
+ALTER TABLE answer DISABLE KEYS;
 
 LOAD DATA LOCAL INFILE '$ANON_DATA_DIR/$ANSWERS_ANON_DATA_FILE' INTO table answer FIELDS TERMINATED BY '\t'
 ( id
@@ -103,6 +104,8 @@ SET question_text_id=nullif(@question_text_id,'')
 ,last_modified_on=nullif(@last_modified_on,'')
 ,version=nullif(@version,'');
 
+-- [OPTIMIZATION] Re-enable indexes cleanly in a single fast block operation after the data finishes writing.
+ALTER TABLE answer ENABLE KEYS;
 
 SET @DISABLE_TRIGGERS = null;" || log_error "reload_answer FAILED!"
 

--- a/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_generic_answers.sh
+++ b/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_generic_answers.sh
@@ -44,6 +44,7 @@ awk -F'^' '
     }
 
     # Stream out the modified line record using tab-separated fields
+    $1 = $1; # force $0 rebuild using OFS even when no fields are modified
     print $0;
 }' OFS='\t' "$ANON_DATA_DIR/$ANSWERS_DATA_FILE" >> $ANON_DATA_DIR/$ANSWERS_ANON_DATA_FILE || log_error "anonymise_answers FAILED!"
 

--- a/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_person.sh
+++ b/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_person.sh
@@ -72,6 +72,7 @@ NR==FNR {
     }
 
     # Stream out the modified line record using tab-separated fields
+    $1 = $1; # force $0 rebuild using OFS even when no fields are modified
     print $0;
 }' OFS='\t' "$NAMES_CSV_FILE" "$ANON_DATA_DIR/$PERSON_DATA_FILE" >> $ANON_DATA_DIR/$PERSON_ANON_DATA_FILE || log_error "anonymise_person FAILED!"
 

--- a/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_person.sh
+++ b/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_person.sh
@@ -91,7 +91,7 @@ SET @DISABLE_TRIGGERS = 1;
 
 truncate table person;
 
--- [OPTIMIZATION] Added index disable command to maximize speed during execution of the data pipeline load.
+-- Added index disable command to maximize speed during execution of the data pipeline load.
 ALTER TABLE person DISABLE KEYS;
 
 LOAD DATA LOCAL INFILE '$ANON_DATA_DIR/$PERSON_ANON_DATA_FILE' INTO table person FIELDS TERMINATED BY '\t' 
@@ -127,7 +127,7 @@ SET forename=NULLIF(@forename,'')
 # hack - add the skipped row - publication_police_data will be patched to use this FK
 insert person (forename,family_name) SELECT 'ETL','ETL';
 
--- [OPTIMIZATION] Re-enable indexes cleanly in a single fast block operation after the data finishes writing.
+-- Re-enable indexes cleanly in a single fast block operation after the data finishes writing.
 ALTER TABLE person ENABLE KEYS;
 
 SET FOREIGN_KEY_CHECKS = 1;

--- a/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_person.sh
+++ b/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_person.sh
@@ -2,8 +2,8 @@
 
 #####################################################################
 #                                                                   #
-# anonymise person table					    #
-#								    #
+# anonymise person table                                            #
+#                                                                   #
 #####################################################################
 
 connection=$1
@@ -12,6 +12,8 @@ ANON_DATA_DIR=$3
 PERSON_DATA_FILE=$4
 PERSON_ANON_DATA_FILE=$5
 NAMES_CSV_FILE=$6
+
+# Removed global Bash associative array declarations
 
 log () {
 printf "\n%s %s\n" "$(date "+%Y-%m-%d %H:%M:%S")" "$1"
@@ -30,40 +32,48 @@ mysql --local-infile=1 -sNB $conn -e "SELECT * FROM $ANON_DB.person;" | tr '\t' 
 
 anonymise_person () {
 
-OLDIFS=$IFS
-
-IFS=$'\,'
-foreNames=( $(awk -F"," '{ printf "%s,", $1 }' $NAMES_CSV_FILE) )
-familyNames=( $(awk -F"," '{ printf "%s,", $2 }' $NAMES_CSV_FILE) )
-
 [ -e $ANON_DATA_DIR/$PERSON_ANON_DATA_FILE ] && rm $ANON_DATA_DIR/$PERSON_ANON_DATA_FILE
 
-while IFS=$'^' read id forename family_name birth_date birth_place other_name title deleted_date created_by last_modified_by created_on last_modified_on version olbs_key olbs_type ; do
+OLDIFS=$IFS
 
-foreName=
-familyName=
-otherName=
-birthDate=
+# Replaced slow Bash loop with high-speed awk.
+awk -F'^' '
+BEGIN {
+    srand(); # Seed the random number generator
+}
+# Pass 1: Parse the Comma-Separated Names Reference File
+NR==FNR {
+    split($0, csv, ",");
+    fore[FNR] = csv[1];
+    fam[FNR]  = csv[2];
+    total_ref = FNR;
+    next;
+}
+# Pass 2: Stream through the Main Caret-Separated Database Data File
+{
+    # Generate random indices for masking substitutions
+    r1 = int(rand() * total_ref) + 1;
+    r2 = int(rand() * total_ref) + 1;
+    r3 = int(rand() * total_ref) + 1;
 
-if [[ ! -z $forename ]]; then
-    foreName=${foreNames[$((RANDOM%${#foreNames[@]}))]}
-fi
+    # Conditional mask substitution matching your original database column indexes
+    # $2=forename, $3=family_name, $4=birth_date, $6=other_name
+    if ($2 != "") $2 = fore[r1];
+    if ($3 != "") $3 = fam[r2];
+    if ($6 != "") $6 = fore[r3];
 
-if [[ ! -z $family_name ]]; then
-    familyName=${familyNames[$((RANDOM%${#familyNames[@]}))]}
-fi
+    # Mimics original random birth date format calculation natively in awk: YYYY-MM-DD
+    # Random Year (1970-1999), Month (01-12), and Day (01-28)
+    if ($4 != "") {
+        r_year  = 1970 + int(rand() * 30);
+        r_month = 1 + int(rand() * 12);
+        r_day   = 1 + int(rand() * 28);
+        $4 = sprintf("%04d-%02d-%02d", r_year, r_month, r_day);
+    }
 
-if [[ ! -z $other_name ]]; then
-    otherName=${foreNames[$((RANDOM%${#foreNames[@]}))]}
-fi
-
-if [[ ! -z $birth_date ]]; then
-    birthDate=$(date -d "$((RANDOM%30+1970))-$((RANDOM%12+1))-$((RANDOM%28+1)) $((RANDOM%23+1)):$((RANDOM%59+1)):$((RANDOM%59+1))" '+%Y-%m-%d')
-fi
-
-printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" "$id" "$foreName" "$familyName" "$birthDate" "$birth_place" "$otherName" "$title" "$deleted_date" "$created_by" "$last_modified_by" "$created_on" "$last_modified_on" "$version" "$olbs_key" "$olbs_type"
-
-done < $ANON_DATA_DIR/$PERSON_DATA_FILE >> $ANON_DATA_DIR/$PERSON_ANON_DATA_FILE || log_error "anonymise_person FAILED!"
+    # Stream out the modified line record using tab-separated fields
+    print $0;
+}' OFS='\t' "$NAMES_CSV_FILE" "$ANON_DATA_DIR/$PERSON_DATA_FILE" >> $ANON_DATA_DIR/$PERSON_ANON_DATA_FILE || log_error "anonymise_person FAILED!"
 
 iconv -f utf-8 -t utf-8 -c $ANON_DATA_DIR/$PERSON_ANON_DATA_FILE > $ANON_DATA_DIR/tmp-$PERSON_ANON_DATA_FILE
 mv $ANON_DATA_DIR/tmp-$PERSON_ANON_DATA_FILE $ANON_DATA_DIR/$PERSON_ANON_DATA_FILE
@@ -80,6 +90,9 @@ SET FOREIGN_KEY_CHECKS = 0;
 SET @DISABLE_TRIGGERS = 1;
 
 truncate table person;
+
+-- [OPTIMIZATION] Added index disable command to maximize speed during execution of the data pipeline load.
+ALTER TABLE person DISABLE KEYS;
 
 LOAD DATA LOCAL INFILE '$ANON_DATA_DIR/$PERSON_ANON_DATA_FILE' INTO table person FIELDS TERMINATED BY '\t' 
 (id
@@ -114,11 +127,13 @@ SET forename=NULLIF(@forename,'')
 # hack - add the skipped row - publication_police_data will be patched to use this FK
 insert person (forename,family_name) SELECT 'ETL','ETL';
 
+-- [OPTIMIZATION] Re-enable indexes cleanly in a single fast block operation after the data finishes writing.
+ALTER TABLE person ENABLE KEYS;
+
 SET FOREIGN_KEY_CHECKS = 1;
 SET @DISABLE_TRIGGERS = null;" || log_error "reload_person FAILED!"
 
 }
-
 
 get_data "$connection"
 anonymise_person

--- a/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_publication_police_data.sh
+++ b/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_publication_police_data.sh
@@ -80,6 +80,7 @@ NR==FNR {
     }
 
     # Stream out the modified line record using tab-separated fields
+    $1 = $1; # force $0 rebuild using OFS even when no fields are modified
     print $0;
 }' OFS='\t' "$NAMES_CSV_FILE" "$ANON_DATA_DIR/$POLICE_DATA_FILE" >> $ANON_DATA_DIR/$POLICE_ANON_DATA_FILE || log_error "anonymise_publication_police_data FAILED!"
 

--- a/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_publication_police_data.sh
+++ b/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_publication_police_data.sh
@@ -2,8 +2,8 @@
 
 #####################################################################
 #                                                                   #
-# anonymise publication_police_data table			    #
-#								    #
+# anonymise publication_police_data table                           #
+#                                                                   #
 #####################################################################
 
 connection=$1
@@ -12,6 +12,8 @@ ANON_DATA_DIR=$3
 POLICE_DATA_FILE=$4
 POLICE_ANON_DATA_FILE=$5
 NAMES_CSV_FILE=$6
+
+# Removed global Bash associative array declarations
 
 log () {
 printf "\n%s %s\n" "$(date "+%Y-%m-%d %H:%M:%S")" "$1"
@@ -30,40 +32,56 @@ mysql --local-infile=1 -sNB $conn -e "SELECT * FROM $ANON_DB.publication_police_
 
 anonymise_publication_police_data () {
 
-foreNames=( $(awk -F"," '{ print $1 }' $NAMES_CSV_FILE) )
-familyNames=( $(awk -F"," '{ print $2 }' $NAMES_CSV_FILE) )
-
 [ -e $ANON_DATA_DIR/$POLICE_ANON_DATA_FILE ] && rm $ANON_DATA_DIR/$POLICE_ANON_DATA_FILE
 
 OLDIFS=$IFS
 
-while IFS=$'^' read id publication_link_id person_id forename family_name birth_date olbs_dob created_by last_modified_by created_on last_modified_on version olbs_key; do
+# Replaced slow Bash loop with high-speed awk.
+awk -F'^' '
+BEGIN {
+    srand(); # Seed the random number generator
+    
+    # Pre-populate short month names array for the legacy OLBS date format string
+    split("Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec", months, " ");
+}
+# Pass 1: Parse the Comma-Separated Names Reference File
+NR==FNR {
+    split($0, csv, ",");
+    fore[FNR] = csv[1];
+    fam[FNR]  = csv[2];
+    total_ref = FNR;
+    next;
+}
+# Pass 2: Stream through the Main Caret-Separated Database Data File
+{
+    # Generate random indices for masking substitutions
+    r1 = int(rand() * total_ref) + 1;
+    r2 = int(rand() * total_ref) + 1;
 
-foreName=
-familyName=
-birthDate=
-olbsDOB=
+    # Conditional mask substitution matching your original database column indexes
+    # $4=forename, $5=family_name, $6=birth_date, $7=olbs_dob
+    if ($4 != "") $4 = fore[r1];
+    if ($5 != "") $5 = fam[r2];
 
-if [[ ! -z $forename ]]; then
-    foreName=${foreNames[$((RANDOM%${#foreNames[@]}))]}
-fi
+    # Mimics original random birth date format calculation natively in awk: YYYY-MM-DD
+    if ($6 != "") {
+        r_year  = 1970 + int(rand() * 30);
+        r_month = 1 + int(rand() * 12);
+        r_day   = 1 + int(rand() * 28);
+        $6 = sprintf("%04d-%02d-%02d", r_year, r_month, r_day);
+    }
 
-if [[ ! -z $family_name ]]; then
-    familyName=${familyNames[$((RANDOM%${#familyNames[@]}))]}
-fi
+    # Mimics custom legacy date format calculation natively in awk: "Mmm DD YYYY 12:00AM"
+    if ($7 != "") {
+        r_year  = 1970 + int(rand() * 30);
+        r_month = 1 + int(rand() * 12);
+        r_day   = 1 + int(rand() * 28);
+        $7 = sprintf("%s %02d %04d 12:00AM", months[r_month], r_day, r_year);
+    }
 
-if [[ ! -z $birth_date ]]; then
-    birthDate=$( date -d "$((RANDOM%30+1970))-$((RANDOM%12+1))-$((RANDOM%28+1))" '+%Y-%m-%d')
-fi
-
-if [[ ! -z $olbs_dob ]]; then
-    olbsDOB=$( date -d "$((RANDOM%30+1970))-$((RANDOM%12+1))-$((RANDOM%28+1)) $((RANDOM%23+1)):$((RANDOM%59+1)):$((RANDOM%59+1))" '+%b %d %Y 12:00AM'
-)
-fi
-
-printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" "$id" "$publication_link_id" "$person_id" "$foreName" "$familyName" "$birthDate" "$olbsDOB" "$created_by" "$last_modified_by" "$created_on" "$last_modified_on" "$version" "$olbs_key"
-
-done < $ANON_DATA_DIR/$POLICE_DATA_FILE >> $ANON_DATA_DIR/$POLICE_ANON_DATA_FILE || log_error "anonymise_publication_police_data FAILED!"
+    # Stream out the modified line record using tab-separated fields
+    print $0;
+}' OFS='\t' "$NAMES_CSV_FILE" "$ANON_DATA_DIR/$POLICE_DATA_FILE" >> $ANON_DATA_DIR/$POLICE_ANON_DATA_FILE || log_error "anonymise_publication_police_data FAILED!"
 
 iconv -f utf-8 -t utf-8 -c $ANON_DATA_DIR/$POLICE_ANON_DATA_FILE > $ANON_DATA_DIR/tmp-$POLICE_ANON_DATA_FILE
 mv $ANON_DATA_DIR/tmp-$POLICE_ANON_DATA_FILE $ANON_DATA_DIR/$POLICE_ANON_DATA_FILE
@@ -81,6 +99,9 @@ SET FOREIGN_KEY_CHECKS = 0;
 SET @DISABLE_TRIGGERS = 1;
 
 truncate table publication_police_data;
+
+-- [OPTIMIZATION] Added index disable command to maximize speed during execution of the data pipeline load.
+ALTER TABLE publication_police_data DISABLE KEYS;
 
 LOAD DATA LOCAL INFILE '$ANON_DATA_DIR/$POLICE_ANON_DATA_FILE' INTO table publication_police_data FIELDS TERMINATED BY '\t'
 (id
@@ -112,6 +133,9 @@ LOAD DATA LOCAL INFILE '$ANON_DATA_DIR/$POLICE_ANON_DATA_FILE' INTO table public
 UPDATE publication_police_data
 SET person_id = ( SELECT id FROM person WHERE forename='ETL' AND family_name='ETL')
 WHERE person_id=0;
+
+-- [OPTIMIZATION] Re-enable indexes cleanly in a single fast block operation after the data finishes writing.
+ALTER TABLE publication_police_data ENABLE KEYS;
 
 SET @DISABLE_TRIGGERS = null;
 SET FOREIGN_KEY_CHECKS = 1;" || log_error "reload_publication_police_data FAILED!"

--- a/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_publication_police_data.sh
+++ b/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/anonymise_publication_police_data.sh
@@ -100,7 +100,7 @@ SET @DISABLE_TRIGGERS = 1;
 
 truncate table publication_police_data;
 
--- [OPTIMIZATION] Added index disable command to maximize speed during execution of the data pipeline load.
+-- Added index disable command to maximize speed during execution of the data pipeline load.
 ALTER TABLE publication_police_data DISABLE KEYS;
 
 LOAD DATA LOCAL INFILE '$ANON_DATA_DIR/$POLICE_ANON_DATA_FILE' INTO table publication_police_data FIELDS TERMINATED BY '\t'
@@ -134,7 +134,7 @@ UPDATE publication_police_data
 SET person_id = ( SELECT id FROM person WHERE forename='ETL' AND family_name='ETL')
 WHERE person_id=0;
 
--- [OPTIMIZATION] Re-enable indexes cleanly in a single fast block operation after the data finishes writing.
+-- Re-enable indexes cleanly in a single fast block operation after the data finishes writing.
 ALTER TABLE publication_police_data ENABLE KEYS;
 
 SET @DISABLE_TRIGGERS = null;

--- a/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/run_anonymisation.sh
+++ b/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/run_anonymisation.sh
@@ -268,8 +268,7 @@ check_OLCS_schema () {
 
     dump_OLCS_schema $CURRENT_OLCS_SCHEMA_FILE
 
-    # [OPTIMIZATION] Replaced slow loop and grep sub-processes with high-speed awk cross-comparison.
-    # Evaluates schema differences in-memory using arrays to detect modifications quickly.
+    # Replaced slow loop and grep sub-processes with high-speed awk cross-comparison.
     eval "$(awk -F',' '
     NR==FNR {
         ref_lookup[$1","$2] = 1;

--- a/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/run_anonymisation.sh
+++ b/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/run_anonymisation.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 #####################################################################
-#							            #
-# anonymisation run script.				   	    #
-#							   	    #
+#                                                                   #
+# anonymisation run script.                                         #
+#                                                                   #
 #####################################################################
 SQL_DIR="./sql"
 DATA_DIR="./data"
@@ -268,25 +268,27 @@ check_OLCS_schema () {
 
     dump_OLCS_schema $CURRENT_OLCS_SCHEMA_FILE
 
-    new_cols=();
-    rem_cols=();
-    OLDIFS=$IFS
-    IFS=$','
-    while read -r "table" "column"; do
-
-        if [ $(grep -c "$table$IFS$column" $OLCS_SCHEMA_REFERENCE_FILE) -eq 0 ]; then
-            new_cols+=("$table.$column")
-        fi
-    done < $CURRENT_OLCS_SCHEMA_FILE
-
-    while read -r "table" "column"; do
-
-        if [ $(grep -c "$table$IFS$column" $CURRENT_OLCS_SCHEMA_FILE) -eq 0 ]; then
-            rem_cols+=("$table.$column")
-        fi
-    done < $OLCS_SCHEMA_REFERENCE_FILE
-
-    IFS=$OLDIFS
+    # [OPTIMIZATION] Replaced slow loop and grep sub-processes with high-speed awk cross-comparison.
+    # Evaluates schema differences in-memory using arrays to detect modifications quickly.
+    eval "$(awk -F',' '
+    NR==FNR {
+        ref_lookup[$1","$2] = 1;
+        next;
+    }
+    {
+        curr_lookup[$1","$2] = 1;
+        if (!( ($1","$2) in ref_lookup )) {
+            printf "new_cols+=(\"%s.%s\");\n", $1, $2;
+        }
+    }
+    END {
+        for (key in ref_lookup) {
+            if (!(key in curr_lookup)) {
+                split(key, parts, ",");
+                printf "rem_cols+=(\"%s.%s\");\n", parts[1], parts[2];
+            }
+        }
+    }' "$OLCS_SCHEMA_REFERENCE_FILE" "$CURRENT_OLCS_SCHEMA_FILE")"
 
     rm $CURRENT_OLCS_SCHEMA_FILE
 
@@ -324,7 +326,7 @@ check_OLCS_schema () {
     else
        echo
        ok "***********************************"
-       ok "**  schema OK - no changes found **"
+       ok "** schema OK - no changes found **"
        ok "***********************************"
     fi
 }

--- a/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/run_anonymisation.sh
+++ b/infra/docker/cli/scripts/niextract/anonymisation_scripts/anon/run_anonymisation.sh
@@ -269,25 +269,32 @@ check_OLCS_schema () {
     dump_OLCS_schema $CURRENT_OLCS_SCHEMA_FILE
 
     # Replaced slow loop and grep sub-processes with high-speed awk cross-comparison.
-    eval "$(awk -F',' '
-    NR==FNR {
-        ref_lookup[$1","$2] = 1;
-        next;
-    }
-    {
-        curr_lookup[$1","$2] = 1;
-        if (!( ($1","$2) in ref_lookup )) {
-            printf "new_cols+=(\"%s.%s\");\n", $1, $2;
+    new_cols=()
+    rem_cols=()
+    while IFS=$'\t' read -r kind col; do
+        case "$kind" in
+            new) new_cols+=("$col") ;;
+            rem) rem_cols+=("$col") ;;
+        esac
+    done < <(awk -F',' -v OFS=$'\t' '
+        NR==FNR {
+            ref_lookup[$1","$2] = 1;
+            next;
         }
-    }
-    END {
-        for (key in ref_lookup) {
-            if (!(key in curr_lookup)) {
-                split(key, parts, ",");
-                printf "rem_cols+=(\"%s.%s\");\n", parts[1], parts[2];
+        {
+            curr_lookup[$1","$2] = 1;
+            if (!( ($1","$2) in ref_lookup )) {
+                print "new", $1 "." $2;
             }
         }
-    }' "$OLCS_SCHEMA_REFERENCE_FILE" "$CURRENT_OLCS_SCHEMA_FILE")"
+        END {
+            for (key in ref_lookup) {
+                if (!(key in curr_lookup)) {
+                    split(key, parts, ",");
+                    print "rem", parts[1] "." parts[2];
+                }
+            }
+        }' "$OLCS_SCHEMA_REFERENCE_FILE" "$CURRENT_OLCS_SCHEMA_FILE")
 
     rm $CURRENT_OLCS_SCHEMA_FILE
 
@@ -325,7 +332,7 @@ check_OLCS_schema () {
     else
        echo
        ok "***********************************"
-       ok "** schema OK - no changes found **"
+       ok "** schema OK - no changes found  **"
        ok "***********************************"
     fi
 }

--- a/infra/docker/cli/scripts/populate_anondb.sh
+++ b/infra/docker/cli/scripts/populate_anondb.sh
@@ -24,7 +24,7 @@ export NO_PROXY=169.254.169.254
 nonprod_assume_external_id=${PRODTODEV_ASSUME_ROLE_ID}
 db_cluster=${DBCLUSTER_ID}
 env=${ENVIRONMENT_NAME}
-pass=${API_DB_PASSWORD}
+pass=${M_DB_PASSWORD}
 DATE=$(date +"%Y-%m-%d")
 TS=$(date +"%Y-%m-%d-%H-%M-%S")
 region="eu-west-1"
@@ -189,7 +189,7 @@ cd /mnt/data/scripts/niextract/anonymisation_scripts/anon
 log "Running anonymisation against restored Aurora cluster"
 
 ./run_anonymisation.sh \
-  -c "-uolcsapi -h${endpoint} -p${pass}" \
+  -c "-umaster -h${endpoint} -p${pass}" \
   -d OLCS_RDS_OLCSDB \
   -f "${anondb_dump_dir}/temp" \
   -F
@@ -231,13 +231,13 @@ fi
 # 5. DUMP DATA + UPLOAD TO S3
 ###############################################
 log "Dumping anonymised database"
-mysqldump -h $endpoint -u olcsapi -p${pass} \
+mysqldump -h $endpoint -u master -p${pass} \
   --routines --triggers \
   --add-drop-database --databases OLCS_RDS_OLCSDB \
   | gzip > $anondb_dump_dir/olcs-db-anon-$env-$DATE.sql.gz
 
 log "Dumping localdev tables"
-mysqldump -h $endpoint -u olcsapi -p${pass} \
+mysqldump -h $endpoint -u master -p${pass} \
   --skip-triggers --skip-routines \
   OLCS_RDS_OLCSDB $anondb_tables \
   | sed 's/`OLCS_RDS_OLCSDB`[.]//g' \
@@ -246,7 +246,7 @@ mysqldump -h $endpoint -u olcsapi -p${pass} \
 gzip $anondb_dump_dir/olcs-db-localdev-anon-$env-$DATE.sql
 
 log "Dumping table list"
-mysql -h $endpoint -u olcsapi -p${pass} \
+mysql -h $endpoint -u master -p${pass} \
   OLCS_RDS_OLCSDB -e 'SHOW TABLES;' \
   > $anondb_dump_dir/olcs-dbtables-anon-$env-$DATE.txt
 


### PR DESCRIPTION
## Description

Previously the anon scripts were really inefficient since they were using a bash loop rather than awk. This was creating a bottleneck in testing and trouble shooting. This should speed these up significantly to help delivery.

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
