### PR TITLE
fix: cli container s3endpoint access

### DIFF
--- a/infra/docker/cli/scripts/populate_anondb.sh
+++ b/infra/docker/cli/scripts/populate_anondb.sh
@@ -19,8 +19,7 @@ set -euo pipefail
 
 export http_proxy=http://${PROXY}
 export https_proxy=http://${PROXY}
-export NO_PROXY=169.254.169.254
-
+ 
 export NO_PROXY=169.254.169.254,169.254.170.2,localhost,127.0.0.1,.amazonaws.com
 
 nonprod_assume_external_id=${PRODTODEV_ASSUME_ROLE_ID}

--- a/infra/docker/cli/scripts/populate_anondb.sh
+++ b/infra/docker/cli/scripts/populate_anondb.sh
@@ -21,6 +21,8 @@ export http_proxy=http://${PROXY}
 export https_proxy=http://${PROXY}
 export NO_PROXY=169.254.169.254
 
+export NO_PROXY=169.254.169.254,169.254.170.2,localhost,127.0.0.1,.amazonaws.com
+
 nonprod_assume_external_id=${PRODTODEV_ASSUME_ROLE_ID}
 db_cluster=${DBCLUSTER_ID}
 env=${ENVIRONMENT_NAME}

--- a/infra/docker/cli/scripts/s3assume.sh
+++ b/infra/docker/cli/scripts/s3assume.sh
@@ -11,7 +11,8 @@ unset AWS_SESSION_TOKEN
 
 export http_proxy=http://${PROXY}:3128
 export https_proxy=http://${PROXY}:3128
-export NO_PROXY=169.254.169.254
+export NO_PROXY=169.254.169.254,169.254.170.2,localhost,127.0.0.1,.amazonaws.com
+
 token=$(curl -s -X PUT 'http://169.254.169.254/latest/api/token' -H 'X-aws-ec2-metadata-token-ttl-seconds: 21600')
 region=$(curl -s -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/meta-data/placement/region)
 ec2_instance_id=$(curl -s -H "X-aws-ec2-metadata-token: $token" http://169.254.169.254/latest/meta-data/instance-id)


### PR DESCRIPTION
## Description

the proxy settings in the scripts had been configured to ensure traffic is directed through a proxy for CLI calls. However, we have centralised service endpoints in the VPC so these need to be configured to use no-proxy configuration within the scripts.

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
