### PR TITLE
fix: add timestamp to anon snapshot creation

### DIFF
--- a/infra/docker/cli/scripts/populate_anondb.sh
+++ b/infra/docker/cli/scripts/populate_anondb.sh
@@ -34,7 +34,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 tmp_cluster_id="olcs-anon-${TS}"
 tmp_instance_id="olcs-anon-${TS}-instance"
 snapshot_id="olcs-anon-snap-${TS}"
-anondb_snapshot_id="olcs-db-anon-${env}-${DATE}"
+anondb_snapshot_id="olcs-db-anon-${env}-${TS}"
 
 anondb_dump_dir="/mnt/data/anondump"
 anondb_tables="template template_test_data translation_key translation_key_text replacement public_holiday fee_type doc_template system_parameter feature_toggle financial_standing_rate"


### PR DESCRIPTION
## Description

The last run of the populate anondb job failed due to duplicate names. The current script appends date only to the produced snapshot name creating and error if this runs successfully multiple times a day. This has been amended to a timestamp now to ensure this is unique.

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
