### PR TITLE
fix: cluster naming now follows vol-app conventions

### DIFF
--- a/infra/terraform/modules/service/batch.tf
+++ b/infra/terraform/modules/service/batch.tf
@@ -96,11 +96,11 @@ locals {
         },
         {
           name  = "READDB_ID"
-          value = "${var.domain_env}-aurora-olcsdb-reader"
+          value = "${var.environment}-aurora-olcsdb-reader"
         },
         {
           name  = "DBCLUSTER_ID"
-          value = "${var.domain_env}-aurora-olcsdb-cluster"
+          value = "${var.environment}-aurora-olcsdb-cluster"
         },
         {
           name  = "READDB_NAME"


### PR DESCRIPTION
## Description

There is now two different naming conventions that reside in the VOL environments. This adds additional complexity when managing the environments and this now leads to a dual naming standard that the code needs to abide by.

This corrects the names for the rds aurora clusters use in the anonymisation.

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
