### PR TITLE
fix: use python rather than sed for substitution operations

### DIFF
--- a/infra/docker/cli/scripts/niextract/scripts/install_NI_Extract_db_objects.sh
+++ b/infra/docker/cli/scripts/niextract/scripts/install_NI_Extract_db_objects.sh
@@ -15,7 +15,14 @@ cd "$SCRIPT_DIR" || exit 1
 run_sql() {
     local file="$1"
     echo "Running $file..."
-    sed 's/DELIMITER \$\$//g; s/DELIMITER ;//g; s/\$\$/;\'$'\n/g' "$file" | mysql $CONNECTION "$DB" || { echo "ERROR: Failed to execute $file"; exit 1; }
+    python3 - "$file" << 'PYEOF' | mysql $CONNECTION "$DB" || { echo "ERROR: Failed to execute $file"; exit 1; }
+import sys
+content = open(sys.argv[1]).read()
+content = content.replace('DELIMITER $$', '')
+content = content.replace('DELIMITER ;', '')
+content = content.replace('$$', ';')
+print(content)
+PYEOF
 }
 
 run_sql "$SCRIPT_DIR/NI_Extract_table.sql"


### PR DESCRIPTION
## Description

The sed commands used to create the sql statements aren't working as expected on busybox. This PR changes the approach to use python instead to try and solve persistent formatting issues.

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
