### PR TITLE
fix: route Notify client via shared egress proxy; fix HTMLPurifier path

### DIFF
--- a/app/api/config/autoload/config.global.php
+++ b/app/api/config/autoload/config.global.php
@@ -290,6 +290,10 @@ return [
                 'en_GB' => '%olcs_notify_template_en_gb%',
                 'cy_GB' => '%olcs_notify_template_cy_gb%',
             ],
+            // Outbound egress in deployed environments is only reachable via the shared forward
+            // proxy, so the Notify HTTP client is routed through it like every other external
+            // integration. Overridden to empty in local.php where egress is direct.
+            'proxy' => 'http://%shd_proxy%',
         ],
         // VOL-7238: dedicated DSN for the admin "Send test via Notify" button. Populated only
         // in pre-cutover envs (dev/int) so admins can exercise the Notify path against a

--- a/app/api/config/autoload/local.php.dist
+++ b/app/api/config/autoload/local.php.dist
@@ -117,6 +117,8 @@ return [
         'en_GB' => '',
         'cy_GB' => '',
       ],
+      // No forward proxy locally — the Notify client connects directly.
+      'proxy' => '',
     ],
     // VOL-7238: dedicated DSN for the admin "Send test via Notify" button (independent of
     // `mail.dsn`). Set to `govuknotify+mailpit://mailpit:1025` to wire the button through

--- a/app/api/module/Api/src/Service/EditorJs/ConverterService.php
+++ b/app/api/module/Api/src/Service/EditorJs/ConverterService.php
@@ -60,7 +60,7 @@ class ConverterService
             throw new \RuntimeException('HTMLPurifier is required for secure HTML sanitization');
         }
 
-        $purifier = new \HTMLPurifier(\HTMLPurifier_Config::createDefault());
+        $purifier = new \HTMLPurifier($this->buildPurifierConfig());
         $cleanHtml = $purifier->purify($html);
 
         // Remove empty paragraphs and other empty block elements
@@ -68,6 +68,23 @@ class ConverterService
         $cleanHtml = preg_replace('/<div[^>]*>\s*<\/div>/', '', (string) $cleanHtml);
 
         return trim((string) $cleanHtml);
+    }
+
+
+    /**
+     * Build the HTMLPurifier config.
+     *
+     * Points the definition-cache serializer at a writable directory. HTMLPurifier's default is
+     * inside the vendor tree, which is read-only in deployed containers and so triggers
+     * "Directory ... not writable" warnings and forces the definition cache to be regenerated on
+     * every call.
+     */
+    public function buildPurifierConfig(): \HTMLPurifier_Config
+    {
+        $config = \HTMLPurifier_Config::createDefault();
+        $config->set('Cache.SerializerPath', sys_get_temp_dir());
+
+        return $config;
     }
 
 

--- a/app/api/module/Email/src/Transport/Factory/GovUkNotifyTransportFactoryFactory.php
+++ b/app/api/module/Email/src/Transport/Factory/GovUkNotifyTransportFactoryFactory.php
@@ -40,10 +40,16 @@ final class GovUkNotifyTransportFactoryFactory implements FactoryInterface
 
         $markdownConverter = new GithubFlavoredMarkdownConverter();
 
-        $clientFactory = static function (string $apiKey): NotifyClient {
+        // In deployed environments outbound internet egress is only reachable via the shared
+        // forward proxy, so the Notify client must be routed through it like every other external
+        // integration. Locally (and before the proxy is resolved from Parameter Store) this is
+        // empty and the client connects directly.
+        $guzzleOptions = self::resolveGuzzleOptions($notifyConfig['proxy'] ?? null);
+
+        $clientFactory = static function (string $apiKey) use ($guzzleOptions): NotifyClient {
             return new NotifyClient([
                 'apiKey' => $apiKey,
-                'httpClient' => new GuzzleAdapter(new GuzzleClient()),
+                'httpClient' => new GuzzleAdapter(new GuzzleClient($guzzleOptions)),
             ]);
         };
 
@@ -53,5 +59,24 @@ final class GovUkNotifyTransportFactoryFactory implements FactoryInterface
             $markdownConverter,
             $chromeTemplate,
         );
+    }
+
+    /**
+     * Build the Guzzle client options for the Notify HTTP client.
+     *
+     * Returns the shared egress proxy when one is configured. An empty value or an unresolved
+     * `%placeholder%` (which still contains a `%`, e.g. when running locally where the cloud
+     * parameter providers are not active) is ignored so the client falls back to a direct
+     * connection rather than pointing Guzzle at a bogus proxy host.
+     *
+     * @return array{proxy?: string}
+     */
+    public static function resolveGuzzleOptions(mixed $proxy): array
+    {
+        if (is_string($proxy) && $proxy !== '' && !str_contains($proxy, '%')) {
+            return ['proxy' => $proxy];
+        }
+
+        return [];
     }
 }

--- a/app/api/test/module/Api/src/Service/EditorJs/ConverterServiceTest.php
+++ b/app/api/test/module/Api/src/Service/EditorJs/ConverterServiceTest.php
@@ -59,6 +59,18 @@ class ConverterServiceTest extends TestCase
         $this->assertInstanceOf(ConverterService::class, $service);
     }
 
+    public function testPurifierConfigUsesWritableSerializerPath(): void
+    {
+        $config = $this->sut->buildPurifierConfig();
+
+        $serializerPath = $config->get('Cache.SerializerPath');
+
+        // Must not be left at HTMLPurifier's default (inside the read-only vendor tree in deployed
+        // containers), which causes "not writable" warnings and per-request cache regeneration.
+        $this->assertSame(sys_get_temp_dir(), $serializerPath);
+        $this->assertDirectoryIsWritable($serializerPath);
+    }
+
     public function testCleanOutputHtmlIsCalled(): void
     {
         $json = json_encode([

--- a/app/api/test/module/Email/src/Transport/Factory/GovUkNotifyTransportFactoryFactoryTest.php
+++ b/app/api/test/module/Email/src/Transport/Factory/GovUkNotifyTransportFactoryFactoryTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dvsa\OlcsTest\Email\Transport\Factory;
+
+use Dvsa\Olcs\Email\Transport\Factory\GovUkNotifyTransportFactoryFactory;
+use PHPUnit\Framework\TestCase;
+
+class GovUkNotifyTransportFactoryFactoryTest extends TestCase
+{
+    public function testResolveGuzzleOptionsUsesConfiguredProxy(): void
+    {
+        $this->assertSame(
+            ['proxy' => 'http://proxy.dev.olcs.dev-dvsacloud.uk:3128'],
+            GovUkNotifyTransportFactoryFactory::resolveGuzzleOptions('http://proxy.dev.olcs.dev-dvsacloud.uk:3128'),
+        );
+    }
+
+    public function testResolveGuzzleOptionsIgnoresUnresolvedPlaceholder(): void
+    {
+        $this->assertSame([], GovUkNotifyTransportFactoryFactory::resolveGuzzleOptions('http://%shd_proxy%'));
+    }
+
+    public function testResolveGuzzleOptionsIgnoresEmptyString(): void
+    {
+        $this->assertSame([], GovUkNotifyTransportFactoryFactory::resolveGuzzleOptions(''));
+    }
+
+    public function testResolveGuzzleOptionsIgnoresNull(): void
+    {
+        $this->assertSame([], GovUkNotifyTransportFactoryFactory::resolveGuzzleOptions(null));
+    }
+}


### PR DESCRIPTION
## Description

Notify test sends timed out (cURL 28) connecting directly instead of via %shd_proxy%.

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
