### PR TITLE
fix(api): correct NTU date comparison so process-ntu selects applications VOL-5546

### DIFF
--- a/app/api/module/Api/src/Domain/QueryHandler/Application/NotTakenUpList.php
+++ b/app/api/module/Api/src/Domain/QueryHandler/Application/NotTakenUpList.php
@@ -36,6 +36,12 @@ class NotTakenUpList extends AbstractQueryHandler
 
     protected function getApplicationsForNtu($now)
     {
+        // The query carries the date as a 'Y-m-d' string (see ProcessNtuCommand). Convert
+        // it to a DateTime so the comparison below is DateTime vs DateTime: comparing the
+        // raw string against a DateTime with > is always false in PHP, which is why no
+        // application was ever selected. See https://dvsa.atlassian.net/browse/VOL-5546
+        $now = new DateTime($now);
+
         $trafficAreas = $this->getRepo('TrafficArea')->fetchAll();
         $applications = $this->getRepo()->fetchForNtu();
 

--- a/app/api/test/module/Api/src/Domain/QueryHandler/Application/NotTakenUpListTest.php
+++ b/app/api/test/module/Api/src/Domain/QueryHandler/Application/NotTakenUpListTest.php
@@ -48,7 +48,8 @@ class NotTakenUpListTest extends QueryHandlerTestCase
     public function testHandleQuery(): void
     {
         $trafficAreaId = 1;
-        $query = Qry::create(['date' => new DateTime('2015-01-01')]);
+        // Date is passed as a 'Y-m-d' string, matching the CLI caller (ProcessNtuCommand).
+        $query = Qry::create(['date' => '2015-01-01']);
 
         $mockTrafficArea = m::mock(TrafficAreaEntity::class)
             ->shouldReceive('getId')


### PR DESCRIPTION
## Description

The batch:process-ntu job has selected zero applications since the laminas-cli migration (b4938e9d32). That migration replaced BatchController::processNtuAction(), which passed a DateTime to the NotTakenUpList query, with ProcessNtuCommand, which passes the date as a 'Y-m-d' string.

In getApplicationsForNtu() that value is compared with `$now > $ntuDate`, where $ntuDate is a DateTime. In PHP a string compared against an object with `>` is always false, so no application was ever flagged Not Taken Up.

Convert the incoming date to a DateTime before the comparison so it is DateTime vs DateTime, and update the query handler test to pass the date as a string (the form the CLI actually uses) so the regression is covered.

Related issue: [VOL-5546](https://dvsa.atlassian.net/browse/VOL-5546)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-5546]: https://dvsa.atlassian.net/browse/VOL-5546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ