### PR TITLE
fix: print sql statements so you can see the malformed statement

### DIFF
--- a/infra/docker/cli/scripts/niextract/scripts/install_NI_Extract_db_objects.sh
+++ b/infra/docker/cli/scripts/niextract/scripts/install_NI_Extract_db_objects.sh
@@ -15,6 +15,9 @@ cd "$SCRIPT_DIR" || exit 1
 run_sql() {
     local file="$1"
     echo "Running $file..."
+    echo "=== FILE CONTENT ==="
+    cat "$file"
+    echo "=== END FILE CONTENT ==="
     grep -v '^DELIMITER' "$file" | mysql $CONNECTION "$DB" --delimiter='$$' 2>&1 || { echo "ERROR: Failed to execute $file"; exit 1; }
 }
 


### PR DESCRIPTION
## Description

As per title the ni extract job is still facing error seemingly caused by the malformed SQL request but only halfway through the generated statements not all the way through. This should enable better visibility so we can actually see the statement causing the error.

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
