### PR TITLE
refactor(api): replace unmaintained phprtflite with in-house RtfEncoder

### DIFF
--- a/app/api/.snyk
+++ b/app/api/.snyk
@@ -2,11 +2,6 @@
 version: v1.25.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
-  'snyk:lic:composer:phprtflite:phprtflite:GPL-3.0':
-    - '*':
-        reason: GPL-3.0 licence concern. OLCS is open source under OGL. Tracked in VOL-5968
-        expires: 2027-01-15T00:00:00.000Z
-        created: 2024-02-28T13:46:27.880Z
   'snyk:lic:composer:behat:transliterator:Artistic-1.0':
     - '*':
         reason: Issue is due to licence

--- a/app/api/composer.json
+++ b/app/api/composer.json
@@ -48,7 +48,6 @@
     "olcs/olcs-transfer": "*",
     "olcs/olcs-utils": "*",
     "oro/doctrine-extensions": "^2",
-    "phprtflite/phprtflite": "~1.3.3",
     "phpseclib/phpseclib": "^3.0.47",
     "qandidate/toggle": "^2.0",
     "ramsey/uuid": "^3.9",

--- a/app/api/composer.lock
+++ b/app/api/composer.lock
@@ -4,7 +4,7 @@
     "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
     "This file is @generated automatically"
   ],
-  "content-hash": "f99068d99ea2ad566744ea89f023bb16",
+  "content-hash": "75fb00b5dffa8bad849c699a1150dd47",
   "packages": [
     {
       "name": "alphagov/notifications-php-client",
@@ -6804,41 +6804,6 @@
         "source": "https://github.com/php-http/promise/tree/1.3.1"
       },
       "time": "2024-03-15T13:55:21+00:00"
-    },
-    {
-      "name": "phprtflite/phprtflite",
-      "version": "v1.3.3",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/phprtflite/PHPRtfLite.git",
-        "reference": "eef76d965fc7a0cb4c7342f229f67ad4793c61c2"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/phprtflite/PHPRtfLite/zipball/eef76d965fc7a0cb4c7342f229f67ad4793c61c2",
-        "reference": "eef76d965fc7a0cb4c7342f229f67ad4793c61c2",
-        "shasum": ""
-      },
-      "type": "library",
-      "autoload": {
-        "psr-0": {
-          "PHPRtfLite": "lib/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": ["GPL-3.0"],
-      "authors": [
-        {
-          "name": "Steffen Zeidler",
-          "email": "sigma_z@sigma-scripts.de"
-        }
-      ],
-      "description": "PHPRtfLite is an API enabling developers to create rtf documents with php.",
-      "support": {
-        "issues": "https://github.com/phprtflite/PHPRtfLite/issues",
-        "source": "https://github.com/phprtflite/PHPRtfLite/tree/v1.3.x"
-      },
-      "time": "2014-07-04T19:43:18+00:00"
     },
     {
       "name": "phpseclib/phpseclib",

--- a/app/api/module/Api/src/Service/Document/Document.php
+++ b/app/api/module/Api/src/Service/Document/Document.php
@@ -8,6 +8,7 @@ use Dvsa\Olcs\Api\Domain\TranslatorAwareInterface;
 use Dvsa\Olcs\Api\Service\Date as DateService;
 use Dvsa\Olcs\Api\Service\Document\Bookmark\Interfaces\DateHelperAwareInterface;
 use Dvsa\Olcs\Api\Service\Document\Bookmark\Interfaces\FileStoreAwareInterface;
+use Dvsa\Olcs\Api\Service\Document\Rtf\RtfEncoder;
 use Dvsa\Olcs\DocumentShare\Data\Object\File as ContentStoreFile;
 use Dvsa\Olcs\DocumentShare\Service\DocumentStoreInterface;
 use Laminas\I18n\Translator\TranslatorInterface;
@@ -118,7 +119,7 @@ class Document
             // it's a fallback TextBlock. Could modify the below to check the bookmark type...
             if ($result !== null) {
                 // convert any extended chars to RTF versions
-                $result = \PHPRtfLite_Utf8::getUnicodeEntities((string)$result, 'UTF-8');
+                $result = RtfEncoder::getUnicodeEntities((string)$result);
 
                 $populatedData[$token] = [
                     'content' => $result,

--- a/app/api/module/Api/src/Service/Document/Parser/RtfParser.php
+++ b/app/api/module/Api/src/Service/Document/Parser/RtfParser.php
@@ -2,6 +2,8 @@
 
 namespace Dvsa\Olcs\Api\Service\Document\Parser;
 
+use Dvsa\Olcs\Api\Service\Document\Rtf\RtfEncoder;
+
 /**
  * RTF parser
  *
@@ -168,6 +170,9 @@ class RtfParser implements ParserInterface
      */
     public function getEntitiesAndQuote($data)
     {
-        return \PHPRtfLite_Utf8::getUnicodeEntities(\PHPRtfLite::quoteRtfCode($data, true), 'UTF-8');
+        // bookmark values may be null (e.g. optional publication link text), so
+        // cast before handing to the strictly-typed encoder — matching the null
+        // tolerance the old untyped library provided.
+        return RtfEncoder::getUnicodeEntities(RtfEncoder::quoteRtfCode((string)$data, true));
     }
 }

--- a/app/api/module/Api/src/Service/Document/Rtf/RtfEncoder.php
+++ b/app/api/module/Api/src/Service/Document/Rtf/RtfEncoder.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dvsa\Olcs\Api\Service\Document\Rtf;
+
+/**
+ * Minimal RTF text-encoding helpers.
+ *
+ * Reproduces the only two functions the document/bookmark pipeline ever used
+ * from the (unmaintained) phprtflite/phprtflite library:
+ *   - PHPRtfLite::quoteRtfCode()
+ *   - PHPRtfLite_Utf8::getUnicodeEntities()
+ *
+ * For every input the old library handled correctly the output is byte-for-byte
+ * identical; this was verified against the real library across the whole Basic
+ * Multilingual Plane before it was removed. The one deliberate divergence is
+ * that supplementary-plane characters (U+10000 and above, e.g. emoji) are now
+ * decoded and emitted correctly as UTF-16 surrogate pairs; the old library
+ * silently corrupted their bytes because its decoder only understood 1-3 byte
+ * UTF-8 sequences.
+ */
+final class RtfEncoder
+{
+    /**
+     * Escapes RTF control characters and, optionally, converts newlines to
+     * RTF line breaks.
+     */
+    public static function quoteRtfCode(string $text, bool $convertNewlines = true): string
+    {
+        // escape backslashes and curly brackets
+        $text = str_replace(['\\', '{', '}'], ['\\\\', '\\{', '\\}'], $text);
+
+        if ($convertNewlines) {
+            // convert breaks into an rtf break
+            $text = str_replace(["\r\n", "\n", "\r"], '\line ', $text);
+        }
+
+        return $text;
+    }
+
+    /**
+     * Converts a UTF-8 string into RTF, replacing every non-ASCII character
+     * with its RTF unicode entity and passing ASCII through untouched.
+     */
+    public static function getUnicodeEntities(string $text): string
+    {
+        $entities = '';
+
+        foreach (self::utf8ToCodePoints($text) as $codePoint) {
+            if ($codePoint === 0xFEFF) {
+                // strip byte-order marks / zero-width no-break spaces
+                continue;
+            }
+
+            if ($codePoint <= 0x7F) {
+                $entities .= chr($codePoint);
+            } elseif ($codePoint <= 0xFFFF) {
+                $entities .= '\uc0{\u' . $codePoint . '}';
+            } elseif ($codePoint <= 0x10FFFF) {
+                // RTF's \u control word only carries a 16-bit code unit, so a
+                // supplementary-plane character must be written as the two
+                // halves of its UTF-16 surrogate pair.
+                $offset = $codePoint - 0x10000;
+                $high = 0xD800 + ($offset >> 10);
+                $low = 0xDC00 + ($offset & 0x3FF);
+                $entities .= '\uc0{\u' . $high . '}\uc0{\u' . $low . '}';
+            }
+            // Code points above U+10FFFF are only reachable from invalid UTF-8
+            // lead bytes (0xF5-0xF7); drop them rather than emit a malformed
+            // surrogate half.
+        }
+
+        return $entities;
+    }
+
+    /**
+     * Decodes a UTF-8 string into an array of Unicode code points.
+     *
+     * Handles 1-4 byte sequences. Behaviour for 1-3 byte sequences is a
+     * verbatim reproduction of the old library's arithmetic (so output stays
+     * byte-identical); the 4-byte branch is the new, correct handling.
+     *
+     * @return int[]
+     */
+    private static function utf8ToCodePoints(string $str): array
+    {
+        $codePoints = [];
+        $values = [];
+        $lookingFor = 1;
+
+        for ($i = 0, $len = strlen($str); $i < $len; $i++) {
+            $thisValue = ord($str[$i]);
+
+            if ($thisValue < 128) {
+                $codePoints[] = $thisValue;
+                continue;
+            }
+
+            if ($values === []) {
+                $lookingFor = match (true) {
+                    $thisValue < 224 => 2,
+                    $thisValue < 240 => 3,
+                    default => 4,
+                };
+            }
+
+            $values[] = $thisValue;
+
+            if (count($values) === $lookingFor) {
+                $codePoints[] = match ($lookingFor) {
+                    2 => (($values[0] % 32) * 64) + ($values[1] % 64),
+                    3 => (($values[0] % 16) * 4096) + (($values[1] % 64) * 64) + ($values[2] % 64),
+                    default => (($values[0] % 8) * 262144) + (($values[1] % 64) * 4096)
+                        + (($values[2] % 64) * 64) + ($values[3] % 64),
+                };
+                $values = [];
+                $lookingFor = 1;
+            }
+        }
+
+        return $codePoints;
+    }
+}

--- a/app/api/test/module/Api/src/Service/Document/Parser/RtfParserTest.php
+++ b/app/api/test/module/Api/src/Service/Document/Parser/RtfParserTest.php
@@ -149,4 +149,12 @@ TXT;
         $parser = new RtfParser();
         $this->assertEquals($endText, $parser->getEntitiesAndQuote($startText));
     }
+
+    public function testGetEntitiesAndQuoteToleratesNull(): void
+    {
+        // Optional bookmark values (e.g. a publication link with no text) arrive
+        // as null; this must not fatal, matching the old library's behaviour.
+        $parser = new RtfParser();
+        $this->assertSame('', $parser->getEntitiesAndQuote(null));
+    }
 }

--- a/app/api/test/module/Api/src/Service/Document/Rtf/RtfEncoderTest.php
+++ b/app/api/test/module/Api/src/Service/Document/Rtf/RtfEncoderTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dvsa\OlcsTest\Api\Service\Document\Rtf;
+
+use Dvsa\Olcs\Api\Service\Document\Rtf\RtfEncoder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RtfEncoder::class)]
+class RtfEncoderTest extends TestCase
+{
+    /**
+     * Builds the RTF unicode entity string the encoder is expected to emit for
+     * the given 16-bit code units, e.g. ent(233) === the entity for 'é'. Kept
+     * as a helper so no literal \uNNNN escape sequence ever appears in this
+     * file's source (which some tooling mistakes for a Unicode escape).
+     */
+    private static function ent(int ...$codeUnits): string
+    {
+        $out = '';
+        foreach ($codeUnits as $unit) {
+            $out .= '\uc0{\u' . $unit . '}';
+        }
+
+        return $out;
+    }
+
+    #[DataProvider('quoteRtfCodeProvider')]
+    public function testQuoteRtfCode(string $input, bool $convertNewlines, string $expected): void
+    {
+        $this->assertSame($expected, RtfEncoder::quoteRtfCode($input, $convertNewlines));
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: bool, 2: string}>
+     */
+    public static function quoteRtfCodeProvider(): array
+    {
+        return [
+            'plain ascii untouched' => ['Hello world', true, 'Hello world'],
+            'single backslash escaped' => ['\\', true, '\\\\'],
+            'braces escaped' => ['{}', true, '\{\}'],
+            'backslash, braces and newline' => ["\\{}\n", true, '\\\\\{\}\line '],
+            'lf converted' => ["a\nb", true, 'a\line b'],
+            'crlf converted' => ["a\r\nb", true, 'a\line b'],
+            'cr converted' => ["a\rb", true, 'a\line b'],
+            'mixed newlines converted' => ["x\r\ny\rz\nq", true, 'x\line y\line z\line q'],
+            'newlines preserved when disabled' => ["a\nb", false, "a\nb"],
+            'braces still escaped when newlines disabled' => ["{a}\n", false, "\{a\}\n"],
+        ];
+    }
+
+    #[DataProvider('getUnicodeEntitiesProvider')]
+    public function testGetUnicodeEntities(string $input, string $expected): void
+    {
+        $this->assertSame($expected, RtfEncoder::getUnicodeEntities($input));
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function getUnicodeEntitiesProvider(): array
+    {
+        return [
+            'ascii passes through untouched' => ['abc123 !@#', 'abc123 !@#'],
+            'rtf control chars are ascii and untouched' => ['\{}', '\{}'],
+            'latin-1 accent (2-byte)' => ['à', self::ent(224)],
+            'first 2-byte char U+0080' => ["\u{0080}", self::ent(128)],
+            'last 2-byte char U+07FF' => ["\u{07FF}", self::ent(2047)],
+            'first 3-byte char U+0800' => ["\u{0800}", self::ent(2048)],
+            'cyrillic (3-byte)' => ['к', self::ent(1082)],
+            'black square U+25A0 (3-byte)' => ['■', self::ent(9632)],
+            'last 3-byte char U+FFFF' => ["\u{FFFF}", self::ent(65535)],
+            'byte order mark is stripped' => ["\u{FEFF}", ''],
+            'bom stripped but surrounding text kept' => ["a\u{FEFF}b", 'ab'],
+            'mixed ascii and non-ascii' => ['café', 'caf' . self::ent(233)],
+        ];
+    }
+
+    /**
+     * Supplementary-plane characters (U+10000 and above) are the deliberate
+     * behavioural fix: the old library corrupted them, we emit the correct
+     * UTF-16 surrogate pair.
+     */
+    #[DataProvider('supplementaryPlaneProvider')]
+    public function testGetUnicodeEntitiesEncodesSupplementaryPlaneAsSurrogatePairs(
+        string $input,
+        string $expected,
+    ): void {
+        $this->assertSame($expected, RtfEncoder::getUnicodeEntities($input));
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function supplementaryPlaneProvider(): array
+    {
+        return [
+            // U+10000 – first supplementary code point -> surrogates D800 DC00
+            'first supplementary U+10000' => ["\u{10000}", self::ent(55296, 56320)],
+            // U+1F600 GRINNING FACE -> surrogates D83D DE00
+            'grinning face emoji U+1F600' => ["\u{1F600}", self::ent(55357, 56832)],
+            // U+10FFFF – last valid code point -> surrogates DBFF DFFF
+            'last code point U+10FFFF' => ["\u{10FFFF}", self::ent(56319, 57343)],
+            'emoji between ascii' => ["a\u{1F600}b", 'a' . self::ent(55357, 56832) . 'b'],
+        ];
+    }
+
+    /**
+     * An invalid 4-byte UTF-8 lead (0xF5-0xF7) decodes to a code point above the
+     * Unicode maximum (U+10FFFF); it must be dropped, never emitted as a
+     * malformed surrogate half.
+     */
+    public function testInvalidFourByteSequenceProducesNoSurrogate(): void
+    {
+        // 0xF7 0xBF 0xBF 0xBF decodes to 0x1FFFFF, which is > U+10FFFF.
+        $this->assertSame('', RtfEncoder::getUnicodeEntities("\xF7\xBF\xBF\xBF"));
+    }
+}


### PR DESCRIPTION
## Description

The document/bookmark pipeline used only two static string helpers from phprtflite/phprtflite (PHPRtfLite::quoteRtfCode and PHPRtfLite_Utf8::getUnicodeEntities). The rest of the unmaintained (2014) library was dead weight, so replace those helpers with a small self-contained RtfEncoder and drop the dependency (and its now-stale Snyk licence ignore).

Output is byte-identical for every input the old library handled; this was verified against the real library across the entire Basic Multilingual Plane, a quote corpus, and the combined pipeline before the dependency was removed. RtfEncoderTest pins the resulting behaviour.

Also fixes 4-byte UTF-8 handling: supplementary-plane characters (U+10000+, e.g. emoji) that the old decoder silently corrupted are now emitted as the correct UTF-16 surrogate pair, and code points beyond U+10FFFF (only reachable from invalid UTF-8) are dropped rather than emitted as a malformed surrogate.

RtfParser::getEntitiesAndQuote casts its argument before handing it to the strictly-typed encoder, preserving the null tolerance the old untyped library provided (optional bookmark text can be null).

Related issue: [VOL-5968](https://dvsa.atlassian.net/browse/VOL-5968)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-5968]: https://dvsa.atlassian.net/browse/VOL-5968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ