### PR TITLE
fix: prevent bold in Notify md conversion; value-driven send_all_mail_to

### DIFF
--- a/app/api/config/autoload/config.global.php
+++ b/app/api/config/autoload/config.global.php
@@ -276,9 +276,11 @@ return [
 
     // Email config
     'email' => [
-        // Debugging option forces all email to be sent to an address
-        // Selfserve/external URI e.g. http://demo_dvsa-selfserve.web03.olcs.mgt.mtpdvsa *Environment specific*
-        'send_all_mail_to' => ($isProductionAccount && !$isProduction) ? '%olcs_send_all_mail_to%' : null,
+        // Debugging option: redirect ALL outbound email to a single address. Driven by the env's
+        // `olcs_send_all_mail_to` param — a real address enables it, a blank/"null" sentinel disables
+        // it (SSM String params cannot be empty, so envs opt out with " " or "null"). NEVER in
+        // production (APP): prod always sends to the real recipients regardless of the param.
+        'send_all_mail_to' => $isProduction ? null : '%olcs_send_all_mail_to%',
         'from_name' => 'OLCS do not reply',
         'from_email' => '%olcs_from_email%',
         'selfserve_uri' => '%olcs_ss_uri%',

--- a/app/api/module/Cli/src/Command/Email/ConvertToMarkdownCommand.php
+++ b/app/api/module/Cli/src/Command/Email/ConvertToMarkdownCommand.php
@@ -258,6 +258,15 @@ class ConvertToMarkdownCommand extends AbstractOlcsCommand
             return 'output contains forbidden raw HTML tag';
         }
 
+        // Notify has no inline bold/italic — it renders the markers literally. Reject them so a bad
+        // conversion fails loudly instead of round-tripping cleanly through CommonMark below.
+        if (preg_match('/\*\*.+?\*\*/s', $markdown) === 1) {
+            return 'output contains bold markers (** **) — Notify has no bold; use plain text or a "## " heading';
+        }
+        if (preg_match('/(?<![\w\/:])_(?!_)[^_\n]+_(?![\w\/])/', $markdown) === 1) {
+            return 'output contains underscore italics (_..._) — Notify has no italic; use plain text';
+        }
+
         $samples = $datasets === [] ? [['__empty__' => []]] : $datasets;
         foreach ($samples as $datasetName => $datasetValues) {
             $values = is_array($datasetValues) ? $datasetValues : [];
@@ -333,7 +342,10 @@ class ConvertToMarkdownCommand extends AbstractOlcsCommand
            - `<p>` blocks → paragraphs separated by blank lines
            - `<h2>` → `## `, `<h3>` → `### ` (Notify supports up to H2 prominently; H3 is a styled subheading)
            - `<a href="X">Y</a>` → `[Y](X)`. If the href is a bare Twig `{{ url }}`, write `[Y]({{ url }})`.
-           - `<strong>`/`<b>` → `**...**`, `<em>`/`<i>` → `*...*`
+           - `<strong>`/`<b>`/`<em>`/`<i>` → Notify has NO bold or italic (it renders `**`/`*`/`_`
+             markers literally). Output the inner text as PLAIN text and drop the emphasis. Only if
+             such an element is the ENTIRE content of a short standalone line (a section label) may
+             you render that whole line as a `## ` heading instead.
            - `<ul><li>` → `- item` per line; `<ol><li>` → `1. item` per line (Notify renders these correctly)
            - `<table>` → Markdown pipe table if it fits cleanly. Otherwise convert to a labelled list.
            - `<br>` → use blank line for hard break, or two spaces at end of line for soft break.

--- a/app/api/module/Email/src/Domain/CommandHandler/SendEmail.php
+++ b/app/api/module/Email/src/Domain/CommandHandler/SendEmail.php
@@ -205,8 +205,12 @@ class SendEmail extends AbstractCommandHandler implements UploaderAwareInterface
         $bcc = $command->getBcc();
         $docs = $command->getDocs();
 
-        if ($this->getSendAllMailTo()) {
-            $to = $this->getSendAllMailTo();
+        // Treat a blank/whitespace-only value or the literal "null" sentinel as "disabled": SSM String
+        // params cannot be empty, so non-prod envs opt out with " " or "null" rather than an empty
+        // string — without trimming, those truthy values would become the redirect recipient (VOL-7240).
+        $sendAllMailTo = trim((string)$this->getSendAllMailTo());
+        if ($sendAllMailTo !== '' && strcasecmp($sendAllMailTo, 'null') !== 0) {
+            $to = $sendAllMailTo;
             /**
              * IMPORTANT CC gets emptied when we have configured emails to be sent to 1 email address
              */

--- a/app/api/test/module/Email/src/Domain/CommandHandler/SendEmailTest.php
+++ b/app/api/test/module/Email/src/Domain/CommandHandler/SendEmailTest.php
@@ -248,4 +248,112 @@ class SendEmailTest extends AbstractCommandHandlerTestCase
 
         $this->sut->handleCommand($command);
     }
+
+    public static function sendAllMailToSentinelProvider(): array
+    {
+        return [
+            'single space'    => [' '],
+            'multiple spaces' => ['   '],
+            'literal null'    => ['null'],
+            'literal NULL'    => ['NULL'],
+            'empty string'    => [''],
+        ];
+    }
+
+    /**
+     * A blank/whitespace-only value or the literal "null" sentinel must NOT redirect: SSM String
+     * params cannot be empty, so non-prod envs disable the catch-all with " " or "null" (VOL-7240).
+     * The real recipient, cc and bcc are preserved and the subject is not prefixed.
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('sendAllMailToSentinelProvider')]
+    public function testHandleCommandSendAllMailToSentinelDoesNotRedirect(string $sentinel): void
+    {
+        $data = [
+            'to' => 'foo@bar.com',
+            'cc' => ['bar@foo.com'],
+            'bcc' => ['bcc@foobar.com'],
+            'docs' => [],
+            'subject' => 'Some subject',
+            'plainBody' => 'This is the email',
+            'htmlBody' => null,
+            'highPriority' => false,
+            'subjectVariables' => []
+        ];
+
+        $command = Cmd::create($data);
+
+        $this->sut->setSendAllMailTo($sentinel);
+
+        $this->repoMap['Document']
+            ->shouldReceive('fetchByIds')
+            ->once()
+            ->with([])
+            ->andReturn([]);
+
+        $this->mockedSmServices['EmailService']->shouldReceive('send')
+            ->once()
+            ->with(
+                'terry.valtech@gmail.com',
+                'Terry',
+                'foo@bar.com',
+                'translated-Some subject',
+                'This is the email',
+                null,
+                ['bar@foo.com'],
+                ['bcc@foobar.com'],
+                [],
+                false,
+                null
+            );
+
+        $this->sut->handleCommand($command);
+    }
+
+    /**
+     * A real address in send_all_mail_to redirects every recipient to it (emptying cc/bcc) and
+     * prefixes the original recipient onto the subject. Surrounding whitespace is trimmed off the
+     * address so an accidentally-padded SSM value still resolves to a clean recipient.
+     */
+    public function testHandleCommandSendAllMailToRedirectsAndTrims(): void
+    {
+        $data = [
+            'to' => 'foo@bar.com',
+            'cc' => ['bar@foo.com'],
+            'bcc' => ['bcc@foobar.com'],
+            'docs' => [],
+            'subject' => 'Some subject',
+            'plainBody' => 'This is the email',
+            'htmlBody' => null,
+            'highPriority' => false,
+            'subjectVariables' => []
+        ];
+
+        $command = Cmd::create($data);
+
+        $this->sut->setSendAllMailTo('  catch-all@dvsa.gov.uk  ');
+
+        $this->repoMap['Document']
+            ->shouldReceive('fetchByIds')
+            ->once()
+            ->with([])
+            ->andReturn([]);
+
+        $this->mockedSmServices['EmailService']->shouldReceive('send')
+            ->once()
+            ->with(
+                'terry.valtech@gmail.com',
+                'Terry',
+                'catch-all@dvsa.gov.uk',
+                'foo@bar.com : translated-Some subject',
+                'This is the email',
+                null,
+                [],
+                [],
+                [],
+                false,
+                null
+            );
+
+        $this->sut->handleCommand($command);
+    }
 }


### PR DESCRIPTION
## Description

Allow send_all_email to in any environment (needed for GovUK Notify Testing on a Team API Key)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
