### PR TITLE
fix: outputting and overwriting the debug files to a sql files to debug

### DIFF
--- a/infra/docker/cli/scripts/niextract/scripts/install_NI_Extract_db_objects.sh
+++ b/infra/docker/cli/scripts/niextract/scripts/install_NI_Extract_db_objects.sh
@@ -14,10 +14,11 @@ cd "$SCRIPT_DIR" || exit 1
 
 run_sql() {
     local file="$1"
+    local filename
+    filename=$(basename "$file")
     echo "Running $file..."
-    echo "=== FILE CONTENT ==="
-    cat "$file"
-    echo "=== END FILE CONTENT ==="
+    echo "File size: $(wc -c < "$file") bytes, lines: $(wc -l < "$file") lines"
+    aws s3 cp "$file" "s3://devapp-olcs-pri-olcs-deploy-s3/anondata/debug/$filename" 2>&1 || echo "S3 upload failed for $filename"
     grep -v '^DELIMITER' "$file" | mysql $CONNECTION "$DB" --delimiter='$$' 2>&1 || { echo "ERROR: Failed to execute $file"; exit 1; }
 }
 


### PR DESCRIPTION
## Description

We are really struggling to debug the ni job without seeing the resultant sql files created. This changes outputs these to a known bucket to support debugging and ephemeral job. It also overwrites them each time preventing these clogging up the S3.

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
