### PR TITLE
fix: rewrite selfserve/internal URIs in Notify markdown body

### DIFF
--- a/app/api/module/Email/src/Domain/CommandHandler/SendEmail.php
+++ b/app/api/module/Email/src/Domain/CommandHandler/SendEmail.php
@@ -230,7 +230,7 @@ class SendEmail extends AbstractCommandHandler implements UploaderAwareInterface
 
         $plainBody = $command->getPlainBody() !== null
             ? $this->replaceUris($command->getPlainBody())
-            : ($hasMarkdownBody ? $command->getMarkdownBody() : '');
+            : ($hasMarkdownBody ? $this->replaceUris((string) $command->getMarkdownBody()) : '');
         $htmlBody = $command->getHtmlBody();
 
         if ($htmlBody !== null) {
@@ -294,7 +294,9 @@ class SendEmail extends AbstractCommandHandler implements UploaderAwareInterface
             'templateKey' => $command->getTemplateKey(),
             'locale' => $command->getLocale(),
             'personalisation' => $command->getPersonalisation(),
-            'markdownBody' => $command->getMarkdownBody(),
+            'markdownBody' => $command->getMarkdownBody() !== null
+                ? $this->replaceUris($command->getMarkdownBody())
+                : null,
             'attachments' => $attachments,
         ];
     }

--- a/app/api/test/module/Email/src/Domain/CommandHandler/SendEmailTest.php
+++ b/app/api/test/module/Email/src/Domain/CommandHandler/SendEmailTest.php
@@ -356,4 +356,61 @@ class SendEmailTest extends AbstractCommandHandlerTestCase
 
         $this->sut->handleCommand($command);
     }
+
+    /**
+     * The Notify markdown path must rewrite the `http://selfserve/` and `http://internal/` placeholder
+     * hosts to the environment's real FQDNs, exactly as the legacy SMTP plain/html path does — both in
+     * the Notify payload body and in the plain fallback derived from the markdown (VOL-7240).
+     */
+    public function testHandleCommandRewritesUrisInNotifyMarkdownBody(): void
+    {
+        $markdown = "It is an offence to operate without a licence.\n\n"
+            . "http://selfserve/continuation/358801 and http://internal/admin";
+        $expected = "It is an offence to operate without a licence.\n\n"
+            . "http://olcs-selfserve/continuation/358801 and http://olcs-internal/admin";
+
+        $data = [
+            'to' => 'foo@bar.com',
+            'cc' => [],
+            'bcc' => [],
+            'docs' => [],
+            'subject' => 'Some subject',
+            'plainBody' => null,
+            'htmlBody' => null,
+            'markdownBody' => $markdown,
+            'templateKey' => 'notify-template-uuid',
+            'locale' => 'en_GB',
+            'personalisation' => [],
+            'highPriority' => false,
+            'subjectVariables' => []
+        ];
+
+        $command = Cmd::create($data);
+
+        $this->sut->setSendAllMailTo(null);
+
+        $this->repoMap['Document']
+            ->shouldReceive('fetchByIds')
+            ->once()
+            ->with([])
+            ->andReturn([]);
+
+        $this->mockedSmServices['EmailService']->shouldReceive('send')
+            ->once()
+            ->with(
+                'terry.valtech@gmail.com',
+                'Terry',
+                'foo@bar.com',
+                'translated-Some subject',
+                $expected,
+                null,
+                [],
+                [],
+                [],
+                false,
+                m::on(fn($payload): bool => is_array($payload) && $payload['markdownBody'] === $expected)
+            );
+
+        $this->sut->handleCommand($command);
+    }
 }


### PR DESCRIPTION
## Description

Apply url rewriting to the notify render path 

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
