### PR TITLE
fix: amend to use basic auth on header and not bearer

### DIFF
--- a/.github/workflows/run-liquibase.yaml
+++ b/.github/workflows/run-liquibase.yaml
@@ -131,7 +131,7 @@ jobs:
           git tag "${{ inputs.etl_ref }}"
           GIT_CONFIG_COUNT=1 \
           GIT_CONFIG_KEY_0="http.extraHeader" \
-          GIT_CONFIG_VALUE_0="Authorization: Bearer ${GH_TOKEN}" \
+          GIT_CONFIG_VALUE_0="Authorization: Basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)" \
           git push origin "${{ inputs.etl_ref }}"
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
## Description


This pull request updates the authentication method used when pushing Git tags in the `run-liquibase.yaml` GitHub Actions workflow. The change switches from using a Bearer token to a Base64-encoded Basic authentication header for improved compatibility and security.

**Workflow authentication update:**

* [`.github/workflows/run-liquibase.yaml`](diffhunk://#diff-aed15055a2a7abc9aa7b86dd9c50e6ae4ca7223ccec67ecb9bc4e8dda3449928L134-R134): Changed the `http.extraHeader` configuration from a Bearer token to a Base64-encoded Basic authentication header using the GitHub token.

Related issue: issue in vol-dev-test channel

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
