### PR TITLE
fix: data export S3 upload fatals since aws-sdk/guzzle security bump

### DIFF
--- a/app/api/module/Cli/src/Domain/CommandHandler/AbstractDataExport.php
+++ b/app/api/module/Cli/src/Domain/CommandHandler/AbstractDataExport.php
@@ -221,15 +221,18 @@ abstract class AbstractDataExport extends AbstractCommandHandler
     protected function uploadToS3($filePath)
     {
         $fileName = basename((string) $filePath);
-        $fileResource = fopen($filePath, 'r');
 
+        // Hand the SDK the file path rather than an open resource: since the
+        // guzzlehttp/psr7 2.12 / aws-sdk bump, a resource passed as Body is
+        // closed by the SDK when the request completes, so a caller-side
+        // fclose() fatals with a TypeError (killed the monthly DfT
+        // international goods export). With SourceFile the SDK opens and
+        // closes the file itself.
         $this->s3Client->putObject([
-            'Bucket' => $this->s3Bucket,
-            'Key'    => $this->path . '/' . $fileName,
-            'Body'   => $fileResource,
+            'Bucket'     => $this->s3Bucket,
+            'Key'        => $this->path . '/' . $fileName,
+            'SourceFile' => $filePath,
         ]);
-
-        fclose($fileResource);
 
         $this->result->addMessage('Uploaded file to S3: ' . $fileName);
     }

--- a/app/api/test/module/Cli/src/Domain/CommandHandler/DataGovUkExportTest.php
+++ b/app/api/test/module/Cli/src/Domain/CommandHandler/DataGovUkExportTest.php
@@ -184,6 +184,13 @@ class DataGovUkExportTest extends AbstractCommandHandlerTestCase
         $this->mockS3client->shouldAllowMockingMethod('putObject');
         $this->mockS3client->shouldReceive('putObject')
             ->once()
+            ->with(m::on(
+                // the SDK must be given the file path, never an open resource:
+                // since guzzlehttp/psr7 2.12 the SDK closes a Body resource
+                // itself and a caller-side fclose() fatals
+                static fn (array $args): bool => isset($args['SourceFile'])
+                    && !isset($args['Body'])
+            ))
             ->andReturn([]);
 
         $actual = $this->sut->handleCommand($cmd);


### PR DESCRIPTION
## Description

The monthly DfT international goods export died with an uncaught TypeError: "fclose(): supplied resource is not a valid stream resource".

We recently updated guzzlehttp/psr7 2.11 -> 2.12.1 / aws-sdk and now a resource passed to putObject as Body is closed by the SDK when the request completes, so our follow-up fclose() hit an already-closed handle and PHP 8 throws an error.

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
