### PR TITLE
fix: letters admin updates batch3 vol 7305

### DIFF
--- a/app/api/module/Api/config/module.config.php
+++ b/app/api/module/Api/config/module.config.php
@@ -208,6 +208,10 @@ return [
             \Dvsa\Olcs\Api\Service\Letter\LetterPreviewService::class =>
                 \Dvsa\Olcs\Api\Service\Letter\LetterPreviewServiceFactory::class,
 
+            // Master Template Resolver (VOL-7305)
+            \Dvsa\Olcs\Api\Service\Letter\MasterTemplateResolver::class =>
+                \Dvsa\Olcs\Api\Service\Letter\MasterTemplateResolverFactory::class,
+
             \Dvsa\Olcs\Api\Service\Ebsr\TransExchangeClient::class =>
                 \Dvsa\Olcs\Api\Service\Ebsr\TransExchangeClientFactory::class,
             \Dvsa\Olcs\Api\Rbac\IdentityProviderInterface::class => \Dvsa\Olcs\Api\Rbac\IdentityProviderFactory::class,

--- a/app/api/module/Api/src/Domain/CommandHandler/Letter/LetterInstance/PrepareToSend.php
+++ b/app/api/module/Api/src/Domain/CommandHandler/Letter/LetterInstance/PrepareToSend.php
@@ -61,6 +61,9 @@ final class PrepareToSend extends AbstractCommandHandler implements
             throw new ValidationException(['Letter instance must be in DRAFT or READY status']);
         }
 
+        // VOL-7402: content flagged "requires input" must be edited before sending
+        $this->assertRequiredInputProvided($letterInstance);
+
         // VOL-7305: pick the right MasterTemplate row for this letter's region (GB/NI/...)
         $masterTemplate = $this->masterTemplateResolver->resolve($letterInstance);
 
@@ -236,6 +239,39 @@ final class PrepareToSend extends AbstractCommandHandler implements
         }
 
         return null;
+    }
+
+    /**
+     * VOL-7402: block sending while any issue or section flagged "requires input"
+     * still carries its default content. The flag exists precisely so a caseworker
+     * must replace boilerplate (deadlines, amounts, names) before the letter goes out.
+     *
+     * @throws ValidationException listing every offending heading
+     */
+    private function assertRequiredInputProvided(LetterInstanceEntity $letterInstance): void
+    {
+        $pending = [];
+
+        foreach ($letterInstance->getLetterInstanceIssues() as $issue) {
+            if ($issue->requiresInput() && !$issue->hasBeenEdited()) {
+                $pending[] = $issue->getHeading() ?: 'Issue';
+            }
+        }
+
+        foreach ($letterInstance->getLetterInstanceSections() as $section) {
+            if ($section->requiresInput() && !$section->hasBeenEdited()) {
+                $pending[] = $section->getLetterSectionVersion()?->getName() ?: 'Section';
+            }
+        }
+
+        if (!empty($pending)) {
+            throw new ValidationException([
+                'requiresInput' => [sprintf(
+                    'This letter cannot be sent yet. Edit the following before sending: %s',
+                    implode(', ', $pending)
+                )],
+            ]);
+        }
     }
 
     /**

--- a/app/api/module/Api/src/Domain/CommandHandler/Letter/LetterInstance/PrepareToSend.php
+++ b/app/api/module/Api/src/Domain/CommandHandler/Letter/LetterInstance/PrepareToSend.php
@@ -122,7 +122,7 @@ final class PrepareToSend extends AbstractCommandHandler implements
 
         // Generate filename using NamingService
         $letterType = $letterInstance->getLetterType();
-        $description = $letterType ? $letterType->getName() : 'Letter';
+        $description = $this->buildDocumentDescription($letterInstance);
         $category = $letterType ? $letterType->getCategory() : null;
         $subCategory = $letterType ? $letterType->getSubCategory() : null;
 
@@ -236,6 +236,34 @@ final class PrepareToSend extends AbstractCommandHandler implements
         }
 
         return null;
+    }
+
+    /**
+     * Letter type name plus any selected radio ("pick one") choice labels.
+     *
+     * VOL-7308: variants like first/final request are letter *choices* within a
+     * single letter type, so the type name alone can't distinguish the documents
+     * in Docs & attachments. Checkbox choices are content add-ons, not variants,
+     * and are deliberately left out.
+     */
+    private function buildDocumentDescription(LetterInstanceEntity $letterInstance): string
+    {
+        $letterType = $letterInstance->getLetterType();
+        $description = $letterType ? $letterType->getName() : 'Letter';
+
+        $variantLabels = [];
+        foreach ($letterInstance->getLetterInstanceChoices() as $instanceChoice) {
+            $choice = $instanceChoice->getLetterChoice();
+            if ($choice !== null && $choice->getInputType() === 'radio' && $choice->getLabel() !== '') {
+                $variantLabels[] = $choice->getLabel();
+            }
+        }
+
+        if (!empty($variantLabels)) {
+            $description .= ' - ' . implode(', ', $variantLabels);
+        }
+
+        return $description;
     }
 
     /**

--- a/app/api/module/Api/src/Domain/CommandHandler/Letter/LetterInstance/PrepareToSend.php
+++ b/app/api/module/Api/src/Domain/CommandHandler/Letter/LetterInstance/PrepareToSend.php
@@ -11,7 +11,6 @@ use Dvsa\Olcs\Api\Domain\DocumentGeneratorAwareInterface;
 use Dvsa\Olcs\Api\Domain\DocumentGeneratorAwareTrait;
 use Dvsa\Olcs\Api\Domain\Exception\ValidationException;
 use Dvsa\Olcs\Api\Entity\Letter\LetterInstance as LetterInstanceEntity;
-use Dvsa\Olcs\Api\Entity\Letter\MasterTemplate;
 use Dvsa\Olcs\Api\Service\ConvertToPdf\ConvertHtmlToPdfInterface;
 use Dvsa\Olcs\Api\Service\Document\NamingServiceAwareInterface;
 use Dvsa\Olcs\Api\Service\Letter\LetterPreviewService;
@@ -38,7 +37,7 @@ final class PrepareToSend extends AbstractCommandHandler implements
 
     protected $repoServiceName = 'LetterInstance';
 
-    protected $extraRepos = ['Document', 'MasterTemplate'];
+    protected $extraRepos = ['Document'];
 
     private LetterPreviewService $previewService;
 
@@ -209,36 +208,6 @@ final class PrepareToSend extends AbstractCommandHandler implements
         $this->result->addMessage('Letter prepared for sending');
 
         return $this->result;
-    }
-
-    /**
-     * Get the master template to use for rendering
-     */
-    private function getMasterTemplate(LetterInstanceEntity $letterInstance): ?MasterTemplate
-    {
-        $letterType = $letterInstance->getLetterType();
-        if ($letterType !== null && $letterType->getMasterTemplate() !== null) {
-            return $letterType->getMasterTemplate();
-        }
-
-        try {
-            $repo = $this->getRepo('MasterTemplate');
-            $result = $repo->fetchList(
-                \Dvsa\Olcs\Transfer\Query\Letter\MasterTemplate\GetList::create([
-                    'isDefault' => true,
-                    'locale' => MasterTemplate::LOCALE_EN_GB,
-                    'limit' => 1,
-                ])
-            );
-
-            if (count($result) > 0) {
-                return $result[0];
-            }
-        } catch (\Exception $e) {
-            Logger::warn('PrepareToSend: Failed to fetch default master template: ' . $e->getMessage());
-        }
-
-        return null;
     }
 
     /**

--- a/app/api/module/Api/src/Domain/CommandHandler/Letter/LetterInstance/PrepareToSend.php
+++ b/app/api/module/Api/src/Domain/CommandHandler/Letter/LetterInstance/PrepareToSend.php
@@ -15,6 +15,7 @@ use Dvsa\Olcs\Api\Entity\Letter\MasterTemplate;
 use Dvsa\Olcs\Api\Service\ConvertToPdf\ConvertHtmlToPdfInterface;
 use Dvsa\Olcs\Api\Service\Document\NamingServiceAwareInterface;
 use Dvsa\Olcs\Api\Service\Letter\LetterPreviewService;
+use Dvsa\Olcs\Api\Service\Letter\MasterTemplateResolver;
 use Dvsa\Olcs\Transfer\Command\CommandInterface;
 use Dvsa\Olcs\Transfer\Command\Letter\LetterInstance\PrepareToSend as Cmd;
 use Olcs\Logging\Log\Logger;
@@ -41,6 +42,8 @@ final class PrepareToSend extends AbstractCommandHandler implements
 
     private LetterPreviewService $previewService;
 
+    private MasterTemplateResolver $masterTemplateResolver;
+
     private ConvertHtmlToPdfInterface $convertHtmlToPdf;
 
     private $contentStore;
@@ -58,8 +61,8 @@ final class PrepareToSend extends AbstractCommandHandler implements
             throw new ValidationException(['Letter instance must be in DRAFT or READY status']);
         }
 
-        // Get master template for rendering
-        $masterTemplate = $this->getMasterTemplate($letterInstance);
+        // VOL-7305: pick the right MasterTemplate row for this letter's region (GB/NI/...)
+        $masterTemplate = $this->masterTemplateResolver->resolve($letterInstance);
 
         // Render preview HTML
         $previewHtml = $this->previewService->renderPreview($letterInstance, $masterTemplate, excludePdfAppendices: true);
@@ -268,6 +271,7 @@ final class PrepareToSend extends AbstractCommandHandler implements
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): mixed
     {
         $this->previewService = $container->get(LetterPreviewService::class);
+        $this->masterTemplateResolver = $container->get(MasterTemplateResolver::class);
         $this->convertHtmlToPdf = $container->get('ConvertToPdf');
         $this->contentStore = $container->get('ContentStore');
         return parent::__invoke($container, $requestedName, $options);

--- a/app/api/module/Api/src/Domain/CommandHandler/Letter/MasterTemplate/Create.php
+++ b/app/api/module/Api/src/Domain/CommandHandler/Letter/MasterTemplate/Create.php
@@ -3,6 +3,8 @@
 namespace Dvsa\Olcs\Api\Domain\CommandHandler\Letter\MasterTemplate;
 
 use Dvsa\Olcs\Api\Domain\CommandHandler\AbstractCommandHandler;
+use Dvsa\Olcs\Api\Domain\Exception\ValidationException;
+use Dvsa\Olcs\Api\Service\EditorJs\EditorJsData;
 use Dvsa\Olcs\Transfer\Command\CommandInterface;
 use Dvsa\Olcs\Api\Domain\Command\Result;
 use Dvsa\Olcs\Api\Entity\Letter\MasterTemplate as MasterTemplateEntity;
@@ -27,10 +29,10 @@ final class Create extends AbstractCommandHandler
         $masterTemplate->setLocale($command->getLocale());
 
         // VOL-7305: optional chrome slot fields (EditorJS JSON)
-        $masterTemplate->setHeaderLeftContent($command->getHeaderLeftContent());
-        $masterTemplate->setHeaderRightContent($command->getHeaderRightContent());
-        $masterTemplate->setSignoffContent($command->getSignoffContent());
-        $masterTemplate->setFooterContent($command->getFooterContent());
+        $masterTemplate->setHeaderLeftContent($this->prepareSlotContent('headerLeftContent', $command->getHeaderLeftContent()));
+        $masterTemplate->setHeaderRightContent($this->prepareSlotContent('headerRightContent', $command->getHeaderRightContent()));
+        $masterTemplate->setSignoffContent($this->prepareSlotContent('signoffContent', $command->getSignoffContent()));
+        $masterTemplate->setFooterContent($this->prepareSlotContent('footerContent', $command->getFooterContent()));
 
         $this->getRepo()->save($masterTemplate);
 
@@ -38,5 +40,24 @@ final class Create extends AbstractCommandHandler
         $this->result->addMessage("Master template '{$masterTemplate->getName()}' created");
 
         return $this->result;
+    }
+
+    /**
+     * Reject data that isn't EditorJS-shaped at all, and fill in the envelope
+     * fields (time / block ids) the parser mandates but hand-authored content omits.
+     *
+     * @throws ValidationException
+     */
+    private function prepareSlotContent(string $field, ?array $content): ?array
+    {
+        if ($content === null) {
+            return null;
+        }
+
+        if (!EditorJsData::isValidShape($content)) {
+            throw new ValidationException([$field => ['Not valid EditorJS content: expected a "blocks" list of {type, data} objects']]);
+        }
+
+        return EditorJsData::normalize($content);
     }
 }

--- a/app/api/module/Api/src/Domain/CommandHandler/Letter/MasterTemplate/Create.php
+++ b/app/api/module/Api/src/Domain/CommandHandler/Letter/MasterTemplate/Create.php
@@ -26,6 +26,12 @@ final class Create extends AbstractCommandHandler
         $masterTemplate->setIsDefault($command->getIsDefault());
         $masterTemplate->setLocale($command->getLocale());
 
+        // VOL-7305: optional chrome slot fields (EditorJS JSON)
+        $masterTemplate->setHeaderLeftContent($command->getHeaderLeftContent());
+        $masterTemplate->setHeaderRightContent($command->getHeaderRightContent());
+        $masterTemplate->setSignoffContent($command->getSignoffContent());
+        $masterTemplate->setFooterContent($command->getFooterContent());
+
         $this->getRepo()->save($masterTemplate);
 
         $this->result->addId('masterTemplate', $masterTemplate->getId());

--- a/app/api/module/Api/src/Domain/CommandHandler/Letter/MasterTemplate/Update.php
+++ b/app/api/module/Api/src/Domain/CommandHandler/Letter/MasterTemplate/Update.php
@@ -3,6 +3,8 @@
 namespace Dvsa\Olcs\Api\Domain\CommandHandler\Letter\MasterTemplate;
 
 use Dvsa\Olcs\Api\Domain\CommandHandler\AbstractCommandHandler;
+use Dvsa\Olcs\Api\Domain\Exception\ValidationException;
+use Dvsa\Olcs\Api\Service\EditorJs\EditorJsData;
 use Dvsa\Olcs\Transfer\Command\CommandInterface;
 use Dvsa\Olcs\Api\Domain\Command\Result;
 use Dvsa\Olcs\Transfer\Command\Letter\MasterTemplate\Update as Cmd;
@@ -38,16 +40,16 @@ final class Update extends AbstractCommandHandler
 
         // VOL-7305: optional chrome slot fields (EditorJS JSON). Null = leave alone.
         if ($command->getHeaderLeftContent() !== null) {
-            $masterTemplate->setHeaderLeftContent($command->getHeaderLeftContent());
+            $masterTemplate->setHeaderLeftContent($this->prepareSlotContent('headerLeftContent', $command->getHeaderLeftContent()));
         }
         if ($command->getHeaderRightContent() !== null) {
-            $masterTemplate->setHeaderRightContent($command->getHeaderRightContent());
+            $masterTemplate->setHeaderRightContent($this->prepareSlotContent('headerRightContent', $command->getHeaderRightContent()));
         }
         if ($command->getSignoffContent() !== null) {
-            $masterTemplate->setSignoffContent($command->getSignoffContent());
+            $masterTemplate->setSignoffContent($this->prepareSlotContent('signoffContent', $command->getSignoffContent()));
         }
         if ($command->getFooterContent() !== null) {
-            $masterTemplate->setFooterContent($command->getFooterContent());
+            $masterTemplate->setFooterContent($this->prepareSlotContent('footerContent', $command->getFooterContent()));
         }
 
         $this->getRepo()->save($masterTemplate);
@@ -56,5 +58,20 @@ final class Update extends AbstractCommandHandler
         $this->result->addMessage("Master template '{$masterTemplate->getName()}' updated");
 
         return $this->result;
+    }
+
+    /**
+     * Reject data that isn't EditorJS-shaped at all, and fill in the envelope
+     * fields (time / block ids) the parser mandates but hand-authored content omits.
+     *
+     * @throws ValidationException
+     */
+    private function prepareSlotContent(string $field, array $content): array
+    {
+        if (!EditorJsData::isValidShape($content)) {
+            throw new ValidationException([$field => ['Not valid EditorJS content: expected a "blocks" list of {type, data} objects']]);
+        }
+
+        return EditorJsData::normalize($content);
     }
 }

--- a/app/api/module/Api/src/Domain/CommandHandler/Letter/MasterTemplate/Update.php
+++ b/app/api/module/Api/src/Domain/CommandHandler/Letter/MasterTemplate/Update.php
@@ -36,6 +36,20 @@ final class Update extends AbstractCommandHandler
             $masterTemplate->setLocale($command->getLocale());
         }
 
+        // VOL-7305: optional chrome slot fields (EditorJS JSON). Null = leave alone.
+        if ($command->getHeaderLeftContent() !== null) {
+            $masterTemplate->setHeaderLeftContent($command->getHeaderLeftContent());
+        }
+        if ($command->getHeaderRightContent() !== null) {
+            $masterTemplate->setHeaderRightContent($command->getHeaderRightContent());
+        }
+        if ($command->getSignoffContent() !== null) {
+            $masterTemplate->setSignoffContent($command->getSignoffContent());
+        }
+        if ($command->getFooterContent() !== null) {
+            $masterTemplate->setFooterContent($command->getFooterContent());
+        }
+
         $this->getRepo()->save($masterTemplate);
 
         $this->result->addId('masterTemplate', $masterTemplate->getId());

--- a/app/api/module/Api/src/Domain/QueryHandler/Letter/LetterInstance/Preview.php
+++ b/app/api/module/Api/src/Domain/QueryHandler/Letter/LetterInstance/Preview.php
@@ -8,6 +8,7 @@ use Dvsa\Olcs\Api\Domain\QueryHandler\AbstractQueryHandler;
 use Dvsa\Olcs\Api\Entity\Letter\LetterInstance as LetterInstanceEntity;
 use Dvsa\Olcs\Api\Entity\Letter\MasterTemplate;
 use Dvsa\Olcs\Api\Service\Letter\LetterPreviewService;
+use Dvsa\Olcs\Api\Service\Letter\MasterTemplateResolver;
 use Dvsa\Olcs\Transfer\Query\QueryInterface;
 use Psr\Container\ContainerInterface;
 
@@ -22,6 +23,7 @@ class Preview extends AbstractQueryHandler
     protected $extraRepos = ['MasterTemplate'];
 
     private LetterPreviewService $previewService;
+    private MasterTemplateResolver $masterTemplateResolver;
 
     /**
      * Bundle for fetching letter instance with all relationships
@@ -83,8 +85,8 @@ class Preview extends AbstractQueryHandler
         /** @var LetterInstanceEntity $letterInstance */
         $letterInstance = $this->getRepo()->fetchUsingId($query);
 
-        // Get the master template from the letter type, or fall back to default
-        $masterTemplate = $this->getMasterTemplate($letterInstance);
+        // VOL-7305: pick the right MasterTemplate row for this letter's region (GB/NI/...)
+        $masterTemplate = $this->masterTemplateResolver->resolve($letterInstance);
 
         // Render the preview HTML
         $previewHtml = $this->previewService->renderPreview($letterInstance, $masterTemplate);
@@ -182,6 +184,7 @@ class Preview extends AbstractQueryHandler
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): self
     {
         $this->previewService = $container->get(LetterPreviewService::class);
+        $this->masterTemplateResolver = $container->get(MasterTemplateResolver::class);
         return parent::__invoke($container, $requestedName, $options);
     }
 }

--- a/app/api/module/Api/src/Domain/QueryHandler/Letter/LetterInstance/Preview.php
+++ b/app/api/module/Api/src/Domain/QueryHandler/Letter/LetterInstance/Preview.php
@@ -6,7 +6,6 @@ namespace Dvsa\Olcs\Api\Domain\QueryHandler\Letter\LetterInstance;
 
 use Dvsa\Olcs\Api\Domain\QueryHandler\AbstractQueryHandler;
 use Dvsa\Olcs\Api\Entity\Letter\LetterInstance as LetterInstanceEntity;
-use Dvsa\Olcs\Api\Entity\Letter\MasterTemplate;
 use Dvsa\Olcs\Api\Service\Letter\LetterPreviewService;
 use Dvsa\Olcs\Api\Service\Letter\MasterTemplateResolver;
 use Dvsa\Olcs\Transfer\Query\QueryInterface;
@@ -20,7 +19,6 @@ use Psr\Container\ContainerInterface;
 class Preview extends AbstractQueryHandler
 {
     protected $repoServiceName = 'LetterInstance';
-    protected $extraRepos = ['MasterTemplate'];
 
     private LetterPreviewService $previewService;
     private MasterTemplateResolver $masterTemplateResolver;
@@ -102,41 +100,6 @@ class Preview extends AbstractQueryHandler
             'previewHtml' => $previewHtml,
             'sectionsList' => $sectionsList,
         ];
-    }
-
-    /**
-     * Get the master template to use for rendering
-     *
-     * @param LetterInstanceEntity $letterInstance
-     * @return MasterTemplate|null
-     */
-    private function getMasterTemplate(LetterInstanceEntity $letterInstance): ?MasterTemplate
-    {
-        // First try to get from the letter type
-        $letterType = $letterInstance->getLetterType();
-        if ($letterType !== null && $letterType->getMasterTemplate() !== null) {
-            return $letterType->getMasterTemplate();
-        }
-
-        // Fall back to default template for locale
-        try {
-            $repo = $this->getRepo('MasterTemplate');
-            $result = $repo->fetchList(
-                \Dvsa\Olcs\Transfer\Query\Letter\MasterTemplate\GetList::create([
-                    'isDefault' => true,
-                    'locale' => MasterTemplate::LOCALE_EN_GB,
-                    'limit' => 1
-                ])
-            );
-
-            if (count($result) > 0) {
-                return $result[0];
-            }
-        } catch (\Exception) {
-            // Log and continue without template
-        }
-
-        return null;
     }
 
     /**

--- a/app/api/module/Api/src/Domain/QueryHandler/Letter/LetterInstance/Preview.php
+++ b/app/api/module/Api/src/Domain/QueryHandler/Letter/LetterInstance/Preview.php
@@ -164,7 +164,15 @@ class Preview extends AbstractQueryHandler
                         'id' => $typeId,
                         'name' => $issueType->getName(),
                         'type' => 'issueType',
+                        'inputPending' => false,
                     ];
+                }
+
+                // VOL-7402: flag types still carrying unedited "requires input"
+                // content so the sidebar can highlight them; sending is blocked
+                // server-side until they are edited.
+                if ($issue->requiresInput() && !$issue->hasBeenEdited()) {
+                    $issueTypeMap[$typeId]['inputPending'] = true;
                 }
             }
         }

--- a/app/api/module/Api/src/Domain/Repository/MasterTemplate.php
+++ b/app/api/module/Api/src/Domain/Repository/MasterTemplate.php
@@ -10,4 +10,26 @@ use Dvsa\Olcs\Api\Entity\Letter\MasterTemplate as Entity;
 class MasterTemplate extends AbstractRepository
 {
     protected $entity = Entity::class;
+
+    /**
+     * Find a MasterTemplate by its (name, locale) pair — used by MasterTemplateResolver
+     * to pivot between chrome variants (e.g. en_GB ↔ en_NI sibling rows sharing the same
+     * family name) at letter-generation time (VOL-7305).
+     *
+     * @param string $name
+     * @param string $locale
+     * @return Entity|null
+     */
+    public function findByNameAndLocale(string $name, string $locale): ?Entity
+    {
+        $qb = $this->createQueryBuilder();
+        $qb->andWhere($qb->expr()->eq($this->alias . '.name', ':name'))
+            ->andWhere($qb->expr()->eq($this->alias . '.locale', ':locale'))
+            ->setParameter('name', $name)
+            ->setParameter('locale', $locale)
+            ->setMaxResults(1);
+
+        $result = $qb->getQuery()->getResult();
+        return $result[0] ?? null;
+    }
 }

--- a/app/api/module/Api/src/Domain/Repository/MasterTemplate.php
+++ b/app/api/module/Api/src/Domain/Repository/MasterTemplate.php
@@ -32,4 +32,28 @@ class MasterTemplate extends AbstractRepository
         $result = $qb->getQuery()->getResult();
         return $result[0] ?? null;
     }
+
+    /**
+     * Fetch the default master template — the chrome used when a LetterType has no
+     * template of its own. Prefers the en_GB row; tolerates a NULL locale so
+     * pre-VOL-7305 default rows keep working until re-saved.
+     *
+     * @return Entity|null
+     */
+    public function fetchDefault(): ?Entity
+    {
+        $qb = $this->createQueryBuilder();
+        $qb->andWhere($qb->expr()->eq($this->alias . '.isDefault', ':isDefault'))
+            ->andWhere($qb->expr()->orX(
+                $qb->expr()->eq($this->alias . '.locale', ':locale'),
+                $qb->expr()->isNull($this->alias . '.locale')
+            ))
+            ->setParameter('isDefault', true)
+            ->setParameter('locale', Entity::LOCALE_EN_GB)
+            ->orderBy($this->alias . '.locale', 'DESC')
+            ->setMaxResults(1);
+
+        $result = $qb->getQuery()->getResult();
+        return $result[0] ?? null;
+    }
 }

--- a/app/api/module/Api/src/Entity/Letter/AbstractMasterTemplate.php
+++ b/app/api/module/Api/src/Entity/Letter/AbstractMasterTemplate.php
@@ -101,13 +101,55 @@ abstract class AbstractMasterTemplate implements BundleSerializableInterface, Js
     protected $isDefault = 0;
 
     /**
-     * en_GB, cy_GB, etc
+     * Locale / chrome variant key — extended vocabulary beyond strict ISO codes,
+     * e.g. en_GB, en_NI, cy_GB, customN_GB, customN_NI. Picked at letter-generation
+     * time by MasterTemplateResolver from the letter context (currently isNi).
      *
      * @var string
      *
-     * @ORM\Column(type="string", name="locale", length=5, nullable=true)
+     * @ORM\Column(type="string", name="locale", length=20, nullable=true)
      */
     protected $locale;
+
+    /**
+     * EditorJS JSON for the top-left header slot (typically the logo). Replaces
+     * the {{HEADER_LEFT_CONTENT}} placeholder in template_content at render time.
+     *
+     * @var array|null
+     *
+     * @ORM\Column(type="json", name="header_left_content", nullable=true)
+     */
+    protected $headerLeftContent;
+
+    /**
+     * EditorJS JSON for the top-right header slot (typically the address block).
+     * Replaces the {{HEADER_RIGHT_CONTENT}} placeholder at render time.
+     *
+     * @var array|null
+     *
+     * @ORM\Column(type="json", name="header_right_content", nullable=true)
+     */
+    protected $headerRightContent;
+
+    /**
+     * EditorJS JSON for the signoff slot (typically "Yours, ..." + caseworker name).
+     * Replaces the {{SIGNOFF_CONTENT}} placeholder at render time.
+     *
+     * @var array|null
+     *
+     * @ORM\Column(type="json", name="signoff_content", nullable=true)
+     */
+    protected $signoffContent;
+
+    /**
+     * EditorJS JSON for the footer slot (typically a single-line footer note).
+     * Replaces the {{FOOTER_CONTENT}} placeholder at render time.
+     *
+     * @var array|null
+     *
+     * @ORM\Column(type="json", name="footer_content", nullable=true)
+     */
+    protected $footerContent;
 
     /**
      * Version
@@ -301,6 +343,102 @@ abstract class AbstractMasterTemplate implements BundleSerializableInterface, Js
     public function getLocale()
     {
         return $this->locale;
+    }
+
+    /**
+     * Set the header left content (EditorJS JSON)
+     *
+     * @param array|null $headerLeftContent
+     *
+     * @return MasterTemplate
+     */
+    public function setHeaderLeftContent($headerLeftContent)
+    {
+        $this->headerLeftContent = $headerLeftContent;
+
+        return $this;
+    }
+
+    /**
+     * Get the header left content (EditorJS JSON)
+     *
+     * @return array|null
+     */
+    public function getHeaderLeftContent()
+    {
+        return $this->headerLeftContent;
+    }
+
+    /**
+     * Set the header right content (EditorJS JSON)
+     *
+     * @param array|null $headerRightContent
+     *
+     * @return MasterTemplate
+     */
+    public function setHeaderRightContent($headerRightContent)
+    {
+        $this->headerRightContent = $headerRightContent;
+
+        return $this;
+    }
+
+    /**
+     * Get the header right content (EditorJS JSON)
+     *
+     * @return array|null
+     */
+    public function getHeaderRightContent()
+    {
+        return $this->headerRightContent;
+    }
+
+    /**
+     * Set the signoff content (EditorJS JSON)
+     *
+     * @param array|null $signoffContent
+     *
+     * @return MasterTemplate
+     */
+    public function setSignoffContent($signoffContent)
+    {
+        $this->signoffContent = $signoffContent;
+
+        return $this;
+    }
+
+    /**
+     * Get the signoff content (EditorJS JSON)
+     *
+     * @return array|null
+     */
+    public function getSignoffContent()
+    {
+        return $this->signoffContent;
+    }
+
+    /**
+     * Set the footer content (EditorJS JSON)
+     *
+     * @param array|null $footerContent
+     *
+     * @return MasterTemplate
+     */
+    public function setFooterContent($footerContent)
+    {
+        $this->footerContent = $footerContent;
+
+        return $this;
+    }
+
+    /**
+     * Get the footer content (EditorJS JSON)
+     *
+     * @return array|null
+     */
+    public function getFooterContent()
+    {
+        return $this->footerContent;
     }
 
     /**

--- a/app/api/module/Api/src/Entity/Letter/MasterTemplate.php
+++ b/app/api/module/Api/src/Entity/Letter/MasterTemplate.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\Mapping as ORM;
 class MasterTemplate extends AbstractMasterTemplate
 {
     public const LOCALE_EN_GB = 'en_GB';
+    public const LOCALE_EN_NI = 'en_NI';
     public const LOCALE_CY_GB = 'cy_GB';
 
     /**

--- a/app/api/module/Api/src/Service/ConvertToPdf/GotenbergClient.php
+++ b/app/api/module/Api/src/Service/ConvertToPdf/GotenbergClient.php
@@ -141,6 +141,15 @@ class GotenbergClient implements ConvertToPdfInterface, ConvertHtmlToPdfInterfac
         $this->httpClient->setMethod(Request::METHOD_POST);
         $this->httpClient->setFileUpload('index.html', 'files', $htmlContent, 'text/html');
 
+        // VOL-7288: Chromium defaults to US Letter and ignores CSS @page size, which
+        // made letter bodies a different page width from merged A4 appendix PDFs.
+        // Honour the document's @page rule when present, A4 otherwise.
+        $this->httpClient->setParameterPost([
+            'preferCssPageSize' => 'true',
+            'paperWidth' => '8.27',
+            'paperHeight' => '11.7',
+        ]);
+
         $response = $this->httpClient->send();
 
         if (!$response->isOk()) {

--- a/app/api/module/Api/src/Service/Document/Bookmark/CaseworkerName.php
+++ b/app/api/module/Api/src/Service/Document/Bookmark/CaseworkerName.php
@@ -4,6 +4,7 @@ namespace Dvsa\Olcs\Api\Service\Document\Bookmark;
 
 use Dvsa\Olcs\Api\Service\Document\Bookmark\Base\DynamicBookmark;
 use Dvsa\Olcs\Api\Domain\Query\Bookmark\UserBundle as Qry;
+use Olcs\Logging\Log\Logger;
 
 /**
  * Caseworker name bookmark
@@ -36,6 +37,11 @@ class CaseworkerName extends DynamicBookmark
         if (!is_array($person)) {
             // Mirrors the previous LetterPreviewService::buildCaseworkerName fallback
             // when the user has no contact details / person set, or no user at all.
+            // This bookmark is shared with legacy RTF docgen (which used to fail
+            // loudly here), so make the silent degradation at least visible.
+            Logger::warn('CaseworkerName bookmark fell back to generic label', [
+                'reason' => 'no person data on user',
+            ]);
             return 'Caseworker';
         }
         return Formatter\Name::format($person);

--- a/app/api/module/Api/src/Service/Document/Bookmark/CaseworkerName.php
+++ b/app/api/module/Api/src/Service/Document/Bookmark/CaseworkerName.php
@@ -15,6 +15,12 @@ class CaseworkerName extends DynamicBookmark
     #[\Override]
     public function getQuery(array $data)
     {
+        // Skip the query when no user id is in scope (e.g. preview of a letter with no
+        // createdBy yet) — render() will fall back to a generic "Caseworker" label.
+        if (empty($data['user'])) {
+            return null;
+        }
+
         $bundle = [
             'contactDetails' => [
                 'person'
@@ -26,6 +32,12 @@ class CaseworkerName extends DynamicBookmark
     #[\Override]
     public function render()
     {
-        return Formatter\Name::format($this->data['contactDetails']['person']);
+        $person = $this->data['contactDetails']['person'] ?? null;
+        if (!is_array($person)) {
+            // Mirrors the previous LetterPreviewService::buildCaseworkerName fallback
+            // when the user has no contact details / person set, or no user at all.
+            return 'Caseworker';
+        }
+        return Formatter\Name::format($person);
     }
 }

--- a/app/api/module/Api/src/Service/EditorJs/ConverterService.php
+++ b/app/api/module/Api/src/Service/EditorJs/ConverterService.php
@@ -84,9 +84,49 @@ class ConverterService
         $config = \HTMLPurifier_Config::createDefault();
         $config->set('Cache.SerializerPath', sys_get_temp_dir());
 
+        // Letter chrome embeds the OTC logo as an inline base64 image. HTMLPurifier's
+        // data-URI scheme handler only admits verified image payloads (png/gif/jpeg),
+        // so allowing the scheme does not open script or arbitrary-content vectors.
+        $config->set('URI.AllowedSchemes', [
+            'http' => true,
+            'https' => true,
+            'mailto' => true,
+            'tel' => true,
+            'data' => true,
+        ]);
+
         return $config;
     }
 
+
+    /**
+     * Normalise EditorJS data to the envelope shape the parser mandates.
+     *
+     * Hand-authored content (DB seeds, imports) often omits the top-level 'time' and
+     * per-block 'id' fields, which the Setono parser treats as required. Fill them in
+     * so such content renders instead of failing the whole conversion; content saved
+     * through the EditorJS editor already conforms and passes through untouched.
+     */
+    public function normalize(array $data): array
+    {
+        if (!isset($data['time']) || !is_int($data['time'])) {
+            $data['time'] = 0;
+        }
+
+        if (!isset($data['version']) || !is_string($data['version'])) {
+            $data['version'] = 'unknown';
+        }
+
+        if (isset($data['blocks']) && is_array($data['blocks'])) {
+            foreach ($data['blocks'] as $i => $block) {
+                if (is_array($block) && (!isset($block['id']) || !is_string($block['id']) || $block['id'] === '')) {
+                    $data['blocks'][$i]['id'] = 'gen-' . $i;
+                }
+            }
+        }
+
+        return $data;
+    }
 
     /**
      * Validate EditorJS JSON structure

--- a/app/api/module/Api/src/Service/EditorJs/ConverterService.php
+++ b/app/api/module/Api/src/Service/EditorJs/ConverterService.php
@@ -31,8 +31,12 @@ class ConverterService
 
     /**
      * Convert EditorJS JSON to HTML for database storage
+     *
+     * @param bool $allowInlineImages Permit data: URI images — for admin-authored
+     *                                letter chrome (the inline OTC logo) ONLY, never
+     *                                caseworker-editable content
      */
-    public function convertJsonToHtml(string $jsonData): string
+    public function convertJsonToHtml(string $jsonData, bool $allowInlineImages = false): string
     {
         if (empty($jsonData)) {
             return '';
@@ -41,7 +45,7 @@ class ConverterService
         try {
             $parserResult = $this->parser->parse($jsonData);
             $html = $this->renderer->render($parserResult);
-            return $this->cleanOutputHtml($html);
+            return $this->cleanOutputHtml($html, $allowInlineImages);
         } catch (\Exception $e) {
             throw new \RuntimeException('Failed to convert JSON to HTML: ' . $e->getMessage());
         }
@@ -53,14 +57,14 @@ class ConverterService
      *
      * @throws \RuntimeException if HTMLPurifier is not available
      */
-    private function cleanOutputHtml(string $html): string
+    private function cleanOutputHtml(string $html, bool $allowInlineImages = false): string
     {
         // HTMLPurifier is required for security
         if (!class_exists('\HTMLPurifier')) {
             throw new \RuntimeException('HTMLPurifier is required for secure HTML sanitization');
         }
 
-        $purifier = new \HTMLPurifier($this->buildPurifierConfig());
+        $purifier = new \HTMLPurifier($this->buildPurifierConfig($allowInlineImages));
         $cleanHtml = $purifier->purify($html);
 
         // Remove empty paragraphs and other empty block elements
@@ -79,21 +83,34 @@ class ConverterService
      * "Directory ... not writable" warnings and forces the definition cache to be regenerated on
      * every call.
      */
-    public function buildPurifierConfig(): \HTMLPurifier_Config
+    public function buildPurifierConfig(bool $allowInlineImages = false): \HTMLPurifier_Config
     {
         $config = \HTMLPurifier_Config::createDefault();
         $config->set('Cache.SerializerPath', sys_get_temp_dir());
 
-        // Letter chrome embeds the OTC logo as an inline base64 image. HTMLPurifier's
-        // data-URI scheme handler only admits verified image payloads (png/gif/jpeg),
-        // so allowing the scheme does not open script or arbitrary-content vectors.
-        $config->set('URI.AllowedSchemes', [
-            'http' => true,
-            'https' => true,
-            'mailto' => true,
-            'tel' => true,
-            'data' => true,
-        ]);
+        // HTMLPurifier's URISchemeRegistry is a process-global singleton: once a
+        // permissive purify instantiates the data scheme, OverrideAllowedSchemes
+        // (default true) lets every later purify accept it regardless of its own
+        // AllowedSchemes. False makes each purify enforce its own list.
+        $config->set('URI.OverrideAllowedSchemes', false);
+
+        if ($allowInlineImages) {
+            // Letter chrome embeds the OTC logo as an inline base64 image. HTMLPurifier's
+            // data-URI scheme handler only admits verified image payloads (png/gif/jpeg),
+            // so allowing the scheme does not open script or arbitrary-content vectors.
+            // The list is the purifier's default set plus 'data' — caseworker-editable
+            // content never gets this config, so it cannot smuggle inline images.
+            $config->set('URI.AllowedSchemes', [
+                'http' => true,
+                'https' => true,
+                'mailto' => true,
+                'ftp' => true,
+                'nntp' => true,
+                'news' => true,
+                'tel' => true,
+                'data' => true,
+            ]);
+        }
 
         return $config;
     }

--- a/app/api/module/Api/src/Service/EditorJs/ConverterService.php
+++ b/app/api/module/Api/src/Service/EditorJs/ConverterService.php
@@ -109,23 +109,7 @@ class ConverterService
      */
     public function normalize(array $data): array
     {
-        if (!isset($data['time']) || !is_int($data['time'])) {
-            $data['time'] = 0;
-        }
-
-        if (!isset($data['version']) || !is_string($data['version'])) {
-            $data['version'] = 'unknown';
-        }
-
-        if (isset($data['blocks']) && is_array($data['blocks'])) {
-            foreach ($data['blocks'] as $i => $block) {
-                if (is_array($block) && (!isset($block['id']) || !is_string($block['id']) || $block['id'] === '')) {
-                    $data['blocks'][$i]['id'] = 'gen-' . $i;
-                }
-            }
-        }
-
-        return $data;
+        return EditorJsData::normalize($data);
     }
 
     /**

--- a/app/api/module/Api/src/Service/EditorJs/EditorJsData.php
+++ b/app/api/module/Api/src/Service/EditorJs/EditorJsData.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dvsa\Olcs\Api\Service\EditorJs;
+
+/**
+ * Shape helpers for EditorJS data arrays.
+ *
+ * The Setono parser mandates the envelope {time: int, version: string,
+ * blocks: [{id, type, data}, ...]} but hand-authored content (DB seeds, imports,
+ * direct API calls) frequently omits 'time' and per-block 'id'. These helpers are
+ * static so command handlers can use them without service wiring.
+ */
+final class EditorJsData
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * Fill in the envelope fields the parser mandates but hand-authored content
+     * omits. Conformant data passes through untouched.
+     */
+    public static function normalize(array $data): array
+    {
+        if (!isset($data['time']) || !is_int($data['time'])) {
+            $data['time'] = 0;
+        }
+
+        if (!isset($data['version']) || !is_string($data['version'])) {
+            $data['version'] = 'unknown';
+        }
+
+        if (isset($data['blocks']) && is_array($data['blocks'])) {
+            foreach ($data['blocks'] as $i => $block) {
+                if (is_array($block) && (!isset($block['id']) || !is_string($block['id']) || $block['id'] === '')) {
+                    $data['blocks'][$i]['id'] = 'gen-' . $i;
+                }
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Structural check: 'blocks' must be an array of blocks each carrying a string
+     * 'type' and an array 'data'. Envelope fields (time/version/id) are NOT required
+     * here — normalize() can supply those; this guards against data that isn't
+     * EditorJS-shaped at all.
+     */
+    public static function isValidShape(array $data): bool
+    {
+        if (!isset($data['blocks']) || !is_array($data['blocks'])) {
+            return false;
+        }
+
+        foreach ($data['blocks'] as $block) {
+            if (!is_array($block) || !isset($block['type']) || !is_string($block['type'])) {
+                return false;
+            }
+            if (!isset($block['data']) || !is_array($block['data'])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/app/api/module/Api/src/Service/Letter/LetterPreviewService.php
+++ b/app/api/module/Api/src/Service/Letter/LetterPreviewService.php
@@ -8,6 +8,7 @@ use Dvsa\Olcs\Api\Entity\Letter\LetterInstance;
 use Dvsa\Olcs\Api\Entity\Letter\MasterTemplate;
 use Dvsa\Olcs\Api\Service\EditorJs\ConverterService;
 use Dvsa\Olcs\Api\Service\Letter\SectionRenderer\SectionRendererPluginManager;
+use Olcs\Logging\Log\Logger;
 
 /**
  * Service for rendering letter previews
@@ -307,6 +308,10 @@ class LetterPreviewService
             return '';
         }
 
+        // Hand-seeded slot content may lack the 'time'/'id' envelope fields the
+        // EditorJS parser mandates — normalise so one bad slot can't 500 the preview.
+        $editorJsContent = $this->converterService->normalize($editorJsContent);
+
         $json = json_encode($editorJsContent);
         if ($json === false) {
             return '';
@@ -344,8 +349,18 @@ class LetterPreviewService
 
         $imgTag = $this->buildLogoImgTagForSlug($slug);
         if ($imgTag === '') {
-            // Slug not seeded or document not uploaded — replace with empty so the
-            // letter still renders cleanly rather than leaking the bare token.
+            // Region-specific slug not seeded — fall back to the legacy single-slug
+            // row so environments that pre-date the -gb/-ni convention keep a logo.
+            $imgTag = $this->buildLogoImgTagForSlug(self::LOGO_TEMPLATE_SLUG);
+        }
+
+        if ($imgTag === '') {
+            // Nothing resolvable — render cleanly without a logo rather than leaking
+            // the bare token, but leave a trace: a silently blank logo cost real
+            // diagnosis time and is otherwise invisible in every environment.
+            Logger::warn('OTC logo could not be resolved for letter chrome', [
+                'slugsTried' => [$slug, self::LOGO_TEMPLATE_SLUG],
+            ]);
             return str_replace(self::OTC_LOGO_TOKEN, '', $json);
         }
 
@@ -398,7 +413,11 @@ class LetterPreviewService
                 htmlspecialchars($mime),
                 $base64
             );
-        } catch (\Exception) {
+        } catch (\Exception $e) {
+            Logger::warn('OTC logo lookup failed', [
+                'slug' => $slug,
+                'reason' => $e->getMessage(),
+            ]);
             return '';
         }
     }

--- a/app/api/module/Api/src/Service/Letter/LetterPreviewService.php
+++ b/app/api/module/Api/src/Service/Letter/LetterPreviewService.php
@@ -282,10 +282,10 @@ class LetterPreviewService
             // VOL-7305: chrome slot placeholders rendered from the MasterTemplate's
             // EditorJS fields. Bookmarks ([[OTC_LOGO]], [[CASEWORKER_NAME]], etc.)
             // inside the slot content are resolved by VolGrabReplacementService.
-            '{{HEADER_LEFT_CONTENT}}'  => $this->renderSlot($masterTemplate?->getHeaderLeftContent(),  $volGrabContext),
+            '{{HEADER_LEFT_CONTENT}}'  => $this->renderSlot($masterTemplate?->getHeaderLeftContent(), $volGrabContext),
             '{{HEADER_RIGHT_CONTENT}}' => $this->renderSlot($masterTemplate?->getHeaderRightContent(), $volGrabContext),
-            '{{SIGNOFF_CONTENT}}'      => $this->renderSlot($masterTemplate?->getSignoffContent(),     $volGrabContext),
-            '{{FOOTER_CONTENT}}'       => $this->renderSlot($masterTemplate?->getFooterContent(),     $volGrabContext),
+            '{{SIGNOFF_CONTENT}}'      => $this->renderSlot($masterTemplate?->getSignoffContent(), $volGrabContext),
+            '{{FOOTER_CONTENT}}'       => $this->renderSlot($masterTemplate?->getFooterContent(), $volGrabContext),
             // Recipient address block. Future enhancement could compute this from
             // the licence's correspondence address; for now we keep the placeholder
             // recognised (resolved to empty) so it doesn't leak into the output.

--- a/app/api/module/Api/src/Service/Letter/LetterPreviewService.php
+++ b/app/api/module/Api/src/Service/Letter/LetterPreviewService.php
@@ -396,24 +396,34 @@ class LetterPreviewService
                 return '';
             }
 
+            // read() returns File|false — never null (same trap documented on the
+            // legacy buildLogoImage below), so guard falsy or a missing file fatals.
             $file = $this->contentStore->read($document->getIdentifier());
-            if ($file === null) {
+            if (!$file) {
                 return '';
             }
 
             $content = (string) $file->getContent();
-            $base64 = base64_encode($content);
 
-            // Pick mime from the magic bytes — default to png so older seed files keep working
+            // The purifier's data-URI handler only admits GD-verified png/gif/jpeg —
+            // anything else (SVG, WebP, corrupt file) would be stripped *silently*
+            // downstream, so refuse it here where we can log and fall back instead.
             $info = @getimagesizefromstring($content);
-            $mime = ($info && !empty($info['mime'])) ? $info['mime'] : 'image/png';
+            $mime = $info['mime'] ?? null;
+            if (!in_array($mime, ['image/png', 'image/gif', 'image/jpeg'], true)) {
+                Logger::warn('OTC logo document is not a supported image type', [
+                    'slug' => $slug,
+                    'detectedMime' => $mime ?? 'not an image',
+                ]);
+                return '';
+            }
 
             return sprintf(
                 '<img src="data:%s;base64,%s" alt="OTC logo" style="max-width:180px;height:auto;">',
                 htmlspecialchars($mime),
-                $base64
+                base64_encode($content)
             );
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Logger::warn('OTC logo lookup failed', [
                 'slug' => $slug,
                 'reason' => $e->getMessage(),

--- a/app/api/module/Api/src/Service/Letter/LetterPreviewService.php
+++ b/app/api/module/Api/src/Service/Letter/LetterPreviewService.php
@@ -179,7 +179,7 @@ class LetterPreviewService
                 if ($items !== '') {
                     $html .= '<div class="issue-todos">';
                     $html .= '<h4 class="todo-heading" style="font-size:14pt;font-weight:bold;color:#000;">What you need to do</h4>';
-                    $html .= '<ul class="todo-list">' . $items . '</ul>';
+                    $html .= '<div class="todo-list">' . $items . '</div>';
                     $html .= '</div>';
                 }
             }

--- a/app/api/module/Api/src/Service/Letter/LetterPreviewService.php
+++ b/app/api/module/Api/src/Service/Letter/LetterPreviewService.php
@@ -6,6 +6,7 @@ namespace Dvsa\Olcs\Api\Service\Letter;
 
 use Dvsa\Olcs\Api\Entity\Letter\LetterInstance;
 use Dvsa\Olcs\Api\Entity\Letter\MasterTemplate;
+use Dvsa\Olcs\Api\Service\EditorJs\ConverterService;
 use Dvsa\Olcs\Api\Service\Letter\SectionRenderer\SectionRendererPluginManager;
 
 /**
@@ -17,9 +18,17 @@ use Dvsa\Olcs\Api\Service\Letter\SectionRenderer\SectionRendererPluginManager;
 class LetterPreviewService
 {
     private const string LOGO_TEMPLATE_SLUG = 'otclogo-letters';
+    private const string OTC_LOGO_SLUG_GB = 'otclogo-letters-gb';
+    private const string OTC_LOGO_SLUG_NI = 'otclogo-letters-ni';
+    private const string OTC_LOGO_TOKEN = '[[OTC_LOGO]]';
 
-    public function __construct(private readonly SectionRendererPluginManager $rendererManager, private $contentStore, private $docTemplateRepo, private readonly VolGrabReplacementService $volGrabReplacementService)
-    {
+    public function __construct(
+        private readonly SectionRendererPluginManager $rendererManager,
+        private $contentStore,
+        private $docTemplateRepo,
+        private readonly VolGrabReplacementService $volGrabReplacementService,
+        private readonly ?ConverterService $converterService = null
+    ) {
     }
 
     /**
@@ -42,8 +51,18 @@ class LetterPreviewService
             $html = $this->renderWithoutTemplate($assembledHtml, '', $appendicesHtml);
         } else {
             // Build placeholder values — assembled content goes into SECTIONS_CONTENT,
-            // ISSUES_CONTENT is empty since issues are now inline within the assembly
-            $placeholders = $this->buildPlaceholders($letterInstance, $assembledHtml, '', '', $appendicesHtml);
+            // ISSUES_CONTENT is empty since issues are now inline within the assembly.
+            // The MasterTemplate's chrome slot fields (header/signoff/footer) are rendered
+            // here too and slot into the page-chrome HTML shell (VOL-7305).
+            $placeholders = $this->buildPlaceholders(
+                $letterInstance,
+                $assembledHtml,
+                '',
+                '',
+                $appendicesHtml,
+                $masterTemplate,
+                $context
+            );
 
             $html = $this->populateTemplate($masterTemplate->getTemplateContent(), $placeholders);
         }
@@ -238,7 +257,9 @@ class LetterPreviewService
         string $sectionsHtml,
         string $issuesHtml,
         string $closingHtml,
-        string $appendicesHtml = ''
+        string $appendicesHtml = '',
+        ?MasterTemplate $masterTemplate = null,
+        array $volGrabContext = []
     ): array {
         return [
             '{{LOGO_IMAGE}}' => $this->buildLogoImage(),
@@ -248,14 +269,138 @@ class LetterPreviewService
             '{{ISSUES_CONTENT}}' => $issuesHtml,
             '{{CLOSING_CONTENT}}' => $closingHtml,
             '{{CASEWORKER_NAME}}' => $this->buildCaseworkerName($letterInstance),
-            '{{DVSA_ADDRESS}}' => $this->buildDvsaAddress(),
+            // VOL-7305: DVSA_ADDRESS is no longer hardcoded in PHP. It lives in the
+            // headerRightContent slot on the matching MasterTemplate row, picked by
+            // MasterTemplateResolver. Kept here as '' for backward compat in case any
+            // legacy template still references the placeholder.
+            '{{DVSA_ADDRESS}}' => '',
             '{{ENTITY_REFERENCE}}' => $this->buildEntityReference($letterInstance),
             '{{SALUTATION}}' => $this->buildSalutation($letterInstance),
             '{{SIGNATURE_NAME}}' => '', // To be populated from user/config
             '{{SIGNATURE_TITLE}}' => '', // To be populated from user/config
-            '{{FOOTER_CONTENT}}' => '',
+            // VOL-7305: chrome slot placeholders rendered from the MasterTemplate's
+            // EditorJS fields. Bookmarks ([[OTC_LOGO]], [[CASEWORKER_NAME]], etc.)
+            // inside the slot content are resolved by VolGrabReplacementService.
+            '{{HEADER_LEFT_CONTENT}}'  => $this->renderSlot($masterTemplate?->getHeaderLeftContent(),  $volGrabContext),
+            '{{HEADER_RIGHT_CONTENT}}' => $this->renderSlot($masterTemplate?->getHeaderRightContent(), $volGrabContext),
+            '{{SIGNOFF_CONTENT}}'      => $this->renderSlot($masterTemplate?->getSignoffContent(),     $volGrabContext),
+            '{{FOOTER_CONTENT}}'       => $this->renderSlot($masterTemplate?->getFooterContent(),     $volGrabContext),
+            // Recipient address block. Future enhancement could compute this from
+            // the licence's correspondence address; for now we keep the placeholder
+            // recognised (resolved to empty) so it doesn't leak into the output.
+            '{{RECIPIENT_ADDRESS_BLOCK}}' => '',
             '{{APPENDICES_CONTENT}}' => $appendicesHtml,
         ];
+    }
+
+    /**
+     * Render an EditorJS chrome slot to HTML, with vol-grab bookmark replacement.
+     * Returns empty string for null/empty content or if no ConverterService is wired.
+     *
+     * @param array|null $editorJsContent EditorJS JSON as array (from MasterTemplate slot field)
+     * @param array $context Vol-grab context (licence, application, user, etc.)
+     * @return string HTML
+     */
+    private function renderSlot(?array $editorJsContent, array $context): string
+    {
+        if (empty($editorJsContent) || $this->converterService === null) {
+            return '';
+        }
+
+        $json = json_encode($editorJsContent);
+        if ($json === false) {
+            return '';
+        }
+
+        // VOL-7305: resolve [[OTC_LOGO]] before standard bookmark replacement +
+        // EditorJS-to-HTML conversion. The token picks the right region's logo from
+        // the content store via the existing DocTemplate-by-slug mechanism.
+        $json = $this->replaceOtcLogoToken($json, $context);
+
+        $jsonWithGrabs = $this->volGrabReplacementService->replaceGrabs($json, $context);
+
+        return $this->converterService->convertJsonToHtml($jsonWithGrabs);
+    }
+
+    /**
+     * Replace any [[OTC_LOGO]] token in EditorJS JSON with an inline-base64 `<img>` tag.
+     * The image is chosen by isNi context — NI letters get the NI logo, all else GB.
+     *
+     * Embedded directly in the JSON string (properly escaped) so the EditorJS converter
+     * later turns the surrounding paragraph into HTML with the img tag in place.
+     *
+     * @param string $json
+     * @param array $context
+     * @return string JSON with the OTC_LOGO token replaced
+     */
+    private function replaceOtcLogoToken(string $json, array $context): string
+    {
+        if (!str_contains($json, self::OTC_LOGO_TOKEN)) {
+            return $json;
+        }
+
+        $isNi = (bool) ($context['isNi'] ?? false);
+        $slug = $isNi ? self::OTC_LOGO_SLUG_NI : self::OTC_LOGO_SLUG_GB;
+
+        $imgTag = $this->buildLogoImgTagForSlug($slug);
+        if ($imgTag === '') {
+            // Slug not seeded or document not uploaded — replace with empty so the
+            // letter still renders cleanly rather than leaking the bare token.
+            return str_replace(self::OTC_LOGO_TOKEN, '', $json);
+        }
+
+        // JSON-escape the img tag so it can be safely interpolated inside a JSON string
+        $escaped = json_encode($imgTag, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if ($escaped === false) {
+            return str_replace(self::OTC_LOGO_TOKEN, '', $json);
+        }
+        // Strip the surrounding quotes json_encode added
+        $escaped = substr($escaped, 1, -1);
+
+        return str_replace(self::OTC_LOGO_TOKEN, $escaped, $json);
+    }
+
+    /**
+     * Fetch a DocTemplate by slug, read its underlying Document from the content store,
+     * and return an inline-base64 `<img>` tag. Returns '' on any miss (no DocTemplate,
+     * no Document, missing file) — caller decides how to handle a blank slot.
+     *
+     * @param string $slug
+     * @return string
+     */
+    private function buildLogoImgTagForSlug(string $slug): string
+    {
+        try {
+            $docTemplate = $this->docTemplateRepo->fetchByTemplateSlug($slug);
+            if ($docTemplate === null) {
+                return '';
+            }
+
+            $document = $docTemplate->getDocument();
+            if ($document === null) {
+                return '';
+            }
+
+            $file = $this->contentStore->read($document->getIdentifier());
+            if ($file === null) {
+                return '';
+            }
+
+            $content = (string) $file->getContent();
+            $base64 = base64_encode($content);
+
+            // Pick mime from the magic bytes — default to png so older seed files keep working
+            $info = @getimagesizefromstring($content);
+            $mime = ($info && !empty($info['mime'])) ? $info['mime'] : 'image/png';
+
+            return sprintf(
+                '<img src="data:%s;base64,%s" alt="OTC logo" style="max-width:180px;height:auto;">',
+                htmlspecialchars($mime),
+                $base64
+            );
+        } catch (\Exception) {
+            return '';
+        }
     }
 
     /**
@@ -277,20 +422,6 @@ class LetterPreviewService
             }
         }
         return 'Caseworker';
-    }
-
-    /**
-     * Build static DVSA address
-     *
-     * @return string HTML formatted DVSA address
-     */
-    private function buildDvsaAddress(): string
-    {
-        return 'The Central Licensing Office<br>' .
-               'Hillcrest House<br>' .
-               '386 Harehills Lane<br>' .
-               'Leeds<br>' .
-               'LS9 6NF';
     }
 
     /**
@@ -390,7 +521,7 @@ class LetterPreviewService
      */
     private function buildVolGrabContext(LetterInstance $letterInstance): array
     {
-        return array_filter([
+        $context = array_filter([
             'licence' => $letterInstance->getLicence()?->getId(),
             'application' => $letterInstance->getApplication()?->getId(),
             'user' => $letterInstance->getCreatedBy()?->getId(),
@@ -398,6 +529,13 @@ class LetterPreviewService
             'busRegId' => $letterInstance->getBusReg()?->getId(),
             'organisation' => $letterInstance->getOrganisation()?->getId(),
         ]);
+
+        // VOL-7305: isNi is needed by the OTC_LOGO token resolver and is a useful
+        // signal for any future region-aware bookmark. Added outside the array_filter
+        // because false is a meaningful value (GB letter) that should survive.
+        $context['isNi'] = (bool) ($letterInstance->getLicence()?->isNi() ?? false);
+
+        return $context;
     }
 
     /**

--- a/app/api/module/Api/src/Service/Letter/LetterPreviewService.php
+++ b/app/api/module/Api/src/Service/Letter/LetterPreviewService.php
@@ -324,7 +324,18 @@ class LetterPreviewService
 
         $jsonWithGrabs = $this->volGrabReplacementService->replaceGrabs($json, $context);
 
-        return $this->converterService->convertJsonToHtml($jsonWithGrabs);
+        try {
+            // allowInlineImages: chrome slots are admin-authored, and the OTC logo
+            // is embedded as a base64 data URI — caseworker content never gets this.
+            return $this->converterService->convertJsonToHtml($jsonWithGrabs, true);
+        } catch (\Throwable $e) {
+            // e.g. a block type the renderer doesn't support — degrade to an empty
+            // slot rather than 500ing every letter that uses this master template.
+            Logger::warn('Letter chrome slot failed to render', [
+                'reason' => $e->getMessage(),
+            ]);
+            return '';
+        }
     }
 
     /**

--- a/app/api/module/Api/src/Service/Letter/LetterPreviewServiceFactory.php
+++ b/app/api/module/Api/src/Service/Letter/LetterPreviewServiceFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Dvsa\Olcs\Api\Service\Letter;
 
+use Dvsa\Olcs\Api\Service\EditorJs\ConverterService;
 use Dvsa\Olcs\Api\Service\Letter\SectionRenderer\SectionRendererPluginManager;
 use Dvsa\Olcs\Api\Service\Letter\VolGrabReplacementService;
 use Laminas\ServiceManager\Factory\FactoryInterface;
@@ -31,7 +32,8 @@ class LetterPreviewServiceFactory implements FactoryInterface
             $container->get(SectionRendererPluginManager::class),
             $container->get('ContentStore'),
             $repoManager->get('DocTemplate'),
-            $container->get(VolGrabReplacementService::class)
+            $container->get(VolGrabReplacementService::class),
+            $container->get(ConverterService::class)
         );
     }
 }

--- a/app/api/module/Api/src/Service/Letter/MasterTemplateResolver.php
+++ b/app/api/module/Api/src/Service/Letter/MasterTemplateResolver.php
@@ -32,7 +32,11 @@ class MasterTemplateResolver
      */
     public function resolve(LetterInstance $letterInstance): ?MasterTemplate
     {
-        $base = $letterInstance->getLetterType()?->getMasterTemplate();
+        // Letter types without their own template fall back to the default chrome —
+        // parity with the pre-resolver behaviour; a null here would silently render
+        // the letter bare (no logo, sender address, signoff or footer).
+        $base = $letterInstance->getLetterType()?->getMasterTemplate()
+            ?? $this->masterTemplateRepo->fetchDefault();
         if ($base === null) {
             return null;
         }

--- a/app/api/module/Api/src/Service/Letter/MasterTemplateResolver.php
+++ b/app/api/module/Api/src/Service/Letter/MasterTemplateResolver.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dvsa\Olcs\Api\Service\Letter;
+
+use Dvsa\Olcs\Api\Domain\Repository\MasterTemplate as MasterTemplateRepo;
+use Dvsa\Olcs\Api\Entity\Letter\LetterInstance;
+use Dvsa\Olcs\Api\Entity\Letter\MasterTemplate;
+
+/**
+ * Picks the right MasterTemplate row for a given letter instance.
+ *
+ * Each LetterType points at a "base" MasterTemplate; sibling rows share that base's
+ * name but differ by locale (en_GB, en_NI, cy_GB, future customN_*). The resolver
+ * computes a preferred locale from the letter's context (currently driven only by
+ * isNi) and returns the matching sibling — falling back to the base if no exact
+ * match exists.
+ *
+ * VOL-7305.
+ */
+class MasterTemplateResolver
+{
+    public function __construct(
+        private readonly MasterTemplateRepo $masterTemplateRepo
+    ) {
+    }
+
+    /**
+     * @param LetterInstance $letterInstance
+     * @return MasterTemplate|null
+     */
+    public function resolve(LetterInstance $letterInstance): ?MasterTemplate
+    {
+        $base = $letterInstance->getLetterType()?->getMasterTemplate();
+        if ($base === null) {
+            return null;
+        }
+
+        $preferredLocale = $this->preferredLocaleFor($letterInstance);
+
+        if ($base->getLocale() === $preferredLocale) {
+            return $base;
+        }
+
+        $sibling = $this->masterTemplateRepo->findByNameAndLocale($base->getName(), $preferredLocale);
+        return $sibling ?? $base;
+    }
+
+    /**
+     * Maps the letter context to a MasterTemplate.locale code.
+     *
+     * Today this is driven only by isNi — NI letters get en_NI, everything else en_GB.
+     * Welsh (cy_GB) and custom-chrome (customN_*) selection are deliberate future
+     * extension points, not in scope for VOL-7305.
+     *
+     * @param LetterInstance $letter
+     * @return string
+     */
+    private function preferredLocaleFor(LetterInstance $letter): string
+    {
+        $isNi = $letter->getLicence()?->isNi() ?? false;
+
+        // future: read a per-LetterType chrome override here, or a Welsh-language
+        //         flag carried in the LetterInstance, to pick cy_GB or customN_*.
+
+        return $isNi ? MasterTemplate::LOCALE_EN_NI : MasterTemplate::LOCALE_EN_GB;
+    }
+}

--- a/app/api/module/Api/src/Service/Letter/MasterTemplateResolverFactory.php
+++ b/app/api/module/Api/src/Service/Letter/MasterTemplateResolverFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dvsa\Olcs\Api\Service\Letter;
+
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Factory for MasterTemplateResolver (VOL-7305).
+ */
+class MasterTemplateResolverFactory implements FactoryInterface
+{
+    #[\Override]
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null): MasterTemplateResolver
+    {
+        $repoManager = $container->get('RepositoryServiceManager');
+
+        return new MasterTemplateResolver(
+            $repoManager->get('MasterTemplate')
+        );
+    }
+}

--- a/app/api/module/Api/src/Service/Letter/SectionRenderer/TodoSectionRenderer.php
+++ b/app/api/module/Api/src/Service/Letter/SectionRenderer/TodoSectionRenderer.php
@@ -9,8 +9,8 @@ use Dvsa\Olcs\Api\Entity\Letter\LetterInstanceTodo;
 /**
  * Renderer for LetterInstanceTodo entities.
  *
- * Outputs a single `<li>` containing the to-do description (EditorJS → HTML
- * with vol-grab replacement). The enclosing "What you need to do" block + `<ul>`
+ * Outputs a single block `<div>` containing the to-do description (EditorJS → HTML
+ * with vol-grab replacement). The enclosing "What you need to do" heading + container
  * is rendered by LetterPreviewService::renderIssues() once per issue-type group.
  */
 class TodoSectionRenderer extends AbstractSectionRenderer
@@ -60,7 +60,9 @@ class TodoSectionRenderer extends AbstractSectionRenderer
             return '';
         }
 
-        return '<li class="todo-item">' . $body . '</li>';
+        // VOL-7280: a block, not a list item — as an <li> the whole to-do became a
+        // bullet and bullets inside its own content demoted to hollow nested ones.
+        return '<div class="todo-item">' . $body . '</div>';
     }
 
     #[\Override]

--- a/app/api/module/Api/src/Service/Letter/VolGrabReplacementService.php
+++ b/app/api/module/Api/src/Service/Letter/VolGrabReplacementService.php
@@ -76,8 +76,10 @@ class VolGrabReplacementService
             // Step 4: Render bookmarks to get values
             $populatedData = $this->renderBookmarks($bookmarks, $queryResults);
 
-            // Step 5: Replace in JSON
-            return $parser->replace($editorJsJson, $populatedData);
+            // Step 5: Replace in JSON, then strip anything that couldn't be resolved
+            // (unknown bookmark, or a dynamic bookmark whose query produced nothing)
+            // so literal [[TOKEN]] text never reaches a letter sent to an operator.
+            return $this->stripUnresolvedTokens($parser->replace($editorJsJson, $populatedData));
         } catch (\Exception $e) {
             // Log error but return original content to avoid breaking letters
             Logger::err('VOL Grab replacement failed: ' . $e->getMessage());
@@ -261,12 +263,30 @@ class VolGrabReplacementService
             $queryResults = $this->executeQueries($bookmarks, $context);
             $populatedData = $this->renderBookmarks($bookmarks, $queryResults, true);
 
-            return $this->replaceTokensInHtml($html, $populatedData);
+            return $this->stripUnresolvedTokens($this->replaceTokensInHtml($html, $populatedData));
         } catch (\Exception $e) {
             // Log error but return original content to avoid breaking letters
             Logger::err('VOL Grab replacement in HTML failed: ' . $e->getMessage());
             return $html;
         }
+    }
+
+    /**
+     * Remove any [[TOKEN]]s left after replacement — an unknown bookmark class or a
+     * dynamic bookmark whose query returned nothing (e.g. CASEWORKER_NAME on a letter
+     * with no creating user) otherwise leaks the literal token into the rendered
+     * letter and the PDF posted to the operator.
+     */
+    private function stripUnresolvedTokens(string $content): string
+    {
+        if (preg_match_all(self::GRAB_PATTERN, $content, $matches) && !empty($matches[1])) {
+            Logger::warn('Unresolved VOL grab tokens stripped from letter content', [
+                'tokens' => array_values(array_unique($matches[1])),
+            ]);
+            $content = (string) preg_replace(self::GRAB_PATTERN, '', $content);
+        }
+
+        return $content;
     }
 
     /**

--- a/app/api/test/module/Api/src/Domain/CommandHandler/Letter/LetterInstance/PrepareToSendTest.php
+++ b/app/api/test/module/Api/src/Domain/CommandHandler/Letter/LetterInstance/PrepareToSendTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dvsa\OlcsTest\Api\Domain\CommandHandler\Letter\LetterInstance;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Dvsa\Olcs\Api\Domain\CommandHandler\Letter\LetterInstance\PrepareToSend;
+use Dvsa\Olcs\Api\Entity\Letter\LetterChoice;
+use Dvsa\Olcs\Api\Entity\Letter\LetterInstance;
+use Dvsa\Olcs\Api\Entity\Letter\LetterInstanceChoice;
+use Dvsa\Olcs\Api\Entity\Letter\LetterType;
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+/**
+ * PrepareToSend LetterInstance Test
+ */
+class PrepareToSendTest extends MockeryTestCase
+{
+    private function buildDescription(LetterInstance $letterInstance): string
+    {
+        $method = new \ReflectionMethod(PrepareToSend::class, 'buildDocumentDescription');
+        $method->setAccessible(true);
+
+        return $method->invoke(
+            (new \ReflectionClass(PrepareToSend::class))->newInstanceWithoutConstructor(),
+            $letterInstance
+        );
+    }
+
+    private function mockChoice(string $label, string $inputType): LetterInstanceChoice
+    {
+        $letterChoice = m::mock(LetterChoice::class);
+        $letterChoice->shouldReceive('getLabel')->andReturn($label);
+        $letterChoice->shouldReceive('getInputType')->andReturn($inputType);
+
+        $instanceChoice = m::mock(LetterInstanceChoice::class);
+        $instanceChoice->shouldReceive('getLetterChoice')->andReturn($letterChoice);
+
+        return $instanceChoice;
+    }
+
+    public function testDescriptionIncludesSelectedRadioChoiceLabels(): void
+    {
+        // VOL-7308: first/final is a letter *choice* within one letter type, so the
+        // Docs & attachments description must carry the chosen variant.
+        $letterType = m::mock(LetterType::class);
+        $letterType->shouldReceive('getName')->andReturn('GV - Incomplete app New/Var');
+
+        $letterInstance = m::mock(LetterInstance::class);
+        $letterInstance->shouldReceive('getLetterType')->andReturn($letterType);
+        $letterInstance->shouldReceive('getLetterInstanceChoices')->andReturn(new ArrayCollection([
+            $this->mockChoice('First request', 'radio'),
+            $this->mockChoice('Include urgent flag', 'checkbox'),
+        ]));
+
+        $this->assertSame(
+            'GV - Incomplete app New/Var - First request',
+            $this->buildDescription($letterInstance)
+        );
+    }
+
+    public function testDescriptionIsJustTypeNameWithoutRadioChoices(): void
+    {
+        $letterType = m::mock(LetterType::class);
+        $letterType->shouldReceive('getName')->andReturn('GV - Blank letter to operator');
+
+        $letterInstance = m::mock(LetterInstance::class);
+        $letterInstance->shouldReceive('getLetterType')->andReturn($letterType);
+        $letterInstance->shouldReceive('getLetterInstanceChoices')->andReturn(new ArrayCollection());
+
+        $this->assertSame('GV - Blank letter to operator', $this->buildDescription($letterInstance));
+    }
+
+    public function testDescriptionFallsBackWhenNoLetterType(): void
+    {
+        $letterInstance = m::mock(LetterInstance::class);
+        $letterInstance->shouldReceive('getLetterType')->andReturn(null);
+        $letterInstance->shouldReceive('getLetterInstanceChoices')->andReturn(new ArrayCollection());
+
+        $this->assertSame('Letter', $this->buildDescription($letterInstance));
+    }
+}

--- a/app/api/test/module/Api/src/Domain/CommandHandler/Letter/LetterInstance/PrepareToSendTest.php
+++ b/app/api/test/module/Api/src/Domain/CommandHandler/Letter/LetterInstance/PrepareToSendTest.php
@@ -81,4 +81,81 @@ class PrepareToSendTest extends MockeryTestCase
 
         $this->assertSame('Letter', $this->buildDescription($letterInstance));
     }
+
+    private function assertRequiredInput(LetterInstance $letterInstance): void
+    {
+        $method = new \ReflectionMethod(PrepareToSend::class, 'assertRequiredInputProvided');
+        $method->setAccessible(true);
+        $method->invoke(
+            (new \ReflectionClass(PrepareToSend::class))->newInstanceWithoutConstructor(),
+            $letterInstance
+        );
+    }
+
+    private function mockRequiresInputIssue(string $heading, bool $requiresInput, bool $edited): m\MockInterface
+    {
+        $issue = m::mock(\Dvsa\Olcs\Api\Entity\Letter\LetterInstanceIssue::class);
+        $issue->shouldReceive('requiresInput')->andReturn($requiresInput);
+        $issue->shouldReceive('hasBeenEdited')->andReturn($edited);
+        $issue->shouldReceive('getHeading')->andReturn($heading);
+
+        return $issue;
+    }
+
+    public function testPrepareToSendBlockedWhenRequiredInputIssueUnedited(): void
+    {
+        // VOL-7402: a section flagged "requires input" must be changed from its
+        // default content before the letter can be sent.
+        $letterInstance = m::mock(LetterInstance::class);
+        $letterInstance->shouldReceive('getLetterInstanceIssues')->andReturn(new ArrayCollection([
+            $this->mockRequiresInputIssue('Financial evidence', true, false),
+        ]));
+        $letterInstance->shouldReceive('getLetterInstanceSections')->andReturn(new ArrayCollection());
+
+        $this->expectException(\Dvsa\Olcs\Api\Domain\Exception\ValidationException::class);
+
+        try {
+            $this->assertRequiredInput($letterInstance);
+        } catch (\Dvsa\Olcs\Api\Domain\Exception\ValidationException $e) {
+            $this->assertStringContainsString('Financial evidence', json_encode($e->getMessages()));
+            throw $e;
+        }
+    }
+
+    public function testPrepareToSendAllowedWhenRequiredInputProvided(): void
+    {
+        $letterInstance = m::mock(LetterInstance::class);
+        $letterInstance->shouldReceive('getLetterInstanceIssues')->andReturn(new ArrayCollection([
+            $this->mockRequiresInputIssue('Financial evidence', true, true),
+            $this->mockRequiresInputIssue('Adverts', false, false),
+        ]));
+        $letterInstance->shouldReceive('getLetterInstanceSections')->andReturn(new ArrayCollection());
+
+        $this->assertRequiredInput($letterInstance);
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testPrepareToSendBlockedWhenRequiredInputSectionUnedited(): void
+    {
+        $sectionVersion = m::mock(\Dvsa\Olcs\Api\Entity\Letter\LetterSectionVersion::class);
+        $sectionVersion->shouldReceive('getName')->andReturn('Introductory wording');
+
+        $section = m::mock(\Dvsa\Olcs\Api\Entity\Letter\LetterInstanceSection::class);
+        $section->shouldReceive('requiresInput')->andReturn(true);
+        $section->shouldReceive('hasBeenEdited')->andReturn(false);
+        $section->shouldReceive('getLetterSectionVersion')->andReturn($sectionVersion);
+
+        $letterInstance = m::mock(LetterInstance::class);
+        $letterInstance->shouldReceive('getLetterInstanceIssues')->andReturn(new ArrayCollection());
+        $letterInstance->shouldReceive('getLetterInstanceSections')->andReturn(new ArrayCollection([$section]));
+
+        $this->expectException(\Dvsa\Olcs\Api\Domain\Exception\ValidationException::class);
+
+        try {
+            $this->assertRequiredInput($letterInstance);
+        } catch (\Dvsa\Olcs\Api\Domain\Exception\ValidationException $e) {
+            $this->assertStringContainsString('Introductory wording', json_encode($e->getMessages()));
+            throw $e;
+        }
+    }
 }

--- a/app/api/test/module/Api/src/Domain/CommandHandler/Letter/MasterTemplate/CreateTest.php
+++ b/app/api/test/module/Api/src/Domain/CommandHandler/Letter/MasterTemplate/CreateTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dvsa\OlcsTest\Api\Domain\CommandHandler\Letter\MasterTemplate;
+
+use Dvsa\Olcs\Api\Domain\CommandHandler\Letter\MasterTemplate\Create as CommandHandler;
+use Dvsa\Olcs\Api\Domain\Exception\ValidationException;
+use Dvsa\Olcs\Api\Domain\Repository\MasterTemplate as MasterTemplateRepo;
+use Dvsa\Olcs\Api\Entity\Letter\MasterTemplate as MasterTemplateEntity;
+use Dvsa\Olcs\Transfer\Command\Letter\MasterTemplate\Create as Cmd;
+use Dvsa\OlcsTest\Api\Domain\CommandHandler\AbstractCommandHandlerTestCase;
+use Mockery as m;
+
+/**
+ * Create MasterTemplate Test
+ */
+class CreateTest extends AbstractCommandHandlerTestCase
+{
+    public function setUp(): void
+    {
+        $this->sut = new CommandHandler();
+        $this->mockRepo('MasterTemplate', MasterTemplateRepo::class);
+
+        parent::setUp();
+    }
+
+    public function testHandleCommandNormalisesSeedShapedSlotContent(): void
+    {
+        $seedShaped = [
+            'version' => '2.28.2',
+            'blocks' => [
+                ['type' => 'paragraph', 'data' => ['text' => 'Vehicle Operator Licensing']],
+            ],
+        ];
+
+        $command = Cmd::create([
+            'name' => 'NI Letter Template',
+            'templateContent' => '<html>{{FOOTER_CONTENT}}</html>',
+            'isDefault' => false,
+            'locale' => 'en_NI',
+            'footerContent' => $seedShaped,
+        ]);
+
+        $captured = null;
+        $this->repoMap['MasterTemplate']->shouldReceive('save')
+            ->once()
+            ->andReturnUsing(function (MasterTemplateEntity $entity) use (&$captured) {
+                $captured = $entity->getFooterContent();
+                $entity->setId(99);
+            });
+
+        $result = $this->sut->handleCommand($command);
+
+        $this->assertSame(99, $result->getId('masterTemplate'));
+        $this->assertIsInt($captured['time']);
+        $this->assertSame('gen-0', $captured['blocks'][0]['id']);
+    }
+
+    public function testHandleCommandRejectsNonEditorJsShapedSlotContent(): void
+    {
+        $command = Cmd::create([
+            'name' => 'Bad Template',
+            'templateContent' => '<html></html>',
+            'isDefault' => false,
+            'locale' => 'en_GB',
+            'headerRightContent' => ['blocks' => 'not-an-array'],
+        ]);
+
+        $this->expectException(ValidationException::class);
+
+        $this->sut->handleCommand($command);
+    }
+}

--- a/app/api/test/module/Api/src/Domain/CommandHandler/Letter/MasterTemplate/UpdateTest.php
+++ b/app/api/test/module/Api/src/Domain/CommandHandler/Letter/MasterTemplate/UpdateTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dvsa\OlcsTest\Api\Domain\CommandHandler\Letter\MasterTemplate;
+
+use Dvsa\Olcs\Api\Domain\CommandHandler\Letter\MasterTemplate\Update as CommandHandler;
+use Dvsa\Olcs\Api\Domain\Exception\ValidationException;
+use Dvsa\Olcs\Api\Domain\Repository\MasterTemplate as MasterTemplateRepo;
+use Dvsa\Olcs\Api\Entity\Letter\MasterTemplate as MasterTemplateEntity;
+use Dvsa\Olcs\Transfer\Command\Letter\MasterTemplate\Update as Cmd;
+use Dvsa\OlcsTest\Api\Domain\CommandHandler\AbstractCommandHandlerTestCase;
+use Mockery as m;
+
+/**
+ * Update MasterTemplate Test
+ */
+class UpdateTest extends AbstractCommandHandlerTestCase
+{
+    public function setUp(): void
+    {
+        $this->sut = new CommandHandler();
+        $this->mockRepo('MasterTemplate', MasterTemplateRepo::class);
+
+        parent::setUp();
+    }
+
+    public function testHandleCommandNormalisesSeedShapedSlotContent(): void
+    {
+        // Seed/hand-authored shape: no top-level 'time', blocks without 'id' — the
+        // EditorJS parser requires both, so the handler must normalise on the way in.
+        $seedShaped = [
+            'version' => '2.28.2',
+            'blocks' => [
+                ['type' => 'paragraph', 'data' => ['text' => 'Office of the Traffic Commissioner']],
+            ],
+        ];
+
+        $command = Cmd::create([
+            'id' => 1,
+            'name' => 'Default Letter Template',
+            'headerLeftContent' => $seedShaped,
+            'version' => 1,
+        ]);
+
+        $entity = m::mock(MasterTemplateEntity::class)->makePartial();
+        $entity->setId(1);
+        $entity->shouldReceive('getName')->andReturn('Default Letter Template');
+
+        $captured = null;
+        $entity->shouldReceive('setHeaderLeftContent')
+            ->once()
+            ->andReturnUsing(function ($content) use (&$captured) {
+                $captured = $content;
+            });
+
+        $this->repoMap['MasterTemplate']->shouldReceive('fetchUsingId')
+            ->with($command)
+            ->once()
+            ->andReturn($entity);
+        $this->repoMap['MasterTemplate']->shouldReceive('save')
+            ->with($entity)
+            ->once();
+
+        $this->sut->handleCommand($command);
+
+        $this->assertIsInt($captured['time']);
+        $this->assertSame('gen-0', $captured['blocks'][0]['id']);
+        $this->assertSame($seedShaped['blocks'][0]['data'], $captured['blocks'][0]['data']);
+    }
+
+    public function testHandleCommandRejectsNonEditorJsShapedSlotContent(): void
+    {
+        $command = Cmd::create([
+            'id' => 1,
+            'name' => 'Default Letter Template',
+            'signoffContent' => ['nonsense' => 'no blocks key here'],
+            'version' => 1,
+        ]);
+
+        $entity = m::mock(MasterTemplateEntity::class)->makePartial();
+        $entity->setId(1);
+
+        $this->repoMap['MasterTemplate']->shouldReceive('fetchUsingId')
+            ->with($command)
+            ->andReturn($entity);
+
+        $this->expectException(ValidationException::class);
+
+        $this->sut->handleCommand($command);
+    }
+}

--- a/app/api/test/module/Api/src/Domain/QueryHandler/Letter/LetterInstance/PreviewTest.php
+++ b/app/api/test/module/Api/src/Domain/QueryHandler/Letter/LetterInstance/PreviewTest.php
@@ -143,12 +143,18 @@ class PreviewTest extends QueryHandlerTestCase
 
         $mockIssue1 = m::mock(LetterInstanceIssue::class);
         $mockIssue1->shouldReceive('getLetterIssueVersion')->andReturn($mockIssueVersion1);
+        $mockIssue1->shouldReceive('requiresInput')->andReturn(false);
+        $mockIssue1->shouldReceive('hasBeenEdited')->andReturn(false);
 
         $mockIssue2 = m::mock(LetterInstanceIssue::class);
         $mockIssue2->shouldReceive('getLetterIssueVersion')->andReturn($mockIssueVersion2);
+        $mockIssue2->shouldReceive('requiresInput')->andReturn(false);
+        $mockIssue2->shouldReceive('hasBeenEdited')->andReturn(false);
 
         $mockIssue3 = m::mock(LetterInstanceIssue::class);
         $mockIssue3->shouldReceive('getLetterIssueVersion')->andReturn($mockIssueVersion3);
+        $mockIssue3->shouldReceive('requiresInput')->andReturn(false);
+        $mockIssue3->shouldReceive('hasBeenEdited')->andReturn(false);
 
         $mockLetterInstance = m::mock(LetterInstanceEntity::class);
         $mockLetterInstance->shouldReceive('getLetterType')
@@ -232,5 +238,49 @@ class PreviewTest extends QueryHandlerTestCase
             ->andReturn(['id' => 123, 'reference' => 'VOL/LET/123']);
 
         return $mockLetterInstance;
+    }
+
+    public function testSectionsListFlagsPendingRequiredInput(): void
+    {
+        // VOL-7402: the sidebar needs to know which issue types still contain
+        // unedited "requires input" content so it can highlight them.
+        $query = Qry::create(['id' => 123]);
+
+        $mockIssueType = m::mock(LetterIssueType::class);
+        $mockIssueType->shouldReceive('getId')->andReturn(1);
+        $mockIssueType->shouldReceive('getName')->andReturn('Finances');
+
+        $mockIssueVersion = m::mock(LetterIssueVersion::class);
+        $mockIssueVersion->shouldReceive('getLetterIssueType')->andReturn($mockIssueType);
+
+        $pendingIssue = m::mock(LetterInstanceIssue::class);
+        $pendingIssue->shouldReceive('getLetterIssueVersion')->andReturn($mockIssueVersion);
+        $pendingIssue->shouldReceive('requiresInput')->andReturn(true);
+        $pendingIssue->shouldReceive('hasBeenEdited')->andReturn(false);
+
+        $mockLetterType = m::mock(\Dvsa\Olcs\Api\Entity\Letter\LetterType::class);
+        $mockLetterType->shouldReceive('getMasterTemplate')->andReturn(null);
+
+        $mockLetterInstance = m::mock(LetterInstanceEntity::class);
+        $mockLetterInstance->shouldReceive('getLetterType')->andReturn($mockLetterType);
+        $mockLetterInstance->shouldReceive('getLetterInstanceIssues')
+            ->andReturn(new ArrayCollection([$pendingIssue]));
+        $mockLetterInstance->shouldReceive('serialize')->andReturn(['id' => 123]);
+
+        $this->repoMap['LetterInstance']->shouldReceive('fetchUsingId')
+            ->with($query)
+            ->once()
+            ->andReturn($mockLetterInstance);
+
+        $this->mockMasterTemplateResolver->shouldReceive('resolve')
+            ->andReturn(null);
+
+        $this->mockPreviewService->shouldReceive('renderPreview')
+            ->once()
+            ->andReturn('<html>Preview</html>');
+
+        $result = $this->sut->handleQuery($query);
+
+        $this->assertTrue($result['sectionsList'][0]['inputPending']);
     }
 }

--- a/app/api/test/module/Api/src/Domain/QueryHandler/Letter/LetterInstance/PreviewTest.php
+++ b/app/api/test/module/Api/src/Domain/QueryHandler/Letter/LetterInstance/PreviewTest.php
@@ -15,6 +15,7 @@ use Dvsa\Olcs\Api\Entity\Letter\LetterIssueVersion;
 use Dvsa\Olcs\Api\Entity\Letter\LetterType;
 use Dvsa\Olcs\Api\Entity\Letter\MasterTemplate;
 use Dvsa\Olcs\Api\Service\Letter\LetterPreviewService;
+use Dvsa\Olcs\Api\Service\Letter\MasterTemplateResolver;
 use Dvsa\Olcs\Transfer\Query\Letter\LetterInstance\Preview as Qry;
 use Dvsa\OlcsTest\Api\Domain\QueryHandler\QueryHandlerTestCase;
 use Mockery as m;
@@ -25,6 +26,7 @@ use Mockery as m;
 class PreviewTest extends QueryHandlerTestCase
 {
     private m\MockInterface|LetterPreviewService $mockPreviewService;
+    private m\MockInterface|MasterTemplateResolver $mockMasterTemplateResolver;
 
     public function setUp(): void
     {
@@ -33,33 +35,36 @@ class PreviewTest extends QueryHandlerTestCase
         $this->mockRepo('MasterTemplate', MasterTemplateRepo::class);
 
         $this->mockPreviewService = m::mock(LetterPreviewService::class);
+        $this->mockMasterTemplateResolver = m::mock(MasterTemplateResolver::class);
 
         $this->mockedSmServices = [
             LetterPreviewService::class => $this->mockPreviewService,
+            MasterTemplateResolver::class => $this->mockMasterTemplateResolver,
         ];
 
         parent::setUp();
     }
 
-    public function testHandleQueryWithMasterTemplateFromLetterType(): void
+    public function testHandleQueryUsesResolvedMasterTemplate(): void
     {
+        // VOL-7305: handler delegates master-template selection to MasterTemplateResolver.
         $data = ['id' => 123];
         $query = Qry::create($data);
 
         $mockMasterTemplate = m::mock(MasterTemplate::class);
-        $mockMasterTemplate->shouldReceive('getTemplateContent')
-            ->andReturn('<html>{{LETTER_REFERENCE}}</html>');
 
         $mockLetterType = m::mock(LetterType::class);
-        $mockLetterType->shouldReceive('getMasterTemplate')
-            ->andReturn($mockMasterTemplate);
-
         $mockLetterInstance = $this->createMockLetterInstance($mockLetterType);
 
         $this->repoMap['LetterInstance']->shouldReceive('fetchUsingId')
             ->with($query)
             ->once()
             ->andReturn($mockLetterInstance);
+
+        $this->mockMasterTemplateResolver->shouldReceive('resolve')
+            ->with($mockLetterInstance)
+            ->once()
+            ->andReturn($mockMasterTemplate);
 
         $this->mockPreviewService->shouldReceive('renderPreview')
             ->with($mockLetterInstance, $mockMasterTemplate)
@@ -75,17 +80,14 @@ class PreviewTest extends QueryHandlerTestCase
         $this->assertEquals('<html>VOL/LET/123</html>', $result['previewHtml']);
     }
 
-    public function testHandleQueryFallsBackToDefaultTemplate(): void
+    public function testHandleQueryWhenResolverReturnsNull(): void
     {
+        // VOL-7305: if the resolver finds nothing, renderPreview gets null and falls
+        // back to its templateless rendering path.
         $data = ['id' => 123];
         $query = Qry::create($data);
 
         $mockLetterType = m::mock(LetterType::class);
-        $mockLetterType->shouldReceive('getMasterTemplate')
-            ->andReturn(null);
-
-        $mockDefaultTemplate = m::mock(MasterTemplate::class);
-
         $mockLetterInstance = $this->createMockLetterInstance($mockLetterType);
 
         $this->repoMap['LetterInstance']->shouldReceive('fetchUsingId')
@@ -93,40 +95,10 @@ class PreviewTest extends QueryHandlerTestCase
             ->once()
             ->andReturn($mockLetterInstance);
 
-        $this->repoMap['MasterTemplate']->shouldReceive('fetchList')
+        $this->mockMasterTemplateResolver->shouldReceive('resolve')
+            ->with($mockLetterInstance)
             ->once()
-            ->andReturn([$mockDefaultTemplate]);
-
-        $this->mockPreviewService->shouldReceive('renderPreview')
-            ->with($mockLetterInstance, $mockDefaultTemplate)
-            ->once()
-            ->andReturn('<html>Preview HTML</html>');
-
-        $result = $this->sut->handleQuery($query);
-
-        $this->assertIsArray($result);
-        $this->assertEquals('<html>Preview HTML</html>', $result['previewHtml']);
-    }
-
-    public function testHandleQueryWithNoTemplateAvailable(): void
-    {
-        $data = ['id' => 123];
-        $query = Qry::create($data);
-
-        $mockLetterType = m::mock(LetterType::class);
-        $mockLetterType->shouldReceive('getMasterTemplate')
             ->andReturn(null);
-
-        $mockLetterInstance = $this->createMockLetterInstance($mockLetterType);
-
-        $this->repoMap['LetterInstance']->shouldReceive('fetchUsingId')
-            ->with($query)
-            ->once()
-            ->andReturn($mockLetterInstance);
-
-        $this->repoMap['MasterTemplate']->shouldReceive('fetchList')
-            ->once()
-            ->andReturn([]);
 
         $this->mockPreviewService->shouldReceive('renderPreview')
             ->with($mockLetterInstance, null)
@@ -147,7 +119,8 @@ class PreviewTest extends QueryHandlerTestCase
         $mockMasterTemplate = m::mock(MasterTemplate::class);
 
         $mockLetterType = m::mock(LetterType::class);
-        $mockLetterType->shouldReceive('getMasterTemplate')
+
+        $this->mockMasterTemplateResolver->shouldReceive('resolve')
             ->andReturn($mockMasterTemplate);
 
         // Create issues with different types
@@ -221,7 +194,8 @@ class PreviewTest extends QueryHandlerTestCase
         $mockMasterTemplate = m::mock(MasterTemplate::class);
 
         $mockLetterType = m::mock(LetterType::class);
-        $mockLetterType->shouldReceive('getMasterTemplate')
+
+        $this->mockMasterTemplateResolver->shouldReceive('resolve')
             ->andReturn($mockMasterTemplate);
 
         $mockLetterInstance = m::mock(LetterInstanceEntity::class);

--- a/app/api/test/module/Api/src/Service/ConvertToPdf/GotenbergClientTest.php
+++ b/app/api/test/module/Api/src/Service/ConvertToPdf/GotenbergClientTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dvsa\OlcsTest\Api\Service\ConvertToPdf;
+
+use Dvsa\Olcs\Api\Service\ConvertToPdf\GotenbergClient;
+use Laminas\Http\Client as HttpClient;
+use Laminas\Http\Response;
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+#[\PHPUnit\Framework\Attributes\CoversClass(\Dvsa\Olcs\Api\Service\ConvertToPdf\GotenbergClient::class)]
+class GotenbergClientTest extends MockeryTestCase
+{
+    public function testConvertHtmlRequestsA4PageSize(): void
+    {
+        // VOL-7288: without explicit sizing Gotenberg's Chromium renders US Letter
+        // (612x792pt) and ignores the template's @page{size:A4}, so the letter body
+        // came out a different width from the merged A4 appendix PDFs.
+        $tempFile = tempnam(sys_get_temp_dir(), 'gotenberg_test_') . '.pdf';
+
+        $response = m::mock(Response::class);
+        $response->shouldReceive('isOk')->andReturn(true);
+        $response->shouldReceive('getBody')->andReturn('%PDF-1.4 fake');
+
+        $httpClient = m::mock(HttpClient::class);
+        $httpClient->shouldReceive('reset')->once();
+        $httpClient->shouldReceive('setUri')->once()->with('http://gotenberg/forms/chromium/convert/html');
+        $httpClient->shouldReceive('setMethod')->once();
+        $httpClient->shouldReceive('setFileUpload')
+            ->once()
+            ->with('index.html', 'files', '<html></html>', 'text/html');
+        $httpClient->shouldReceive('setParameterPost')
+            ->once()
+            ->with(m::on(function (array $params): bool {
+                return ($params['preferCssPageSize'] ?? null) === 'true'
+                    && isset($params['paperWidth'], $params['paperHeight']);
+            }));
+        $httpClient->shouldReceive('send')->once()->andReturn($response);
+
+        try {
+            $sut = new GotenbergClient($httpClient, 'http://gotenberg');
+            $sut->convertHtml('<html></html>', $tempFile);
+
+            $this->assertStringEqualsFile($tempFile, '%PDF-1.4 fake');
+        } finally {
+            if (file_exists($tempFile)) {
+                unlink($tempFile);
+            }
+        }
+    }
+}

--- a/app/api/test/module/Api/src/Service/Document/Bookmark/CaseworkerNameTest.php
+++ b/app/api/test/module/Api/src/Service/Document/Bookmark/CaseworkerNameTest.php
@@ -40,4 +40,31 @@ class CaseworkerNameTest extends \PHPUnit\Framework\TestCase
             $bookmark->render()
         );
     }
+
+    public function testRenderFallbackIsLogged(): void
+    {
+        // This bookmark is shared with legacy RTF docgen, which used to fail loudly
+        // on missing person data — the graceful fallback must at least be visible.
+        $spyLogger = new class extends \Psr\Log\AbstractLogger {
+            public array $records = [];
+
+            public function log($level, $message, array $context = []): void
+            {
+                $this->records[] = [$level, (string) $message];
+            }
+        };
+        \Olcs\Logging\Log\Logger::setLogger($spyLogger);
+
+        try {
+            $bookmark = new CaseworkerName();
+            $bookmark->setData([]);
+
+            $this->assertEquals('Caseworker', $bookmark->render());
+            $this->assertNotEmpty(
+                array_filter($spyLogger->records, static fn($r) => $r[0] === 'warning')
+            );
+        } finally {
+            \Olcs\Logging\Log\Logger::setLogger(new \Psr\Log\NullLogger());
+        }
+    }
 }

--- a/app/api/test/module/Api/src/Service/EditorJs/ConverterServiceTest.php
+++ b/app/api/test/module/Api/src/Service/EditorJs/ConverterServiceTest.php
@@ -44,6 +44,81 @@ class ConverterServiceTest extends TestCase
         $this->assertStringContainsString('Test content', $result);
     }
 
+    public function testConvertJsonToHtmlKeepsDataUriImages(): void
+    {
+        $json = json_encode([
+            'time' => 1234567890,
+            'version' => '2.28.2',
+            'blocks' => [
+                [
+                    'id' => 'logo-block',
+                    'type' => 'paragraph',
+                    'data' => [
+                        // Genuine 1x1 PNG: the purifier's data-scheme handler verifies the
+                        // payload decodes to a real image, so a truncated string would be dropped.
+                        'text' => '<img src="data:image/png;base64,'
+                            . 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
+                            . '" alt="OTC logo">'
+                    ]
+                ]
+            ]
+        ]);
+
+        $result = $this->sut->convertJsonToHtml($json);
+
+        $this->assertStringContainsString('<img', $result);
+        $this->assertStringContainsString('data:image/png;base64', $result);
+    }
+
+    public function testNormalizeFillsMissingEnvelopeFields(): void
+    {
+        // Shape produced by hand-authored seeds: no top-level time, no per-block ids —
+        // both mandatory for the Setono parser.
+        $data = [
+            'version' => '2.28.2',
+            'blocks' => [
+                ['type' => 'paragraph', 'data' => ['text' => 'Office of the Traffic Commissioner']],
+                ['type' => 'paragraph', 'data' => ['text' => 'Leeds']],
+            ],
+        ];
+
+        $normalized = $this->sut->normalize($data);
+
+        $this->assertIsInt($normalized['time']);
+        $this->assertSame('2.28.2', $normalized['version']);
+        foreach ($normalized['blocks'] as $i => $block) {
+            $this->assertNotSame('', (string) $block['id'], "block $i id should be non-empty");
+            $this->assertSame($data['blocks'][$i]['data'], $block['data']);
+        }
+    }
+
+    public function testNormalizeLeavesConformantDataUntouched(): void
+    {
+        $data = [
+            'time' => 1234567890,
+            'version' => '2.31.0',
+            'blocks' => [
+                ['id' => 'abc123', 'type' => 'paragraph', 'data' => ['text' => 'Hello']],
+            ],
+        ];
+
+        $this->assertSame($data, $this->sut->normalize($data));
+    }
+
+    public function testNormalizedSeedShapeConverts(): void
+    {
+        $seedShaped = [
+            'version' => '2.28.2',
+            'blocks' => [
+                ['type' => 'paragraph', 'data' => ['text' => 'Quarry House']],
+            ],
+        ];
+
+        $html = $this->sut->convertJsonToHtml(json_encode($this->sut->normalize($seedShaped)));
+
+        $this->assertStringContainsString('Quarry House', $html);
+    }
+
     public function testConvertJsonToHtmlWithInvalidJson(): void
     {
         $this->expectException(\RuntimeException::class);

--- a/app/api/test/module/Api/src/Service/EditorJs/ConverterServiceTest.php
+++ b/app/api/test/module/Api/src/Service/EditorJs/ConverterServiceTest.php
@@ -44,9 +44,13 @@ class ConverterServiceTest extends TestCase
         $this->assertStringContainsString('Test content', $result);
     }
 
-    public function testConvertJsonToHtmlKeepsDataUriImages(): void
+    /**
+     * Genuine 1x1 PNG: the purifier's data-scheme handler verifies the payload
+     * decodes to a real image, so a truncated string would be dropped.
+     */
+    private function dataUriImageJson(): string
     {
-        $json = json_encode([
+        return json_encode([
             'time' => 1234567890,
             'version' => '2.28.2',
             'blocks' => [
@@ -54,8 +58,6 @@ class ConverterServiceTest extends TestCase
                     'id' => 'logo-block',
                     'type' => 'paragraph',
                     'data' => [
-                        // Genuine 1x1 PNG: the purifier's data-scheme handler verifies the
-                        // payload decodes to a real image, so a truncated string would be dropped.
                         'text' => '<img src="data:image/png;base64,'
                             . 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
                             . '" alt="OTC logo">'
@@ -63,11 +65,24 @@ class ConverterServiceTest extends TestCase
                 ]
             ]
         ]);
+    }
 
-        $result = $this->sut->convertJsonToHtml($json);
+    public function testConvertJsonToHtmlKeepsDataUriImagesWhenInlineImagesAllowed(): void
+    {
+        // Chrome slots (admin-authored) embed the OTC logo as an inline base64 image.
+        $result = $this->sut->convertJsonToHtml($this->dataUriImageJson(), true);
 
         $this->assertStringContainsString('<img', $result);
         $this->assertStringContainsString('data:image/png;base64', $result);
+    }
+
+    public function testConvertJsonToHtmlStripsDataUriImagesByDefault(): void
+    {
+        // Caseworker-editable content (sections/issues/todos) must NOT gain the
+        // ability to smuggle arbitrary inline images into official letters.
+        $result = $this->sut->convertJsonToHtml($this->dataUriImageJson());
+
+        $this->assertStringNotContainsString('data:image', $result);
     }
 
     public function testNormalizeFillsMissingEnvelopeFields(): void

--- a/app/api/test/module/Api/src/Service/Letter/LetterPreviewServiceTest.php
+++ b/app/api/test/module/Api/src/Service/Letter/LetterPreviewServiceTest.php
@@ -1026,6 +1026,189 @@ class LetterPreviewServiceTest extends MockeryTestCase
         $this->assertStringContainsString('<div class="letter-content">', $result);
     }
 
+    public function testRenderPreviewToleratesSeedShapedSlotJson(): void
+    {
+        // The 7.6.0 ETL seed wrote chrome slots without the top-level 'time' and per-block
+        // 'id' fields the EditorJS parser mandates. Rendering must normalise rather than 500.
+        $sut = new LetterPreviewService(
+            $this->mockRendererManager,
+            $this->mockContentStore,
+            $this->mockDocTemplateRepo,
+            $this->mockVolGrabReplacementService,
+            new \Dvsa\Olcs\Api\Service\EditorJs\ConverterService()
+        );
+
+        $this->mockVolGrabReplacementService->shouldReceive('replaceGrabs')
+            ->withAnyArgs()
+            ->andReturnUsing(fn($json, $context) => $json);
+
+        $mockRenderer = m::mock(SectionRendererInterface::class);
+        $mockRenderer->shouldReceive('render')->withAnyArgs()->andReturn('')->byDefault();
+        $this->mockRendererManager->shouldReceive('get')
+            ->with(m::type('string'))
+            ->andReturn($mockRenderer)
+            ->byDefault();
+
+        $mockLetterInstance = m::mock(LetterInstance::class);
+        $mockLetterInstance->shouldReceive('getLetterInstanceSections')->andReturn(new ArrayCollection());
+        $mockLetterInstance->shouldReceive('getLetterInstanceTodos')->andReturn(new ArrayCollection());
+        $mockLetterInstance->shouldReceive('getLetterInstanceIssues')->andReturn(new ArrayCollection());
+        $mockLetterInstance->shouldReceive('getLetterInstanceAppendices')->andReturn(new ArrayCollection());
+        $mockLetterInstance->shouldReceive('getReference')->andReturn('REF123');
+        $mockLetterInstance->shouldReceive('getCreatedBy')->andReturn(null);
+        $mockLetterInstance->shouldReceive('getApplication')->andReturn(null);
+        $mockLetterInstance->shouldReceive('getLicence')->andReturn(null);
+        $mockLetterInstance->shouldReceive('getOrganisation')->andReturn(null);
+        $mockLetterInstance->shouldReceive('getCase')->andReturn(null);
+        $mockLetterInstance->shouldReceive('getBusReg')->andReturn(null);
+
+        $mockTemplate = m::mock(MasterTemplate::class);
+        $mockTemplate->shouldReceive('getHeaderLeftContent')->andReturn(null);
+        $mockTemplate->shouldReceive('getHeaderRightContent')->andReturn([
+            // seed shape: no 'time', blocks without 'id'
+            'version' => '2.28.2',
+            'blocks' => [
+                ['type' => 'paragraph', 'data' => ['text' => 'Office of the Traffic Commissioner']],
+            ],
+        ]);
+        $mockTemplate->shouldReceive('getSignoffContent')->andReturn(null);
+        $mockTemplate->shouldReceive('getFooterContent')->andReturn(null);
+        $mockTemplate->shouldReceive('getTemplateContent')->andReturn('{{HEADER_RIGHT_CONTENT}}');
+
+        $result = $sut->renderPreview($mockLetterInstance, $mockTemplate);
+
+        $this->assertStringContainsString('Office of the Traffic Commissioner', $result);
+    }
+
+    public function testOtcLogoFallsBackToLegacySlugWhenRegionSlugMissing(): void
+    {
+        $sut = $this->createSutWithRealConverter();
+
+        // 1x1 transparent PNG — the purifier verifies data-URI payloads are real images.
+        $pngBinary = base64_decode(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
+        );
+
+        $mockDocument = m::mock();
+        $mockDocument->shouldReceive('getIdentifier')->andReturn('templates/Image/OTClogo.png');
+
+        $mockDocTemplate = m::mock();
+        $mockDocTemplate->shouldReceive('getDocument')->andReturn($mockDocument);
+
+        $this->mockDocTemplateRepo->shouldReceive('fetchByTemplateSlug')
+            ->with('otclogo-letters-gb')
+            ->andReturn(null);
+        $this->mockDocTemplateRepo->shouldReceive('fetchByTemplateSlug')
+            ->with('otclogo-letters')
+            ->andReturn($mockDocTemplate);
+
+        $mockFile = m::mock();
+        $mockFile->shouldReceive('getContent')->andReturn($pngBinary);
+        $this->mockContentStore->shouldReceive('read')
+            ->with('templates/Image/OTClogo.png')
+            ->andReturn($mockFile);
+
+        $result = $sut->renderPreview(
+            $this->createMinimalLetterInstance(),
+            $this->createChromeTemplate(['[[OTC_LOGO]]'], '{{HEADER_LEFT_CONTENT}}')
+        );
+
+        $this->assertStringContainsString('data:image/png;base64', $result);
+    }
+
+    public function testOtcLogoResolutionFailureIsLoggedNotFatal(): void
+    {
+        $spyLogger = m::mock(\Psr\Log\LoggerInterface::class);
+        $spyLogger->shouldReceive('warning')->atLeast()->once();
+        \Olcs\Logging\Log\Logger::setLogger($spyLogger);
+
+        try {
+            $sut = $this->createSutWithRealConverter();
+
+            $this->mockDocTemplateRepo->shouldReceive('fetchByTemplateSlug')
+                ->with('otclogo-letters-gb')
+                ->andThrow(new \RuntimeException('doc store down'));
+            $this->mockDocTemplateRepo->shouldReceive('fetchByTemplateSlug')
+                ->with('otclogo-letters')
+                ->andReturn(null);
+
+            $result = $sut->renderPreview(
+                $this->createMinimalLetterInstance(),
+                $this->createChromeTemplate(['[[OTC_LOGO]]'], '{{HEADER_LEFT_CONTENT}}')
+            );
+
+            // Letter still renders, token stripped rather than leaked
+            $this->assertStringNotContainsString('[[OTC_LOGO]]', $result);
+        } finally {
+            \Olcs\Logging\Log\Logger::setLogger(new \Psr\Log\NullLogger());
+        }
+    }
+
+    private function createSutWithRealConverter(): LetterPreviewService
+    {
+        $this->mockVolGrabReplacementService->shouldReceive('replaceGrabs')
+            ->withAnyArgs()
+            ->andReturnUsing(fn($json, $context) => $json)
+            ->byDefault();
+
+        $mockRenderer = m::mock(SectionRendererInterface::class);
+        $mockRenderer->shouldReceive('render')->withAnyArgs()->andReturn('')->byDefault();
+        $this->mockRendererManager->shouldReceive('get')
+            ->with(m::type('string'))
+            ->andReturn($mockRenderer)
+            ->byDefault();
+
+        return new LetterPreviewService(
+            $this->mockRendererManager,
+            $this->mockContentStore,
+            $this->mockDocTemplateRepo,
+            $this->mockVolGrabReplacementService,
+            new \Dvsa\Olcs\Api\Service\EditorJs\ConverterService()
+        );
+    }
+
+    private function createMinimalLetterInstance(): m\MockInterface
+    {
+        $mockLetterInstance = m::mock(LetterInstance::class);
+        $mockLetterInstance->shouldReceive('getLetterInstanceSections')->andReturn(new ArrayCollection());
+        $mockLetterInstance->shouldReceive('getLetterInstanceTodos')->andReturn(new ArrayCollection());
+        $mockLetterInstance->shouldReceive('getLetterInstanceIssues')->andReturn(new ArrayCollection());
+        $mockLetterInstance->shouldReceive('getLetterInstanceAppendices')->andReturn(new ArrayCollection());
+        $mockLetterInstance->shouldReceive('getReference')->andReturn('REF123');
+        $mockLetterInstance->shouldReceive('getCreatedBy')->andReturn(null);
+        $mockLetterInstance->shouldReceive('getApplication')->andReturn(null);
+        $mockLetterInstance->shouldReceive('getLicence')->andReturn(null);
+        $mockLetterInstance->shouldReceive('getOrganisation')->andReturn(null);
+        $mockLetterInstance->shouldReceive('getCase')->andReturn(null);
+        $mockLetterInstance->shouldReceive('getBusReg')->andReturn(null);
+
+        return $mockLetterInstance;
+    }
+
+    /**
+     * @param string[] $headerLeftParagraphs
+     */
+    private function createChromeTemplate(array $headerLeftParagraphs, string $templateContent): m\MockInterface
+    {
+        $blocks = [];
+        foreach ($headerLeftParagraphs as $i => $text) {
+            $blocks[] = ['id' => 'blk-' . $i, 'type' => 'paragraph', 'data' => ['text' => $text]];
+        }
+
+        $mockTemplate = m::mock(MasterTemplate::class);
+        $mockTemplate->shouldReceive('getHeaderLeftContent')->andReturn([
+            'time' => 1234567890,
+            'version' => '2.31.0',
+            'blocks' => $blocks,
+        ]);
+        $mockTemplate->shouldReceive('getHeaderRightContent')->andReturn(null);
+        $mockTemplate->shouldReceive('getSignoffContent')->andReturn(null);
+        $mockTemplate->shouldReceive('getFooterContent')->andReturn(null);
+        $mockTemplate->shouldReceive('getTemplateContent')->andReturn($templateContent);
+
+        return $mockTemplate;
+    }
+
     private function createMockIssue(string $typeName, string $typeDescription, int $typeId): m\MockInterface
     {
         $mockIssueType = m::mock(LetterIssueType::class);

--- a/app/api/test/module/Api/src/Service/Letter/LetterPreviewServiceTest.php
+++ b/app/api/test/module/Api/src/Service/Letter/LetterPreviewServiceTest.php
@@ -165,6 +165,10 @@ class LetterPreviewServiceTest extends MockeryTestCase
 
         $templateContent = '<html>{{LETTER_REFERENCE}} {{SECTIONS_CONTENT}} {{ISSUES_CONTENT}}</html>';
         $mockTemplate = m::mock(MasterTemplate::class);
+        $mockTemplate->shouldReceive('getHeaderLeftContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getHeaderRightContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getSignoffContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getFooterContent')->andReturn(null)->byDefault();
         $mockTemplate->shouldReceive('getTemplateContent')
             ->andReturn($templateContent);
 
@@ -223,6 +227,10 @@ class LetterPreviewServiceTest extends MockeryTestCase
 
         $templateContent = '{{CASEWORKER_NAME}}';
         $mockTemplate = m::mock(MasterTemplate::class);
+        $mockTemplate->shouldReceive('getHeaderLeftContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getHeaderRightContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getSignoffContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getFooterContent')->andReturn(null)->byDefault();
         $mockTemplate->shouldReceive('getTemplateContent')
             ->andReturn($templateContent);
 
@@ -268,6 +276,10 @@ class LetterPreviewServiceTest extends MockeryTestCase
 
         $templateContent = '{{CASEWORKER_NAME}}';
         $mockTemplate = m::mock(MasterTemplate::class);
+        $mockTemplate->shouldReceive('getHeaderLeftContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getHeaderRightContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getSignoffContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getFooterContent')->andReturn(null)->byDefault();
         $mockTemplate->shouldReceive('getTemplateContent')
             ->andReturn($templateContent);
 
@@ -316,6 +328,10 @@ class LetterPreviewServiceTest extends MockeryTestCase
 
         $templateContent = '{{ENTITY_REFERENCE}}';
         $mockTemplate = m::mock(MasterTemplate::class);
+        $mockTemplate->shouldReceive('getHeaderLeftContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getHeaderRightContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getSignoffContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getFooterContent')->andReturn(null)->byDefault();
         $mockTemplate->shouldReceive('getTemplateContent')
             ->andReturn($templateContent);
 
@@ -340,6 +356,7 @@ class LetterPreviewServiceTest extends MockeryTestCase
         $mockOrganisation->shouldReceive('getName')->andReturn('Test Org');
 
         $mockLicence = m::mock(Licence::class);
+        $mockLicence->shouldReceive('isNi')->andReturn(false)->byDefault();
         $mockLicence->shouldReceive('getLicNo')->andReturn('OB1234567');
         $mockLicence->shouldReceive('getId')->andReturn(999);
         $mockLicence->shouldReceive('getOrganisation')->andReturn($mockOrganisation);
@@ -369,6 +386,10 @@ class LetterPreviewServiceTest extends MockeryTestCase
 
         $templateContent = '{{ENTITY_REFERENCE}}';
         $mockTemplate = m::mock(MasterTemplate::class);
+        $mockTemplate->shouldReceive('getHeaderLeftContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getHeaderRightContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getSignoffContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getFooterContent')->andReturn(null)->byDefault();
         $mockTemplate->shouldReceive('getTemplateContent')
             ->andReturn($templateContent);
 
@@ -418,6 +439,10 @@ class LetterPreviewServiceTest extends MockeryTestCase
 
         $templateContent = '{{SALUTATION}}';
         $mockTemplate = m::mock(MasterTemplate::class);
+        $mockTemplate->shouldReceive('getHeaderLeftContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getHeaderRightContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getSignoffContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getFooterContent')->andReturn(null)->byDefault();
         $mockTemplate->shouldReceive('getTemplateContent')
             ->andReturn($templateContent);
 
@@ -442,6 +467,7 @@ class LetterPreviewServiceTest extends MockeryTestCase
         $mockOrganisation->shouldReceive('getName')->andReturn('Licence Org Ltd');
 
         $mockLicence = m::mock(Licence::class);
+        $mockLicence->shouldReceive('isNi')->andReturn(false)->byDefault();
         $mockLicence->shouldReceive('getLicNo')->andReturn('OB123');
         $mockLicence->shouldReceive('getId')->andReturn(1);
         $mockLicence->shouldReceive('getOrganisation')->andReturn($mockOrganisation);
@@ -471,6 +497,10 @@ class LetterPreviewServiceTest extends MockeryTestCase
 
         $templateContent = '{{SALUTATION}}';
         $mockTemplate = m::mock(MasterTemplate::class);
+        $mockTemplate->shouldReceive('getHeaderLeftContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getHeaderRightContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getSignoffContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getFooterContent')->andReturn(null)->byDefault();
         $mockTemplate->shouldReceive('getTemplateContent')
             ->andReturn($templateContent);
 
@@ -516,6 +546,10 @@ class LetterPreviewServiceTest extends MockeryTestCase
 
         $templateContent = '{{SALUTATION}}';
         $mockTemplate = m::mock(MasterTemplate::class);
+        $mockTemplate->shouldReceive('getHeaderLeftContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getHeaderRightContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getSignoffContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getFooterContent')->andReturn(null)->byDefault();
         $mockTemplate->shouldReceive('getTemplateContent')
             ->andReturn($templateContent);
 
@@ -524,7 +558,15 @@ class LetterPreviewServiceTest extends MockeryTestCase
         $this->assertEquals('<p>Dear Sir or Madam,</p>', $result);
     }
 
-    public function testBuildDvsaAddressReturnsStaticAddress(): void
+    /**
+     * VOL-7305: The {{DVSA_ADDRESS}} placeholder used to resolve to a hardcoded
+     * Leeds office address. It now resolves to an empty string — the address lives
+     * in the headerRightContent slot of the matching MasterTemplate row, picked by
+     * MasterTemplateResolver based on the letter's region (GB/NI). This test
+     * preserves the backward-compat guarantee that the token is still recognised
+     * (no leftover {{DVSA_ADDRESS}} text in the output) but produces nothing.
+     */
+    public function testDvsaAddressPlaceholderResolvesToEmptyForBackwardCompat(): void
     {
         $mockSectionRenderer = m::mock(SectionRendererInterface::class);
         $mockIssueRenderer = m::mock(SectionRendererInterface::class);
@@ -559,17 +601,24 @@ class LetterPreviewServiceTest extends MockeryTestCase
         $mockLetterInstance->shouldReceive('getLetterInstanceAppendices')
             ->andReturn(new ArrayCollection());
 
-        $templateContent = '{{DVSA_ADDRESS}}';
+        // Template content is just the legacy placeholder — should resolve to nothing.
+        $templateContent = '[start]{{DVSA_ADDRESS}}[end]';
         $mockTemplate = m::mock(MasterTemplate::class);
+        $mockTemplate->shouldReceive('getHeaderLeftContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getHeaderRightContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getSignoffContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getFooterContent')->andReturn(null)->byDefault();
         $mockTemplate->shouldReceive('getTemplateContent')
             ->andReturn($templateContent);
 
         $result = $this->sut->renderPreview($mockLetterInstance, $mockTemplate);
 
-        $this->assertStringContainsString('The Central Licensing Office', $result);
-        $this->assertStringContainsString('Hillcrest House', $result);
-        $this->assertStringContainsString('Leeds', $result);
-        $this->assertStringContainsString('LS9 6NF', $result);
+        // Token recognised + replaced with empty
+        $this->assertStringNotContainsString('{{DVSA_ADDRESS}}', $result);
+        $this->assertStringContainsString('[start][end]', $result);
+        // None of the old hardcoded literals leak through
+        $this->assertStringNotContainsString('Central Licensing Office', $result);
+        $this->assertStringNotContainsString('Hillcrest House', $result);
     }
 
     public function testRenderIssuesGroupedByType(): void
@@ -619,6 +668,10 @@ class LetterPreviewServiceTest extends MockeryTestCase
         // Issues are rendered via assembly fallback into SECTIONS_CONTENT (no __ISSUES__ meta-section)
         $templateContent = '{{SECTIONS_CONTENT}}';
         $mockTemplate = m::mock(MasterTemplate::class);
+        $mockTemplate->shouldReceive('getHeaderLeftContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getHeaderRightContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getSignoffContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getFooterContent')->andReturn(null)->byDefault();
         $mockTemplate->shouldReceive('getTemplateContent')
             ->andReturn($templateContent);
 
@@ -648,6 +701,7 @@ class LetterPreviewServiceTest extends MockeryTestCase
         $mockSection = $this->createMockSection();
 
         $mockLicence = m::mock(Licence::class);
+        $mockLicence->shouldReceive('isNi')->andReturn(false)->byDefault();
         $mockLicence->shouldReceive('getId')->andReturn(123);
         $mockLicence->shouldReceive('getLicNo')->andReturn('OB123');
         $mockLicence->shouldReceive('getOrganisation')->andReturn(null);
@@ -703,6 +757,7 @@ class LetterPreviewServiceTest extends MockeryTestCase
         $mockSection = $this->createMockSection();
 
         $mockLicence = m::mock(Licence::class);
+        $mockLicence->shouldReceive('isNi')->andReturn(false)->byDefault();
         $mockLicence->shouldReceive('getId')->andReturn(111);
         $mockLicence->shouldReceive('getLicNo')->andReturn('OB111');
         $mockLicence->shouldReceive('getOrganisation')->andReturn(null);
@@ -796,9 +851,9 @@ class LetterPreviewServiceTest extends MockeryTestCase
         $mockLetterInstance->shouldReceive('getLetterInstanceAppendices')
             ->andReturn(new ArrayCollection());
 
-        // Verify context is empty when all entities are null
+        // Context carries isNi=false (default) even when all linked entities are null
         $mockSectionRenderer->shouldReceive('render')
-            ->with($mockSection, [])
+            ->with($mockSection, ['isNi' => false])
             ->once()
             ->andReturn('<div class="section">Content</div>');
 
@@ -822,6 +877,7 @@ class LetterPreviewServiceTest extends MockeryTestCase
         $mockIssue = $this->createMockIssue('Test Type', 'Test Description', 1);
 
         $mockLicence = m::mock(Licence::class);
+        $mockLicence->shouldReceive('isNi')->andReturn(false)->byDefault();
         $mockLicence->shouldReceive('getId')->andReturn(789);
         $mockLicence->shouldReceive('getLicNo')->andReturn('OB789');
         $mockLicence->shouldReceive('getOrganisation')->andReturn(null);
@@ -877,6 +933,7 @@ class LetterPreviewServiceTest extends MockeryTestCase
         $mockSection = $this->createMockSection();
 
         $mockLicence = m::mock(Licence::class);
+        $mockLicence->shouldReceive('isNi')->andReturn(false)->byDefault();
         $mockLicence->shouldReceive('getId')->andReturn(123);
         $mockLicence->shouldReceive('getLicNo')->andReturn('OB123');
         $mockLicence->shouldReceive('getOrganisation')->andReturn(null);
@@ -906,6 +963,10 @@ class LetterPreviewServiceTest extends MockeryTestCase
 
         $templateContent = '<html>{{SECTIONS_CONTENT}} [[TODAYS_DATE]]</html>';
         $mockTemplate = m::mock(MasterTemplate::class);
+        $mockTemplate->shouldReceive('getHeaderLeftContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getHeaderRightContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getSignoffContent')->andReturn(null)->byDefault();
+        $mockTemplate->shouldReceive('getFooterContent')->andReturn(null)->byDefault();
         $mockTemplate->shouldReceive('getTemplateContent')
             ->andReturn($templateContent);
 
@@ -953,10 +1014,11 @@ class LetterPreviewServiceTest extends MockeryTestCase
         $mockLetterInstance->shouldReceive('getLetterInstanceAppendices')
             ->andReturn(new ArrayCollection());
 
-        // Override default mock to verify vol-grab replacement is called even without template
+        // Override default mock to verify vol-grab replacement is called even without template.
+        // Context now always carries isNi (VOL-7305) even when no licence is attached.
         $this->mockVolGrabReplacementService->shouldReceive('replaceGrabsInHtml')
             ->once()
-            ->with(m::type('string'), [])
+            ->with(m::type('string'), ['isNi' => false])
             ->andReturnUsing(fn($html, $context) => $html);
 
         $result = $this->sut->renderPreview($mockLetterInstance, null);

--- a/app/api/test/module/Api/src/Service/Letter/LetterPreviewServiceTest.php
+++ b/app/api/test/module/Api/src/Service/Letter/LetterPreviewServiceTest.php
@@ -1170,10 +1170,10 @@ class LetterPreviewServiceTest extends MockeryTestCase
     private function createMinimalLetterInstance(): m\MockInterface
     {
         $mockLetterInstance = m::mock(LetterInstance::class);
-        $mockLetterInstance->shouldReceive('getLetterInstanceSections')->andReturn(new ArrayCollection());
-        $mockLetterInstance->shouldReceive('getLetterInstanceTodos')->andReturn(new ArrayCollection());
-        $mockLetterInstance->shouldReceive('getLetterInstanceIssues')->andReturn(new ArrayCollection());
-        $mockLetterInstance->shouldReceive('getLetterInstanceAppendices')->andReturn(new ArrayCollection());
+        $mockLetterInstance->shouldReceive('getLetterInstanceSections')->andReturn(new ArrayCollection())->byDefault();
+        $mockLetterInstance->shouldReceive('getLetterInstanceTodos')->andReturn(new ArrayCollection())->byDefault();
+        $mockLetterInstance->shouldReceive('getLetterInstanceIssues')->andReturn(new ArrayCollection())->byDefault();
+        $mockLetterInstance->shouldReceive('getLetterInstanceAppendices')->andReturn(new ArrayCollection())->byDefault();
         $mockLetterInstance->shouldReceive('getReference')->andReturn('REF123');
         $mockLetterInstance->shouldReceive('getCreatedBy')->andReturn(null);
         $mockLetterInstance->shouldReceive('getApplication')->andReturn(null);
@@ -1207,6 +1207,37 @@ class LetterPreviewServiceTest extends MockeryTestCase
         $mockTemplate->shouldReceive('getTemplateContent')->andReturn($templateContent);
 
         return $mockTemplate;
+    }
+
+    public function testTodosRenderInBlockContainerNotList(): void
+    {
+        // VOL-7280: the to-do group must not be a <ul> — each to-do is a block,
+        // so bullets inside a to-do's own content stay top-level and solid.
+        $mockIssueRenderer = m::mock(SectionRendererInterface::class);
+        $mockIssueRenderer->shouldReceive('render')->andReturn('<div class="issue">Issue body</div>');
+        $mockTodoRenderer = m::mock(SectionRendererInterface::class);
+        $mockTodoRenderer->shouldReceive('render')->andReturn('<div class="todo-item">Upload statements</div>');
+
+        $this->mockRendererManager->shouldReceive('get')->with('issue')->andReturn($mockIssueRenderer);
+        $this->mockRendererManager->shouldReceive('get')->with('todo')->andReturn($mockTodoRenderer);
+        $this->mockRendererManager->shouldReceive('get')->with('content-section')->andReturn($mockIssueRenderer)->byDefault();
+
+        $mockIssue = $this->createMockIssue('Adverts', 'Advert issues with your application', 1);
+
+        $mockTodo = m::mock(\Dvsa\Olcs\Api\Entity\Letter\LetterInstanceTodo::class);
+        $mockTodo->shouldReceive('getLetterInstanceIssue')->andReturn($mockIssue);
+
+        $mockLetterInstance = $this->createMinimalLetterInstance();
+        $mockLetterInstance->shouldReceive('getLetterInstanceIssues')
+            ->andReturn(new ArrayCollection([$mockIssue]));
+        $mockLetterInstance->shouldReceive('getLetterInstanceTodos')
+            ->andReturn(new ArrayCollection([$mockTodo]));
+
+        $result = $this->sut->renderPreview($mockLetterInstance, null);
+
+        $this->assertStringContainsString('<div class="todo-list">', $result);
+        $this->assertStringNotContainsString('<ul class="todo-list">', $result);
+        $this->assertStringContainsString('What you need to do', $result);
     }
 
     private function createMockIssue(string $typeName, string $typeDescription, int $typeId): m\MockInterface

--- a/app/api/test/module/Api/src/Service/Letter/LetterPreviewServiceTest.php
+++ b/app/api/test/module/Api/src/Service/Letter/LetterPreviewServiceTest.php
@@ -1185,6 +1185,40 @@ class LetterPreviewServiceTest extends MockeryTestCase
         }
     }
 
+    public function testSlotWithUnsupportedBlockTypeRendersEmptyNotFatal(): void
+    {
+        // The Setono renderer only supports paragraph/header/list; an 'image' or
+        // 'table' block in a seeded/imported slot must degrade to an empty slot,
+        // not 500 the whole letter.
+        $spyLogger = m::mock(\Psr\Log\LoggerInterface::class);
+        $spyLogger->shouldReceive('warning')->atLeast()->once();
+        \Olcs\Logging\Log\Logger::setLogger($spyLogger);
+
+        try {
+            $sut = $this->createSutWithRealConverter();
+
+            $mockTemplate = m::mock(MasterTemplate::class);
+            $mockTemplate->shouldReceive('getHeaderLeftContent')->andReturn([
+                'time' => 1234567890,
+                'version' => '2.31.0',
+                'blocks' => [
+                    ['id' => 'x1', 'type' => 'image', 'data' => ['url' => 'http://example.com/x.png']],
+                ],
+            ]);
+            $mockTemplate->shouldReceive('getHeaderRightContent')->andReturn(null);
+            $mockTemplate->shouldReceive('getSignoffContent')->andReturn(null);
+            $mockTemplate->shouldReceive('getFooterContent')->andReturn(null);
+            $mockTemplate->shouldReceive('getTemplateContent')
+                ->andReturn('BEFORE[{{HEADER_LEFT_CONTENT}}]AFTER');
+
+            $result = $sut->renderPreview($this->createMinimalLetterInstance(), $mockTemplate);
+
+            $this->assertStringContainsString('BEFORE[]AFTER', $result);
+        } finally {
+            \Olcs\Logging\Log\Logger::setLogger(new \Psr\Log\NullLogger());
+        }
+    }
+
     public function testOtcLogoResolutionFailureIsLoggedNotFatal(): void
     {
         $spyLogger = m::mock(\Psr\Log\LoggerInterface::class);

--- a/app/api/test/module/Api/src/Service/Letter/LetterPreviewServiceTest.php
+++ b/app/api/test/module/Api/src/Service/Letter/LetterPreviewServiceTest.php
@@ -1116,6 +1116,75 @@ class LetterPreviewServiceTest extends MockeryTestCase
         $this->assertStringContainsString('data:image/png;base64', $result);
     }
 
+    public function testOtcLogoMissingFileRendersWithoutLogoNotFatal(): void
+    {
+        // ContentStore::read() returns File|false — a missing file must degrade to a
+        // logo-less letter, not fatal with 'getContent() on bool'.
+        $spyLogger = m::mock(\Psr\Log\LoggerInterface::class);
+        $spyLogger->shouldReceive('warning')->atLeast()->once();
+        \Olcs\Logging\Log\Logger::setLogger($spyLogger);
+
+        try {
+            $sut = $this->createSutWithRealConverter();
+
+            $mockDocument = m::mock();
+            $mockDocument->shouldReceive('getIdentifier')->andReturn('templates/Image/OTClogo.png');
+            $mockDocTemplate = m::mock();
+            $mockDocTemplate->shouldReceive('getDocument')->andReturn($mockDocument);
+
+            $this->mockDocTemplateRepo->shouldReceive('fetchByTemplateSlug')
+                ->andReturn($mockDocTemplate);
+            $this->mockContentStore->shouldReceive('read')
+                ->with('templates/Image/OTClogo.png')
+                ->andReturn(false);
+
+            $result = $sut->renderPreview(
+                $this->createMinimalLetterInstance(),
+                $this->createChromeTemplate(['[[OTC_LOGO]]'], '{{HEADER_LEFT_CONTENT}}')
+            );
+
+            $this->assertStringNotContainsString('[[OTC_LOGO]]', $result);
+            $this->assertStringNotContainsString('data:image', $result);
+        } finally {
+            \Olcs\Logging\Log\Logger::setLogger(new \Psr\Log\NullLogger());
+        }
+    }
+
+    public function testOtcLogoNonImagePayloadRendersWithoutLogo(): void
+    {
+        // A stored logo the purifier would reject (SVG/WebP/corrupt) must degrade
+        // visibly here, not vanish silently downstream in cleanOutputHtml.
+        $spyLogger = m::mock(\Psr\Log\LoggerInterface::class);
+        $spyLogger->shouldReceive('warning')->atLeast()->once();
+        \Olcs\Logging\Log\Logger::setLogger($spyLogger);
+
+        try {
+            $sut = $this->createSutWithRealConverter();
+
+            $mockDocument = m::mock();
+            $mockDocument->shouldReceive('getIdentifier')->andReturn('templates/Image/OTClogo.svg');
+            $mockDocTemplate = m::mock();
+            $mockDocTemplate->shouldReceive('getDocument')->andReturn($mockDocument);
+
+            $this->mockDocTemplateRepo->shouldReceive('fetchByTemplateSlug')
+                ->andReturn($mockDocTemplate);
+
+            $mockFile = m::mock();
+            $mockFile->shouldReceive('getContent')->andReturn('<svg xmlns="http://www.w3.org/2000/svg"/>');
+            $this->mockContentStore->shouldReceive('read')->andReturn($mockFile);
+
+            $result = $sut->renderPreview(
+                $this->createMinimalLetterInstance(),
+                $this->createChromeTemplate(['[[OTC_LOGO]]'], '{{HEADER_LEFT_CONTENT}}')
+            );
+
+            $this->assertStringNotContainsString('data:', $result);
+            $this->assertStringNotContainsString('[[OTC_LOGO]]', $result);
+        } finally {
+            \Olcs\Logging\Log\Logger::setLogger(new \Psr\Log\NullLogger());
+        }
+    }
+
     public function testOtcLogoResolutionFailureIsLoggedNotFatal(): void
     {
         $spyLogger = m::mock(\Psr\Log\LoggerInterface::class);

--- a/app/api/test/module/Api/src/Service/Letter/MasterTemplateResolverTest.php
+++ b/app/api/test/module/Api/src/Service/Letter/MasterTemplateResolverTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dvsa\OlcsTest\Api\Service\Letter;
+
+use Dvsa\Olcs\Api\Domain\Repository\MasterTemplate as MasterTemplateRepo;
+use Dvsa\Olcs\Api\Entity\Letter\LetterInstance;
+use Dvsa\Olcs\Api\Entity\Letter\LetterType;
+use Dvsa\Olcs\Api\Entity\Letter\MasterTemplate;
+use Dvsa\Olcs\Api\Entity\Licence\Licence;
+use Dvsa\Olcs\Api\Service\Letter\MasterTemplateResolver;
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+/**
+ * VOL-7305: MasterTemplateResolver picks the right MasterTemplate row for the
+ * letter's region (isNi), falling back to the LetterType's base template if no
+ * matching sibling exists.
+ */
+#[\PHPUnit\Framework\Attributes\CoversClass(MasterTemplateResolver::class)]
+class MasterTemplateResolverTest extends MockeryTestCase
+{
+    private m\MockInterface|MasterTemplateRepo $mockRepo;
+    private MasterTemplateResolver $sut;
+
+    protected function setUp(): void
+    {
+        $this->mockRepo = m::mock(MasterTemplateRepo::class);
+        $this->sut = new MasterTemplateResolver($this->mockRepo);
+    }
+
+    public function testReturnsNullIfLetterTypeHasNoMasterTemplate(): void
+    {
+        $letterType = m::mock(LetterType::class);
+        $letterType->shouldReceive('getMasterTemplate')->andReturn(null);
+
+        $letter = $this->makeLetter($letterType, isNi: false);
+
+        $this->assertNull($this->sut->resolve($letter));
+    }
+
+    public function testReturnsLetterTypeBaseWhenItAlreadyMatchesPreferredLocaleGb(): void
+    {
+        $base = $this->makeMasterTemplate('OTC Letter Chrome', MasterTemplate::LOCALE_EN_GB);
+        $letterType = $this->makeLetterType($base);
+        $letter = $this->makeLetter($letterType, isNi: false);
+
+        // Already matches en_GB — no repo lookup needed
+        $this->mockRepo->shouldNotReceive('findByNameAndLocale');
+
+        $this->assertSame($base, $this->sut->resolve($letter));
+    }
+
+    public function testPivotsToNiSiblingWhenLicenceIsNi(): void
+    {
+        $base = $this->makeMasterTemplate('OTC Letter Chrome', MasterTemplate::LOCALE_EN_GB);
+        $niSibling = $this->makeMasterTemplate('OTC Letter Chrome', MasterTemplate::LOCALE_EN_NI);
+
+        $letterType = $this->makeLetterType($base);
+        $letter = $this->makeLetter($letterType, isNi: true);
+
+        $this->mockRepo->shouldReceive('findByNameAndLocale')
+            ->with('OTC Letter Chrome', MasterTemplate::LOCALE_EN_NI)
+            ->once()
+            ->andReturn($niSibling);
+
+        $this->assertSame($niSibling, $this->sut->resolve($letter));
+    }
+
+    public function testFallsBackToLetterTypeBaseWhenNoSiblingMatches(): void
+    {
+        $base = $this->makeMasterTemplate('OTC Letter Chrome', MasterTemplate::LOCALE_EN_GB);
+        $letterType = $this->makeLetterType($base);
+
+        // NI letter, but no en_NI sibling exists — should fall back to the base
+        $letter = $this->makeLetter($letterType, isNi: true);
+
+        $this->mockRepo->shouldReceive('findByNameAndLocale')
+            ->with('OTC Letter Chrome', MasterTemplate::LOCALE_EN_NI)
+            ->once()
+            ->andReturn(null);
+
+        $this->assertSame($base, $this->sut->resolve($letter));
+    }
+
+    public function testTreatsMissingLicenceAsGb(): void
+    {
+        $base = $this->makeMasterTemplate('OTC Letter Chrome', MasterTemplate::LOCALE_EN_GB);
+        $letterType = $this->makeLetterType($base);
+
+        // No licence at all — defaults to GB (isNi false)
+        $letter = m::mock(LetterInstance::class);
+        $letter->shouldReceive('getLetterType')->andReturn($letterType);
+        $letter->shouldReceive('getLicence')->andReturn(null);
+
+        $this->mockRepo->shouldNotReceive('findByNameAndLocale');
+
+        $this->assertSame($base, $this->sut->resolve($letter));
+    }
+
+    // ----- helpers -----
+
+    private function makeMasterTemplate(string $name, string $locale): MasterTemplate
+    {
+        $mt = new MasterTemplate();
+        $mt->setName($name);
+        $mt->setLocale($locale);
+        return $mt;
+    }
+
+    private function makeLetterType(?MasterTemplate $base): m\MockInterface
+    {
+        $letterType = m::mock(LetterType::class);
+        $letterType->shouldReceive('getMasterTemplate')->andReturn($base);
+        return $letterType;
+    }
+
+    private function makeLetter(m\MockInterface $letterType, bool $isNi): m\MockInterface
+    {
+        $licence = m::mock(Licence::class);
+        $licence->shouldReceive('isNi')->andReturn($isNi);
+
+        $letter = m::mock(LetterInstance::class);
+        $letter->shouldReceive('getLetterType')->andReturn($letterType);
+        $letter->shouldReceive('getLicence')->andReturn($licence);
+        return $letter;
+    }
+}

--- a/app/api/test/module/Api/src/Service/Letter/MasterTemplateResolverTest.php
+++ b/app/api/test/module/Api/src/Service/Letter/MasterTemplateResolverTest.php
@@ -30,14 +30,52 @@ class MasterTemplateResolverTest extends MockeryTestCase
         $this->sut = new MasterTemplateResolver($this->mockRepo);
     }
 
-    public function testReturnsNullIfLetterTypeHasNoMasterTemplate(): void
+    public function testReturnsNullWhenNoTemplateAndNoDefaultExists(): void
     {
         $letterType = m::mock(LetterType::class);
         $letterType->shouldReceive('getMasterTemplate')->andReturn(null);
 
+        $this->mockRepo->shouldReceive('fetchDefault')->once()->andReturn(null);
+
         $letter = $this->makeLetter($letterType, isNi: false);
 
         $this->assertNull($this->sut->resolve($letter));
+    }
+
+    public function testFallsBackToDefaultTemplateWhenLetterTypeHasNone(): void
+    {
+        // Parity with pre-VOL-7305 behaviour: letter types without a linked master
+        // template must still render with the default chrome, not bare.
+        $default = $this->makeMasterTemplate('Default Letter Template', MasterTemplate::LOCALE_EN_GB);
+
+        $letterType = m::mock(LetterType::class);
+        $letterType->shouldReceive('getMasterTemplate')->andReturn(null);
+
+        $this->mockRepo->shouldReceive('fetchDefault')->once()->andReturn($default);
+        $this->mockRepo->shouldNotReceive('findByNameAndLocale');
+
+        $letter = $this->makeLetter($letterType, isNi: false);
+
+        $this->assertSame($default, $this->sut->resolve($letter));
+    }
+
+    public function testFallbackDefaultStillPivotsToNiSibling(): void
+    {
+        $default = $this->makeMasterTemplate('Default Letter Template', MasterTemplate::LOCALE_EN_GB);
+        $niSibling = $this->makeMasterTemplate('Default Letter Template', MasterTemplate::LOCALE_EN_NI);
+
+        $letterType = m::mock(LetterType::class);
+        $letterType->shouldReceive('getMasterTemplate')->andReturn(null);
+
+        $this->mockRepo->shouldReceive('fetchDefault')->once()->andReturn($default);
+        $this->mockRepo->shouldReceive('findByNameAndLocale')
+            ->with('Default Letter Template', MasterTemplate::LOCALE_EN_NI)
+            ->once()
+            ->andReturn($niSibling);
+
+        $letter = $this->makeLetter($letterType, isNi: true);
+
+        $this->assertSame($niSibling, $this->sut->resolve($letter));
     }
 
     public function testReturnsLetterTypeBaseWhenItAlreadyMatchesPreferredLocaleGb(): void

--- a/app/api/test/module/Api/src/Service/Letter/SectionRenderer/TodoSectionRendererTest.php
+++ b/app/api/test/module/Api/src/Service/Letter/SectionRenderer/TodoSectionRendererTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dvsa\OlcsTest\Api\Service\Letter\SectionRenderer;
+
+use Dvsa\Olcs\Api\Entity\Letter\LetterInstanceTodo;
+use Dvsa\Olcs\Api\Entity\Letter\LetterTodoVersion;
+use Dvsa\Olcs\Api\Service\EditorJs\ConverterService;
+use Dvsa\Olcs\Api\Service\Letter\SectionRenderer\TodoSectionRenderer;
+use Dvsa\Olcs\Api\Service\Letter\VolGrabReplacementService;
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+#[\PHPUnit\Framework\Attributes\CoversClass(\Dvsa\Olcs\Api\Service\Letter\SectionRenderer\TodoSectionRenderer::class)]
+class TodoSectionRendererTest extends MockeryTestCase
+{
+    private TodoSectionRenderer $sut;
+    private m\MockInterface|ConverterService $mockConverterService;
+    private m\MockInterface|VolGrabReplacementService $mockVolGrabService;
+
+    public function setUp(): void
+    {
+        $this->mockConverterService = m::mock(ConverterService::class);
+        $this->mockVolGrabService = m::mock(VolGrabReplacementService::class);
+        $this->sut = new TodoSectionRenderer($this->mockConverterService, $this->mockVolGrabService);
+    }
+
+    public function testRenderOutputsBlockNotListItem(): void
+    {
+        // VOL-7280: a to-do rendered as <li> makes the whole to-do a bullet and
+        // demotes bullets inside its own content to hollow second-level ones.
+        $description = [
+            'blocks' => [
+                ['type' => 'paragraph', 'data' => ['text' => 'Upload bank statements']],
+            ],
+        ];
+
+        $mockVersion = m::mock(LetterTodoVersion::class);
+        $mockVersion->shouldReceive('getDescription')->andReturn($description);
+
+        $mockTodo = m::mock(LetterInstanceTodo::class);
+        $mockTodo->shouldReceive('getLetterTodoVersion')->andReturn($mockVersion);
+
+        $this->mockVolGrabService->shouldReceive('replaceGrabs')
+            ->andReturnUsing(fn($json, $context) => $json);
+        $this->mockConverterService->shouldReceive('convertJsonToHtml')
+            ->andReturn('<p>Upload bank statements</p><ul><li>in the name of the operator</li></ul>');
+
+        $html = $this->sut->render($mockTodo);
+
+        $this->assertStringContainsString('<div class="todo-item">', $html);
+        $this->assertStringNotContainsString('<li class="todo-item">', $html);
+    }
+
+    public function testRenderEmptyDescriptionReturnsEmptyString(): void
+    {
+        $mockVersion = m::mock(LetterTodoVersion::class);
+        $mockVersion->shouldReceive('getDescription')->andReturn(null);
+
+        $mockTodo = m::mock(LetterInstanceTodo::class);
+        $mockTodo->shouldReceive('getLetterTodoVersion')->andReturn($mockVersion);
+
+        $this->assertSame('', $this->sut->render($mockTodo));
+    }
+}

--- a/app/api/test/module/Api/src/Service/Letter/VolGrabReplacementServiceTest.php
+++ b/app/api/test/module/Api/src/Service/Letter/VolGrabReplacementServiceTest.php
@@ -179,8 +179,8 @@ class VolGrabReplacementServiceTest extends MockeryTestCase
         $result = $this->service->replaceGrabs($json, []);
         $decoded = json_decode($result, true);
 
-        // Unknown token should remain in place
-        $this->assertStringContainsString('[[UNKNOWN_TOKEN]]', $decoded['blocks'][0]['data']['text']);
+        // Unresolvable token is stripped so it can't leak into a sent letter
+        $this->assertStringNotContainsString('UNKNOWN_TOKEN', $decoded['blocks'][0]['data']['text']);
     }
 
     public function testReplaceGrabsHandlesQueryExecutionException(): void
@@ -215,8 +215,8 @@ class VolGrabReplacementServiceTest extends MockeryTestCase
         $result = $this->service->replaceGrabs($json, ['licence' => 999]);
         $decoded = json_decode($result, true);
 
-        // Token should remain since query failed
-        $this->assertStringContainsString('[[OP_NAME]]', $decoded['blocks'][0]['data']['text']);
+        // Failed-query token is stripped so it can't leak into a sent letter
+        $this->assertStringNotContainsString('OP_NAME', $decoded['blocks'][0]['data']['text']);
     }
 
     public function testReplaceGrabsHandlesRenderException(): void
@@ -243,8 +243,8 @@ class VolGrabReplacementServiceTest extends MockeryTestCase
         $result = $this->service->replaceGrabs($json, []);
         $decoded = json_decode($result, true);
 
-        // Token should remain since rendering failed
-        $this->assertStringContainsString('[[TEST_TOKEN]]', $decoded['blocks'][0]['data']['text']);
+        // Failed-render token is stripped so it can't leak into a sent letter
+        $this->assertStringNotContainsString('TEST_TOKEN', $decoded['blocks'][0]['data']['text']);
     }
 
     public function testReplaceGrabsHandlesTopLevelException(): void
@@ -287,9 +287,9 @@ class VolGrabReplacementServiceTest extends MockeryTestCase
         $result = $this->service->replaceGrabs($json, []);
         $decoded = json_decode($result, true);
 
-        // Good token replaced, bad token remains
+        // Good token replaced, unresolvable token stripped
         $this->assertStringContainsString('SUCCESS', $decoded['blocks'][0]['data']['text']);
-        $this->assertStringContainsString('[[BAD_TOKEN]]', $decoded['blocks'][0]['data']['text']);
+        $this->assertStringNotContainsString('BAD_TOKEN', $decoded['blocks'][0]['data']['text']);
     }
 
     public function testReplaceGrabsSkipsStaticBookmarksInQueryExecution(): void
@@ -420,7 +420,8 @@ class VolGrabReplacementServiceTest extends MockeryTestCase
 
         $result = $this->service->replaceGrabsInHtml($html, []);
 
-        $this->assertStringContainsString('[[UNKNOWN_TOKEN]]', $result);
+        // Unresolvable token is stripped so it can't leak into a sent letter
+        $this->assertStringNotContainsString('UNKNOWN_TOKEN', $result);
     }
 
     public function testReplaceGrabsInHtmlHandlesMultipleTokens(): void
@@ -506,5 +507,39 @@ class VolGrabReplacementServiceTest extends MockeryTestCase
         $result = $this->service->replaceGrabsInHtml($html, []);
 
         $this->assertStringContainsString('Line 1<br>' . "\n" . 'Line 2<br>' . "\n" . 'Line 3', $result);
+    }
+
+    public function testReplaceGrabsStripsUnresolvableTokensInsteadOfLeakingThem(): void
+    {
+        // A token no bookmark can serve (unknown class, or a dynamic bookmark whose
+        // query produced nothing, e.g. CASEWORKER_NAME with no user in context) must
+        // not appear as literal [[TOKEN]] text in the letter sent to an operator.
+        $json = json_encode([
+            'blocks' => [
+                ['type' => 'paragraph', 'data' => ['text' => 'Signed: [[NO_SUCH_GRAB]]']],
+            ],
+        ]);
+
+        $this->mockBookmarkFactory->shouldReceive('locate')
+            ->with('NO_SUCH_GRAB')
+            ->andThrow(new \InvalidArgumentException('Unknown bookmark'));
+
+        $result = $this->service->replaceGrabs($json, []);
+
+        $this->assertStringNotContainsString('NO_SUCH_GRAB', $result);
+        $this->assertStringContainsString('Signed: ', $result);
+    }
+
+    public function testReplaceGrabsInHtmlStripsUnresolvableTokens(): void
+    {
+        $html = '<p>Signed: [[NO_SUCH_GRAB]]</p>';
+
+        $this->mockBookmarkFactory->shouldReceive('locate')
+            ->with('NO_SUCH_GRAB')
+            ->andThrow(new \InvalidArgumentException('Unknown bookmark'));
+
+        $result = $this->service->replaceGrabsInHtml($html, []);
+
+        $this->assertStringNotContainsString('NO_SUCH_GRAB', $result);
     }
 }

--- a/app/cdn/assets/_js/components/editorjs.js
+++ b/app/cdn/assets/_js/components/editorjs.js
@@ -41,10 +41,13 @@ OLCS.editorjs = (function (document, $, undefined) {
     // Configure EditorJS tools
     var tools = {};
 
-    // Add Header tool if available
+    // Add Header tool if available.
+    // VOL-7305: inlineToolbar enables Bold / Italic / Link from EditorJS core so
+    // admins can format chrome headings the same way as paragraphs.
     if (typeof Header !== "undefined") {
       tools.header = {
         class: Header,
+        inlineToolbar: true,
         config: {
           placeholder: "Enter a header",
           levels: [1, 2, 3, 4, 5, 6],
@@ -126,7 +129,7 @@ OLCS.editorjs = (function (document, $, undefined) {
           });
 
           // Enable spellcheck on all contenteditable elements
-          var editableElements = editorContainer.querySelectorAll("[contenteditable=\"true\"]");
+          var editableElements = editorContainer.querySelectorAll('[contenteditable="true"]');
           editableElements.forEach(function (element) {
             element.setAttribute("spellcheck", "true");
           });
@@ -142,7 +145,7 @@ OLCS.editorjs = (function (document, $, undefined) {
                       node.setAttribute("spellcheck", "true");
                     }
                     // Also check for contenteditable descendants
-                    var newEditables = node.querySelectorAll("[contenteditable=\"true\"]");
+                    var newEditables = node.querySelectorAll('[contenteditable="true"]');
                     newEditables.forEach(function (element) {
                       element.setAttribute("spellcheck", "true");
                     });

--- a/app/cdn/assets/_js/components/editorjs.js
+++ b/app/cdn/assets/_js/components/editorjs.js
@@ -129,7 +129,7 @@ OLCS.editorjs = (function (document, $, undefined) {
           });
 
           // Enable spellcheck on all contenteditable elements
-          var editableElements = editorContainer.querySelectorAll('[contenteditable="true"]');
+          var editableElements = editorContainer.querySelectorAll("[contenteditable=true]");
           editableElements.forEach(function (element) {
             element.setAttribute("spellcheck", "true");
           });
@@ -145,7 +145,7 @@ OLCS.editorjs = (function (document, $, undefined) {
                       node.setAttribute("spellcheck", "true");
                     }
                     // Also check for contenteditable descendants
-                    var newEditables = node.querySelectorAll('[contenteditable="true"]');
+                    var newEditables = node.querySelectorAll("[contenteditable=true]");
                     newEditables.forEach(function (element) {
                       element.setAttribute("spellcheck", "true");
                     });

--- a/app/internal/module/Admin/src/Data/Mapper/Letter/MasterTemplate.php
+++ b/app/internal/module/Admin/src/Data/Mapper/Letter/MasterTemplate.php
@@ -18,11 +18,19 @@ class MasterTemplate implements MapperInterface
     #[\Override]
     public static function mapFromResult(array $data): array
     {
+        // VOL-7305: the four chrome slot fields hydrate as JSON arrays from Doctrine.
+        // EditorJS form expects a JSON STRING in the hidden input, so re-encode here.
+        $encodeSlot = static fn($slot) => is_array($slot) ? json_encode($slot) : ($slot ?? null);
+
         $formData = [
             'masterTemplate' => [
                 'id' => $data['id'] ?? null,
                 'name' => $data['name'] ?? null,
                 'templateContent' => $data['templateContent'] ?? null,
+                'headerLeftContent' => $encodeSlot($data['headerLeftContent'] ?? null),
+                'headerRightContent' => $encodeSlot($data['headerRightContent'] ?? null),
+                'signoffContent' => $encodeSlot($data['signoffContent'] ?? null),
+                'footerContent' => $encodeSlot($data['footerContent'] ?? null),
                 'isDefault' => $data['isDefault'] ?? false,
                 'locale' => $data['locale'] ?? null,
             ]
@@ -44,6 +52,23 @@ class MasterTemplate implements MapperInterface
         // Ensure boolean value for isDefault
         if (isset($commandData['isDefault'])) {
             $commandData['isDefault'] = (bool) $commandData['isDefault'];
+        }
+
+        // VOL-7305: EditorJS submits a JSON string per slot field. Decode to array
+        // for the command DTO. Empty/whitespace → null so the API handler treats it
+        // as "leave alone" rather than "clear".
+        $decodeSlot = static function ($value): ?array {
+            if (!is_string($value) || trim($value) === '') {
+                return is_array($value) ? $value : null;
+            }
+            $decoded = json_decode($value, true);
+            return (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) ? $decoded : null;
+        };
+
+        foreach (['headerLeftContent', 'headerRightContent', 'signoffContent', 'footerContent'] as $slot) {
+            if (array_key_exists($slot, $commandData)) {
+                $commandData[$slot] = $decodeSlot($commandData[$slot]);
+            }
         }
 
         return $commandData;

--- a/app/internal/module/Admin/src/Data/Mapper/Letter/MasterTemplate.php
+++ b/app/internal/module/Admin/src/Data/Mapper/Letter/MasterTemplate.php
@@ -54,6 +54,13 @@ class MasterTemplate implements MapperInterface
             $commandData['isDefault'] = (bool) $commandData['isDefault'];
         }
 
+        // The locale select's empty option submits '' — map to null so the API
+        // handler leaves a NULL locale untouched (pre-VOL-7305 rows) rather than
+        // coercing it on an unrelated save.
+        if (isset($commandData['locale']) && $commandData['locale'] === '') {
+            $commandData['locale'] = null;
+        }
+
         // VOL-7305: EditorJS submits a JSON string per slot field. Decode to array
         // for the command DTO. Empty/whitespace → null so the API handler treats it
         // as "leave alone" rather than "clear".

--- a/app/internal/module/Admin/src/Form/Model/Fieldset/Letter/MasterTemplate.php
+++ b/app/internal/module/Admin/src/Form/Model/Fieldset/Letter/MasterTemplate.php
@@ -115,6 +115,7 @@ class MasterTemplate
      * @Form\Options({
      *     "label": "Locale",
      *     "hint": "Chrome variant — en_GB (default), en_NI (NI letters), cy_GB (Welsh). Picked at letter-generation time by isNi.",
+     *     "empty_option": "Not set",
      *     "value_options": {
      *         "en_GB": "en_GB — England, Scotland and Wales (default)",
      *         "en_NI": "en_NI — Northern Ireland",

--- a/app/internal/module/Admin/src/Form/Model/Fieldset/Letter/MasterTemplate.php
+++ b/app/internal/module/Admin/src/Form/Model/Fieldset/Letter/MasterTemplate.php
@@ -107,15 +107,23 @@ class MasterTemplate
     public $isDefault = null;
 
     /**
+     * A select rather than free text: the resolver matches this value exactly
+     * (name + locale is a sibling template's identity), so a typo would silently
+     * break chrome resolution. customN_* one-off variants are a future extension
+     * point — add them here when the resolver learns to pick them.
+     *
      * @Form\Options({
      *     "label": "Locale",
-     *     "hint": "Chrome variant key — en_GB (default), en_NI (NI letters), cy_GB (Welsh), or customN_GB / customN_NI for one-off chromes. Picked at letter-generation time by isNi."
+     *     "hint": "Chrome variant — en_GB (default), en_NI (NI letters), cy_GB (Welsh). Picked at letter-generation time by isNi.",
+     *     "value_options": {
+     *         "en_GB": "en_GB — England, Scotland and Wales (default)",
+     *         "en_NI": "en_NI — Northern Ireland",
+     *         "cy_GB": "cy_GB — Welsh"
+     *     }
      * })
      * @Form\Required(false)
-     * @Form\Type("Text")
-     * @Form\Attributes({"class":"medium"})
-     * @Form\Filter("Laminas\Filter\StringTrim")
-     * @Form\Validator("Laminas\Validator\StringLength", options={"max":20})
+     * @Form\Type("select")
+     * @Form\Attributes({"class":"medium", "id":"locale"})
      */
     public $locale = null;
 }

--- a/app/internal/module/Admin/src/Form/Model/Fieldset/Letter/MasterTemplate.php
+++ b/app/internal/module/Admin/src/Form/Model/Fieldset/Letter/MasterTemplate.php
@@ -24,18 +24,76 @@ class MasterTemplate
     public $name = null;
 
     /**
+     * Page-chrome HTML shell with {{SLOT}} placeholders. Advanced — rarely edited.
+     * VOL-7305: switched from EditorJs to Textarea because the field's content is
+     * consumed as raw HTML by populateTemplate(); the EditorJs widget would have
+     * produced incompatible JSON.
+     *
      * @Form\Options({
-     *     "label": "Template Content",
+     *     "label": "Page chrome HTML (advanced)",
+     *     "hint": "HTML shell with {{TOKENS}} placeholders. Rarely edited — the day-to-day chrome content lives in the slot fields below.",
      *     "label_attributes": {
      *         "class": ""
      *     }
      * })
      * @Form\Required(false)
-     * @Form\Type("EditorJs")
-     * @Form\Attributes({"id":"templateContent", "class":"extra-long", "name":"templateContent"})
+     * @Form\Type("Textarea")
+     * @Form\Attributes({"id":"templateContent", "class":"extra-long", "rows":12, "name":"templateContent"})
      * @Form\Filter("Laminas\Filter\StringTrim")
      */
     public $templateContent = null;
+
+    /**
+     * VOL-7305: chrome slot — top-left header (typically the agency logo via [[OTC_LOGO]]).
+     *
+     * @Form\Options({
+     *     "label": "Header (left)",
+     *     "hint": "Top-left of the letter — usually the agency logo. Use [[OTC_LOGO]] to embed the region-appropriate logo automatically."
+     * })
+     * @Form\Required(false)
+     * @Form\Type("EditorJs")
+     * @Form\Attributes({"id":"headerLeftContent", "class":"extra-long", "name":"headerLeftContent"})
+     */
+    public $headerLeftContent = null;
+
+    /**
+     * VOL-7305: chrome slot — top-right header (sender address block + contact details).
+     *
+     * @Form\Options({
+     *     "label": "Header (right)",
+     *     "hint": "Top-right of the letter — typically the sender address block. Vary per locale (en_GB / en_NI) for region-specific addresses."
+     * })
+     * @Form\Required(false)
+     * @Form\Type("EditorJs")
+     * @Form\Attributes({"id":"headerRightContent", "class":"extra-long", "name":"headerRightContent"})
+     */
+    public $headerRightContent = null;
+
+    /**
+     * VOL-7305: chrome slot — signoff/sign-off block above the appendices.
+     *
+     * @Form\Options({
+     *     "label": "Signoff",
+     *     "hint": "Closing salutation and signature line. Use [[CASEWORKER_NAME]] to insert the issuing caseworker's name."
+     * })
+     * @Form\Required(false)
+     * @Form\Type("EditorJs")
+     * @Form\Attributes({"id":"signoffContent", "class":"extra-long", "name":"signoffContent"})
+     */
+    public $signoffContent = null;
+
+    /**
+     * VOL-7305: chrome slot — footer at the very bottom of the letter body.
+     *
+     * @Form\Options({
+     *     "label": "Footer",
+     *     "hint": "Single-line footer note that appears at the bottom of the letter."
+     * })
+     * @Form\Required(false)
+     * @Form\Type("EditorJs")
+     * @Form\Attributes({"id":"footerContent", "class":"extra-long", "name":"footerContent"})
+     */
+    public $footerContent = null;
 
     /**
      * @Form\Options({
@@ -49,12 +107,15 @@ class MasterTemplate
     public $isDefault = null;
 
     /**
-     * @Form\Options({"label": "Locale"})
+     * @Form\Options({
+     *     "label": "Locale",
+     *     "hint": "Chrome variant key — en_GB (default), en_NI (NI letters), cy_GB (Welsh), or customN_GB / customN_NI for one-off chromes. Picked at letter-generation time by isNi."
+     * })
      * @Form\Required(false)
      * @Form\Type("Text")
-     * @Form\Attributes({"class":"small"})
+     * @Form\Attributes({"class":"medium"})
      * @Form\Filter("Laminas\Filter\StringTrim")
-     * @Form\Validator("Laminas\Validator\StringLength", options={"max":5})
+     * @Form\Validator("Laminas\Validator\StringLength", options={"max":20})
      */
     public $locale = null;
 }

--- a/app/internal/module/Admin/src/Table/Tables/admin-master-template.table.php
+++ b/app/internal/module/Admin/src/Table/Tables/admin-master-template.table.php
@@ -42,6 +42,15 @@ return [
             'formatter' => fn($row) => Escape::html($row['name'] ?? ''),
         ],
         [
+            // Sibling chrome templates share a name and differ only by locale
+            // (en_GB / en_NI / ...), so without this column the rows are
+            // indistinguishable in the list.
+            'title' => 'Locale',
+            'name' => 'locale',
+            'sort' => 'locale',
+            'formatter' => fn($row) => Escape::html($row['locale'] ?? 'N/A'),
+        ],
+        [
             'title' => 'Default',
             'name' => 'isDefault',
             'sort' => 'isDefault',

--- a/app/internal/module/Olcs/assets/js/inline/forms/letter-generation.js
+++ b/app/internal/module/Olcs/assets/js/inline/forms/letter-generation.js
@@ -250,6 +250,7 @@ OLCS.ready(function () {
   $("body").on("click", "#prepare-to-send-btn", function (e) {
     e.preventDefault();
     var $btn = $(this);
+    $("#prepare-to-send-error").hide().text("");
     $btn.prop("disabled", true).text("Preparing...");
 
     // Get letterInstanceId from the preview link (set during generateAction success)
@@ -297,7 +298,14 @@ OLCS.ready(function () {
           $btn.prop("disabled", false).text("Prepare to send");
         }
       },
-      error: function () {
+      error: function (xhr) {
+        // Surface the server's reason (e.g. VOL-7402 "requires input" block)
+        // instead of silently resetting the button.
+        var message = "Something went wrong preparing the letter. Try again.";
+        if (xhr.responseJSON && xhr.responseJSON.message) {
+          message = xhr.responseJSON.message;
+        }
+        $("#prepare-to-send-error").text(message).show();
         $btn.prop("disabled", false).text("Prepare to send");
       },
     });

--- a/app/internal/module/Olcs/src/Controller/Letter/LetterGenerationController.php
+++ b/app/internal/module/Olcs/src/Controller/Letter/LetterGenerationController.php
@@ -1005,9 +1005,16 @@ class LetterGenerationController extends AbstractInternalController implements L
                     'label' => $letterChoice['label'] ?? '',
                     'groupLabel' => $letterChoice['groupLabel'] ?? 'Other letter choices',
                     'inputType' => $letterChoice['inputType'] ?? 'checkbox',
+                    'displayOrder' => (int) ($letterChoice['displayOrder'] ?? 0),
                 ];
             }
         }
+
+        // VOL-7282: honour the admin-configured ordering (label as tiebreak)
+        usort(
+            $choices,
+            fn(array $a, array $b) => [$a['displayOrder'], $a['label']] <=> [$b['displayOrder'], $b['label']]
+        );
 
         return $choices;
     }

--- a/app/internal/module/Olcs/src/Controller/Letter/LetterGenerationController.php
+++ b/app/internal/module/Olcs/src/Controller/Letter/LetterGenerationController.php
@@ -266,6 +266,10 @@ class LetterGenerationController extends AbstractInternalController implements L
                 'id' => $issue['id'],
                 'name' => $issue['letterIssueVersion']['heading'] ?? 'Issue',
                 'type' => 'issue',
+                // VOL-7402: flagged content must be edited before the letter can be
+                // sent (enforced server-side in PrepareToSend) — highlight it here.
+                'inputPending' => !empty($issue['letterIssueVersion']['requiresInput'])
+                    && empty($issue['editedContent']),
             ];
         }
 
@@ -311,6 +315,8 @@ class LetterGenerationController extends AbstractInternalController implements L
                 'name' => $name,
                 'position' => $instanceSection['positionInAssembly'] ?? 0,
                 'type' => 'section',
+                'inputPending' => !empty($sectionVersion['requiresInput'])
+                    && empty($instanceSection['editedContent']),
             ];
         }
 
@@ -727,9 +733,17 @@ class LetterGenerationController extends AbstractInternalController implements L
         $response = $this->handleCommand($command);
 
         if (!$response->isOk()) {
-            $messages = $response->getResult()['messages'] ?? [];
-            $errorMessage = is_array($messages) ? implode(', ', $messages) : $messages;
-            return $this->jsonError('Failed to prepare letter: ' . $errorMessage);
+            // Validation failures arrive keyed and nested (field => [message, ...]),
+            // so flatten before joining or the user sees the literal string "Array".
+            $messages = (array) ($response->getResult()['messages'] ?? []);
+            $flatMessages = [];
+            array_walk_recursive(
+                $messages,
+                static function ($message) use (&$flatMessages): void {
+                    $flatMessages[] = (string) $message;
+                }
+            );
+            return $this->jsonError('Failed to prepare letter: ' . implode(', ', $flatMessages));
         }
 
         $result = $response->getResult();

--- a/app/internal/module/Olcs/view/pages/letter/create.phtml
+++ b/app/internal/module/Olcs/view/pages/letter/create.phtml
@@ -161,6 +161,8 @@
         </a>
     </p>
 
+    <p id="prepare-to-send-error" class="govuk-error-message" style="display: none;"></p>
+
     <div class="govuk-button-group">
         <button type="button" id="prepare-to-send-btn" class="govuk-button" data-module="govuk-button">
             Prepare to send

--- a/app/internal/module/Olcs/view/pages/letter/preview-sidebar.phtml
+++ b/app/internal/module/Olcs/view/pages/letter/preview-sidebar.phtml
@@ -24,6 +24,9 @@
             <label class="govuk-label govuk-checkboxes__label"
                    for="section-<?= $this->escapeHtmlAttr($section['id']) ?>">
                 <?= $this->escapeHtml($section['name']) ?>
+                <?php if (!empty($section['inputPending'])): ?>
+                <strong class="govuk-tag govuk-tag--red">Input required</strong>
+                <?php endif; ?>
             </label>
         </div>
         <?php endforeach; ?>
@@ -46,6 +49,9 @@
             <label class="govuk-label govuk-checkboxes__label"
                    for="letter-section-<?= $this->escapeHtmlAttr($instanceSection['id']) ?>">
                 <?= $this->escapeHtml($instanceSection['name']) ?>
+                <?php if (!empty($instanceSection['inputPending'])): ?>
+                <strong class="govuk-tag govuk-tag--red">Input required</strong>
+                <?php endif; ?>
             </label>
         </div>
         <?php endforeach; ?>

--- a/app/internal/test/Admin/src/Data/Mapper/Letter/MasterTemplateTest.php
+++ b/app/internal/test/Admin/src/Data/Mapper/Letter/MasterTemplateTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AdminTest\Data\Mapper\Letter;
+
+use Admin\Data\Mapper\Letter\MasterTemplate;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+/**
+ * @see MasterTemplate
+ */
+class MasterTemplateTest extends MockeryTestCase
+{
+    public function testMapFromFormMapsEmptyLocaleToNull(): void
+    {
+        // The locale select's empty option submits '' — that must reach the command
+        // as null so the Update handler leaves a NULL locale untouched instead of
+        // coercing pre-VOL-7305 rows to a concrete locale on unrelated saves.
+        $commandData = MasterTemplate::mapFromForm([
+            'masterTemplate' => [
+                'id' => 1,
+                'name' => 'Default Letter Template',
+                'locale' => '',
+            ],
+        ]);
+
+        $this->assertNull($commandData['locale']);
+    }
+
+    public function testMapFromFormPassesConcreteLocaleThrough(): void
+    {
+        $commandData = MasterTemplate::mapFromForm([
+            'masterTemplate' => [
+                'id' => 1,
+                'name' => 'Default Letter Template',
+                'locale' => 'en_NI',
+            ],
+        ]);
+
+        $this->assertSame('en_NI', $commandData['locale']);
+    }
+
+    public function testMapFromFormDecodesSlotJsonStrings(): void
+    {
+        $slotJson = '{"time":1,"version":"2.31.0","blocks":[{"id":"a","type":"paragraph","data":{"text":"Hi"}}]}';
+
+        $commandData = MasterTemplate::mapFromForm([
+            'masterTemplate' => [
+                'id' => 1,
+                'name' => 'Default Letter Template',
+                'headerLeftContent' => $slotJson,
+                'signoffContent' => '',
+            ],
+        ]);
+
+        $this->assertSame('Hi', $commandData['headerLeftContent']['blocks'][0]['data']['text']);
+        $this->assertNull($commandData['signoffContent']);
+    }
+}

--- a/app/internal/test/Olcs/src/Controller/Letter/LetterGenerationControllerTest.php
+++ b/app/internal/test/Olcs/src/Controller/Letter/LetterGenerationControllerTest.php
@@ -99,4 +99,34 @@ class LetterGenerationControllerTest extends MockeryTestCase
         $this->assertNotNull($error);
         $this->assertStringContainsString('Stage', $error);
     }
+
+    public function testFetchLetterChoicesSortsByDisplayOrder(): void
+    {
+        // VOL-7282: admin sets First request = 1, Final request = 2, but the modal
+        // showed them in insertion order.
+        $sut = m::mock(Sut::class, [
+            m::mock(TranslationHelperService::class),
+            m::mock(FormHelperService::class),
+            m::mock(FlashMessengerHelperService::class),
+            m::mock(Navigation::class),
+        ])->makePartial()->shouldAllowMockingProtectedMethods();
+
+        $sut->shouldReceive('fetchTemplateById')->with(1)->andReturn(['letterType' => ['id' => 7]]);
+
+        $response = m::mock();
+        $response->shouldReceive('isOk')->andReturn(true);
+        $response->shouldReceive('getResult')->andReturn([
+            'letterTypeChoices' => [
+                ['letterChoice' => ['id' => 20, 'label' => 'Final request', 'groupLabel' => 'First or final request', 'inputType' => 'radio', 'displayOrder' => 2, 'isActive' => true]],
+                ['letterChoice' => ['id' => 10, 'label' => 'First request', 'groupLabel' => 'First or final request', 'inputType' => 'radio', 'displayOrder' => 1, 'isActive' => true]],
+            ],
+        ]);
+        $sut->shouldReceive('handleQuery')->andReturn($response);
+
+        $method = new \ReflectionMethod(Sut::class, 'fetchLetterChoicesForLetterType');
+        $method->setAccessible(true);
+        $choices = $method->invoke($sut, 1);
+
+        $this->assertSame(['First request', 'Final request'], array_column($choices, 'label'));
+    }
 }


### PR DESCRIPTION
## VOL-7305 — Admin-editable letter chrome
- Master template chrome (header left/right, signoff, footer) is now admin-editable
  EditorJS content on the MasterTemplate, resolved per region (en_GB / en_NI) by a new
  MasterTemplateResolver (sibling rows linked by name + locale, isNi picks the variant)
- [[OTC_LOGO]] token embeds the region-appropriate OTC logo from the content store as
  an inline base64 image, with fallback to the legacy `otclogo-letters` doc template slug
- Slot JSON is validated and normalised on save (Create/Update reject non-EditorJS
  shapes; missing time/block ids filled in) and normalised defensively at render time,
  so malformed seed/legacy data degrades instead of 500ing the preview
- Admin list gains a Locale column; locale is a select (en_GB / en_NI / cy_GB) with a
  "Not set" option so pre-existing NULL-locale rows aren't silently rewritten on save

## VOL-7100 sub-tickets
- VOL-7280: to-dos render as blocks, not bullets — nested bullets in to-do content stay
  top-level and solid (inset-text CSS removal on issues to follow in the ETL patch)
- VOL-7282: create-letter modal honours the admin-configured letter choice display order
- VOL-7288: letter PDFs render at A4 (preferCssPageSize + explicit dims) instead of
  Chromium's US Letter default, matching merged A4 appendix PDFs
- VOL-7308: generated document description appends the selected radio choice label(s)
  (e.g. "… - First request") so first/final letters are distinguishable in Docs & attachments
- VOL-7402: requires-input is now enforced — PrepareToSend rejects letters whose flagged
  issues/sections still hold default content (listing the headings), the preview sidebar
  tags them "Input required", and the send modal surfaces the reason

## Hardening (post-review)
- Resolver falls back to the isDefault master template when a letter type has none
  (parity with previous behaviour); dead fallback copies removed from both handlers
- data: URI images are permitted only for admin-authored chrome, never caseworker
  content — including a fix for HTMLPurifier's process-global scheme registry leaking
  the allowance into subsequent purifies (URI.OverrideAllowedSchemes=false)
- Logo resolution survives missing files (read() returns false, not null) and rejects
  non-png/gif/jpeg payloads with a warning instead of a silent blank
- Unresolved [[TOKEN]]s are stripped (with a warning) rather than leaking literal
  token text into posted PDFs; CaseworkerName's generic fallback now logs

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
