### PR TITLE
fix: wrong env name for param

### DIFF
--- a/infra/terraform/environments/int/parameters.tf
+++ b/infra/terraform/environments/int/parameters.tf
@@ -1,7 +1,7 @@
 module "parameters" {
   source = "../../modules/parameters"
 
-  environment = "int"
+  environment = "qa"
 
   application_parameters = {
     address_service_azure_client_id              = "a759978f-1ce5-4e46-8980-4f51bed98e45"


### PR DESCRIPTION
## Description
fixes the int/qa naming in vol-app param
<!--
Include a summary of the change here.
-->

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
