### PR TITLE
fix: restore CSV exports broken by toIterable() migration (VOL-7445)

### DIFF
--- a/app/api/module/Api/src/Domain/QueryHandler/Bus/BusRegBrowseExport.php
+++ b/app/api/module/Api/src/Domain/QueryHandler/Bus/BusRegBrowseExport.php
@@ -67,8 +67,8 @@ class BusRegBrowseExport extends AbstractQueryHandler
         fputcsv($fp, $this->columnsToExport, ',', '"', '\\');
 
         $hasData = false;
-        while (false !== ($row = $iterableResult->next())) {
-            fputcsv($fp, current($row), ',', '"', '\\');
+        foreach ($iterableResult as $row) {
+            fputcsv($fp, $row, ',', '"', '\\');
             $hasData = true;
         }
 

--- a/app/api/module/Api/src/Domain/QueryHandler/Lva/AbstractGoodsVehiclesExport.php
+++ b/app/api/module/Api/src/Domain/QueryHandler/Lva/AbstractGoodsVehiclesExport.php
@@ -28,9 +28,7 @@ abstract class AbstractGoodsVehiclesExport extends AbstractQueryHandler
         $iterableResult = $repo->fetchForExport($qb);
 
         $result = [];
-        while (false !== ($row = $iterableResult->next())) {
-            $row = current($row);
-
+        foreach ($iterableResult as $row) {
             $resultRow = [
                 'vehicle' => [
                     'vrm' => $row['vrm'],

--- a/app/api/module/Api/src/Domain/Repository/BusRegBrowseView.php
+++ b/app/api/module/Api/src/Domain/Repository/BusRegBrowseView.php
@@ -40,7 +40,7 @@ class BusRegBrowseView extends AbstractRepository
      * @param array  $trafficAreas Traffic areas
      * @param string $status       Status
      *
-     * @return array
+     * @return iterable<array<int, mixed>>
      */
     public function fetchForExport($columns, $date, $trafficAreas, $status = null)
     {

--- a/app/api/module/Api/src/Domain/Repository/LicenceVehicle.php
+++ b/app/api/module/Api/src/Domain/Repository/LicenceVehicle.php
@@ -482,7 +482,7 @@ class LicenceVehicle extends AbstractRepository
      *
      * @param QueryBuilder $qb Prepared Query Builder
      *
-     * @return \Doctrine\ORM\Internal\Hydration\IterableResult
+     * @return iterable<array<string, mixed>>
      */
     public function fetchForExport(QueryBuilder $qb)
     {

--- a/app/api/module/Api/src/Domain/Repository/Organisation.php
+++ b/app/api/module/Api/src/Domain/Repository/Organisation.php
@@ -193,7 +193,7 @@ class Organisation extends AbstractRepository
      *
      * @param string $status Status
      *
-     * @return \Doctrine\ORM\Internal\Hydration\IterableResult
+     * @return iterable<array<string, mixed>>
      */
     public function fetchAllByStatusForCpidExport($status = null)
     {

--- a/app/api/module/Cli/src/Service/Queue/Consumer/CpidOrganisationExport.php
+++ b/app/api/module/Cli/src/Service/Queue/Consumer/CpidOrganisationExport.php
@@ -49,8 +49,8 @@ class CpidOrganisationExport extends AbstractConsumer
         //  create csv file in memory
         $fh = fopen("php://temp", 'w');
 
-        while (false !== ($row = $iterableResult->next())) {
-            fputcsv($fh, current($row), ',', '"', '\\');
+        foreach ($iterableResult as $row) {
+            fputcsv($fh, $row, ',', '"', '\\');
         }
 
         rewind($fh);

--- a/app/api/test/module/Api/src/Domain/QueryHandler/Bus/BusRegBrowseExportTest.php
+++ b/app/api/test/module/Api/src/Domain/QueryHandler/Bus/BusRegBrowseExportTest.php
@@ -46,14 +46,11 @@ final class BusRegBrowseExportTest extends QueryHandlerTestCase
                 $status
             )
             ->andReturn(
-                m::mock()
-                    ->shouldReceive('next')
-                    ->andReturn(
-                        [['VAL11', 'VAL12']],
-                        [['VAL21', 'VAL22']],
-                        false
-                    )
-                    ->getMock()
+                // Query::toIterable() yields each row directly (no [0 => ...] wrapper)
+                (static function (): \Generator {
+                    yield ['VAL11', 'VAL12'];
+                    yield ['VAL21', 'VAL22'];
+                })()
             );
 
         $result = $this->sut->handleQuery($query);
@@ -96,12 +93,9 @@ final class BusRegBrowseExportTest extends QueryHandlerTestCase
                 $status
             )
             ->andReturn(
-                m::mock()
-                    ->shouldReceive('next')
-                    ->andReturn(
-                        false
-                    )
-                    ->getMock()
+                (static function (): \Generator {
+                    yield from [];
+                })()
             );
 
         $this->sut->handleQuery($query);

--- a/app/api/test/module/Api/src/Domain/QueryHandler/Lva/AbstractGoodsVehiclesExportTest.php
+++ b/app/api/test/module/Api/src/Domain/QueryHandler/Lva/AbstractGoodsVehiclesExportTest.php
@@ -57,11 +57,11 @@ final class AbstractGoodsVehiclesExportTest extends QueryHandlerTestCase
             'ceasedDate' => 'unit_CeasedDate',
         ];
 
-        $mockDbIterator = m::mock(\Doctrine\ORM\Internal\Hydration\IterableResult::class)
-            ->shouldReceive('next')->once()->andReturn([$dbRow1])
-            ->shouldReceive('next')->once()->andReturn([$dbRow2])
-            ->shouldReceive('next')->once()->andReturn(false)
-            ->getMock();
+        // Query::toIterable() yields each hydrated row directly (no [0 => ...] wrapper)
+        $mockDbIterator = (static function () use ($dbRow1, $dbRow2): \Generator {
+            yield $dbRow1;
+            yield $dbRow2;
+        })();
 
         $this->repoMap['LicenceVehicle']
             ->shouldReceive('fetchForExport')->once()->with($qb)->andReturn($mockDbIterator);

--- a/app/api/test/module/Cli/src/Service/Queue/Consumer/CpidOrganisationExportTest.php
+++ b/app/api/test/module/Cli/src/Service/Queue/Consumer/CpidOrganisationExportTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Dvsa\OlcsTest\Cli\Service\Queue\Consumer;
 
-use Doctrine\ORM\Internal\Hydration\IterableResult;
 use Dvsa\Olcs\Api\Domain\CommandHandlerManager;
 use Dvsa\Olcs\Api\Domain\Repository;
 use Dvsa\Olcs\Api\Entity;
@@ -40,12 +39,10 @@ final class CpidOrganisationExportTest extends AbstractConsumerTestCase
         $this->organisationRepo->shouldReceive('fetchAllByStatusForCpidExport')
             ->with('unit_Status')
             ->andReturn(
-                m::mock(IterableResult::class)
-                    ->makePartial()
-                    ->shouldReceive('next')
-                    ->twice()
-                    ->andReturn([$row], false)
-                    ->getMock()
+                // Query::toIterable() yields each row directly (no [0 => ...] wrapper)
+                (static function () use ($row): \Generator {
+                    yield $row;
+                })()
             );
 
         parent::setUp();


### PR DESCRIPTION
## Description

Rector change #1588 swapped iterate() for toIterable() in the export repos but left three consumers on the removed IterableResult API, so ->next() returned null and current(null) threw. This switches the goods-vehicle, bus-registration and CPID export consumers to foreach and update their tests to thge new interface

Related issue: VOL-7445

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
