### PR TITLE
chore(terraform): use PSR-3 string for log_level SSM parameter

### DIFF
--- a/infra/terraform/environments/dev/parameters.tf
+++ b/infra/terraform/environments/dev/parameters.tf
@@ -34,7 +34,7 @@ module "parameters" {
     govuk_account_private_key_algorithm          = "RS256"
     govuk_account_public_key                     = "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUExZXJNSjAxclBJOEQrbnFvYUZaQQpHUVZkR3VTUm5mV2pqUHpOYWJQbFB5U3FaaVZCdGo3WTNnL3lEV1JoWUUzeTE3YTBaeExmd2FkTGZPbE5jczVxCkJ1M1BwSlNCUm5EVmVZMlhQdjdIaHE5b2tvbTFVMzgzekozVU5NSmNYTyt4UU9FMzB1cVh0OFQ3RFkrZ2F5VXoKcFFpYlUzNE1tQ21rR0JHT3dENDYrcWN3NUZWZ3FaZjJDUEdOdkEwenNyZ2g5cEIrWGtKbXpWdERFbVY3Sjh2bApnaDM2OWRRbHE5SHNNWE82Q1pXakI1bWUrU2NqY215WUNnSHZDT2ViNGVpL3p2TzIrNUhqMy8zZEFpTzZWa25kClozTENqelYvU1hPSHFmbVRmUHJVeUNLQ2lDMWxEMTRuSldDOWpQZk1xZk1CVlIrdGxubCtrb1o0blMwWkFrSGsKMndJREFRQUIKLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCg=="
     lar_base_uri                                 = "https://ce5rumk6p4.execute-api.eu-west-1.amazonaws.com/ci/"
-    log_level                                    = "4"
+    log_level                                    = "warning"
     olcs_aws_account_number                      = "054614622558"
     olcs_aws_region                              = "eu-west-1"
     olcs_aws_s3_role_arn                         = "arn:aws:iam::054614622558:role/OLCS-DEVAPPDEV-BASE-API"

--- a/infra/terraform/environments/int/parameters.tf
+++ b/infra/terraform/environments/int/parameters.tf
@@ -34,7 +34,7 @@ module "parameters" {
     govuk_account_private_key_algorithm          = "RS256"
     govuk_account_public_key                     = "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUExZXJNSjAxclBJOEQrbnFvYUZaQQpHUVZkR3VTUm5mV2pqUHpOYWJQbFB5U3FaaVZCdGo3WTNnL3lEV1JoWUUzeTE3YTBaeExmd2FkTGZPbE5jczVxCkJ1M1BwSlNCUm5EVmVZMlhQdjdIaHE5b2tvbTFVMzgzekozVU5NSmNYTyt4UU9FMzB1cVh0OFQ3RFkrZ2F5VXoKcFFpYlUzNE1tQ21rR0JHT3dENDYrcWN3NUZWZ3FaZjJDUEdOdkEwenNyZ2g5cEIrWGtKbXpWdERFbVY3Sjh2bApnaDM2OWRRbHE5SHNNWE82Q1pXakI1bWUrU2NqY215WUNnSHZDT2ViNGVpL3p2TzIrNUhqMy8zZEFpTzZWa25kClozTENqelYvU1hPSHFmbVRmUHJVeUNLQ2lDMWxEMTRuSldDOWpQZk1xZk1CVlIrdGxubCtrb1o0blMwWkFrSGsKMndJREFRQUIKLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCg=="
     lar_base_uri                                 = "https://ce5rumk6p4.execute-api.eu-west-1.amazonaws.com/ci/"
-    log_level                                    = "4"
+    log_level                                    = "warning"
     olcs_aws_account_number                      = "054614622558"
     olcs_aws_region                              = "eu-west-1"
     olcs_aws_s3_role_arn                         = "arn:aws:iam::054614622558:role/OLCS-DEVAPPQA-BASE-API"

--- a/infra/terraform/environments/prep/parameters.tf
+++ b/infra/terraform/environments/prep/parameters.tf
@@ -34,7 +34,7 @@ module "parameters" {
     govuk_account_private_key_algorithm          = "RS256"
     govuk_account_public_key                     = "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQ0lqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FnOEFNSUlDQ2dLQ0FnRUFyY0Y3TERaRUtJV0RoYUVMWlZBYwpLZW9keWdrQ1h6M0RpajVSRXI1WjRWOSs2QU1td21sMmJ3UTFTK2RCeFBHMmowbndNVHBJd1h3ZGRBNmRlNUh2CnNzMy9SbFdIamVndklzakxEYzhJWFRHcEtqZDU4cDdnZHpOTy9jTE8rUkg1R29zdzRRVVpObXAwRVluWW9PNm8Kd1NXMmYwbVkyQXFYV2x0dnBHckt1eDZZdVlJVnZSdlU5RnVYNkYzWi9ZVjVBYzcwK0s3aFdtWXIyUjBOYlVNaQpYNk9zNzk3SDUyQmc5NGRBRVJVQkR3VGtQbGd3cnZKUGtUWHdLWGc5dGIyTG0zcGowS1BRQk1YRElOaEJSRVNECkt5cEh0SndBQkFkVlVGbmFjaDdiN1kzYm1QNHNjMERMTG84S3pLdmZRdkcvbDJ5OGhzT1VlZEFLMDhIQUNWTXkKQ3JHNW9FZTh4VGJKczJIUDMyL1NtMXZWekt2ZDB1TVF0L2pkbC9kRWlIUURFdENVVmRjOG1xTmtsQUFyM0krTAo3RDhDa2IwbjdMbGJzMmo4YkRBbDlMOGNSYTlhdmd2TGhTSVF1V2s1Vkx5bjdvaWpDSnFaZGFreGhLREhYOHJ0Ck1nYUlnM0h4UFBWNEdrVHVGNkZSOFpwMTNjSzZRWEdsaEg2Vy80ZUs3ZWVqLzdsOE1Dc25rWjExcWNYVVREVjcKdXN4dFI4ZzArNXpJVXlwNlRrbDZYQk95dTlmbEo2TlI4Tk0zYXdQRi9mWkFHUHFlVDFkdjJ5Mk5KQ2FsYWhzTQpXN3hYdmdxZ2hlbGkwZEc1ZG00OGsrVG1mb1N6STRUODY1VnB1Nnk0YmFic0FJSHkrWTd1UkhOcFp4Uis1Ry9WCldkL0lLTGdGN3hVcGRuaXhJZWYzcm1rQ0F3RUFBUT09Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo="
     lar_base_uri                                 = "https://huxwmpie60.execute-api.eu-west-1.amazonaws.com/prep/"
-    log_level                                    = "4"
+    log_level                                    = "warning"
     olcs_aws_account_number                      = "146997448015"
     olcs_aws_region                              = "eu-west-1"
     olcs_aws_s3_role_arn                         = "arn:aws:iam::146997448015:role/OLCS-APPPP-BASE-API"

--- a/infra/terraform/environments/prod/parameters.tf
+++ b/infra/terraform/environments/prod/parameters.tf
@@ -34,7 +34,7 @@ module "parameters" {
     govuk_account_private_key_algorithm          = "RS256"
     govuk_account_public_key                     = "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQ0lqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FnOEFNSUlDQ2dLQ0FnRUF5UmZETWpPeEpKK0Z5c0NHR1RzRQpVcXpHVStzdFV4bFJ3alJrd3g4ZEFZcUpzb2ZhbFE5RzFsdnpPTG9CVDh5SzBoN0FLeGN1U29LNVAxQXVTY0FqCmJCd1ZnTUIvNmdncE1acGE0WVVJaEhKZFBYOFl2Z05RSkg2eU8ycExXVkN2WmtyYk8rcFQ3QnIzLzVCL3IzMkgKWW1OZUVlbCtWS2NoTFhDZG5NRGFNazJ4YVRDVHgwNmhVcE5TWmVvbEVQYzdqSktURDlFMTAwQStoRFJyWGl3dwo4T2ZHbEYyT2hTb09FMVV1ckUzS0hRVjBDQ2F5NDcxNk9FaUVPSFQrUHhFVFZwS0VlNzhTVFhDR3MyMC9wYnptCnpxNS8vTjB0S3hscVlNL05tYTkwZW8yd3FWTytYUHUrM1QyTjY0UlJmeDBjQXdTTllmbEFJMk1ieElVMnBsclkKMmtkM013RzNiYmpJaXVlRXU0U0JUWlErMTV5b0tscGFyazU2Snp3ZXhraUF5OEZwTGpWWUs2VGhielc4Z2FCOApnNHBNV3dXNWZpMVB6N0UwbC9nVzhWRHdGYVpWbGk5cFVaTUxvMnhDMFhBRnlJaUdrUzFTMDhRWmJ1ajhKekdPClRxTDhqZEpDYXVWeWxmK3ZVM3E2SENULzVpaDdDNHp4VVBnYm1TeTIreDRkRzh4OG5BaVExbkRQdGZDWC9JTmUKVzZleUtIZ1gyZEllWE1YNmZ1SzVsajloS08wY1FQdXFnN0pBcUNQUUM3cDFoaS96S0RBcEZoVEdCYldxRXo5QgpVRGZhWE5TNFp3QVhtSlNDZWtlWVRmZTZreW9YMWFnakJaM096ZHVyNjhETUpxWWdXWnlaaDFOM0ZCUk9mS1Q4CklQKytZOXBWUWpEbytOT09SaityaW5zQ0F3RUFBUT09Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo="
     lar_base_uri                                 = "https://fx9cl3117i.execute-api.eu-west-1.amazonaws.com/live/"
-    log_level                                    = "4"
+    log_level                                    = "warning"
     olcs_aws_account_number                      = "146997448015"
     olcs_aws_region                              = "eu-west-1"
     olcs_aws_s3_role_arn                         = "arn:aws:iam::146997448015:role/OLCS-APP-BASE-API"

--- a/infra/terraform/environments/reg/parameters.tf
+++ b/infra/terraform/environments/reg/parameters.tf
@@ -34,7 +34,7 @@ module "parameters" {
     govuk_account_private_key_algorithm          = "RS256"
     govuk_account_public_key                     = "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUExZXJNSjAxclBJOEQrbnFvYUZaQQpHUVZkR3VTUm5mV2pqUHpOYWJQbFB5U3FaaVZCdGo3WTNnL3lEV1JoWUUzeTE3YTBaeExmd2FkTGZPbE5jczVxCkJ1M1BwSlNCUm5EVmVZMlhQdjdIaHE5b2tvbTFVMzgzekozVU5NSmNYTyt4UU9FMzB1cVh0OFQ3RFkrZ2F5VXoKcFFpYlUzNE1tQ21rR0JHT3dENDYrcWN3NUZWZ3FaZjJDUEdOdkEwenNyZ2g5cEIrWGtKbXpWdERFbVY3Sjh2bApnaDM2OWRRbHE5SHNNWE82Q1pXakI1bWUrU2NqY215WUNnSHZDT2ViNGVpL3p2TzIrNUhqMy8zZEFpTzZWa25kClozTENqelYvU1hPSHFmbVRmUHJVeUNLQ2lDMWxEMTRuSldDOWpQZk1xZk1CVlIrdGxubCtrb1o0blMwWkFrSGsKMndJREFRQUIKLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCg=="
     lar_base_uri                                 = "https://ce5rumk6p4.execute-api.eu-west-1.amazonaws.com/ci/"
-    log_level                                    = "4"
+    log_level                                    = "warning"
     olcs_aws_account_number                      = "054614622558"
     olcs_aws_region                              = "eu-west-1"
     olcs_aws_s3_role_arn                         = "arn:aws:iam::054614622558:role/OLCS-DEVAPPREG-BASE-API"

--- a/infra/terraform/modules/parameters/variables.tf
+++ b/infra/terraform/modules/parameters/variables.tf
@@ -5,17 +5,17 @@ variable "environment" {
 
 /*
     * Log Level
-    * RFC: http://tools.ietf.org/html/rfc3164
-    * 
-    *    Code      Severity
-    *      0       Emergency: system is unusable
-    *      1       Alert: action must be taken immediately
-    *      2       Critical: critical conditions
-    *      3       Error: error conditions
-    *      4       Warning: warning conditions
-    *      5       Notice: normal but significant condition
-    *      6       Informational: informational messages
-    *      7       Debug: debug-level messages
+    * PSR-3 log level threshold. Messages at this severity and above are
+    * emitted, ordered most-to-least severe (RFC 5424):
+    *
+    *      emergency   system is unusable
+    *      alert       action must be taken immediately
+    *      critical    critical conditions
+    *      error       error conditions
+    *      warning     warning conditions
+    *      notice      normal but significant condition
+    *      info        informational messages
+    *      debug       debug-level messages
 */
 
 variable "application_parameters" {


### PR DESCRIPTION
## Description

The olcs-logging Monolog migration made LoggerFactory accept the log level threshold as either the legacy RFC 5424 syslog integer or a PSR-3 level string, both resolving to the same Monolog\Level. Switch the log_level application parameter to the PSR-3 form for all ECS environments so the config reads the modern way.

- dev/int/prep/prod/reg: log_level "4" -> "warning" (same threshold)
- modules/parameters: refresh the docblock from the syslog integer table to the PSR-3 level strings

Behaviour-preserving: "4" and "warning" both resolve to Level::Warning.

Related issue: [VOL-6099](https://dvsa.atlassian.net/browse/VOL-6099)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-6099]: https://dvsa.atlassian.net/browse/VOL-6099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ