### PR TITLE
fix(api): omit fatal error detail from the 500 response body VOL-2515

### DIFF
--- a/app/api/public/index.php
+++ b/app/api/public/index.php
@@ -52,13 +52,14 @@ function handleFatal()
         ob_clean();
     }
 
+    // VOL-2515: the raw message is never echoed to the client — for uncaught
+    // exceptions it embeds the stack trace and internal paths/hostnames. Full
+    // detail still reaches the logs via Monolog's fatal handler and PHP's
+    // error log.
     echo json_encode(
         [
             'messages' => [
-                'An unexpected fatal error occurred' => [
-                    $error['message'],
-                    $error['file'] . ': ' . $error['line']
-                ]
+                'An unexpected fatal error occurred' => []
             ]
         ]
     );


### PR DESCRIPTION
For uncaught exceptions the fatal error message embeds the stack trace, which can carry internal paths and hostnames, and (when exception trace args are enabled) credentials such as the DB password passed to PDO::__construct. The response now returns a generic body with the JSON shape unchanged; full detail still reaches the logs via Monolog's fatal handler and PHP's error log.

Related issue: [VOL-2515](https://dvsa.atlassian.net/browse/VOL-2515)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-2515]: https://dvsa.atlassian.net/browse/VOL-2515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ