### PR TITLE
fix(selfserve): stop a failed conversation submit recursing until the worker dies VOL-7492

### DIFF
--- a/app/selfserve/module/Olcs/src/Controller/ConversationsController.php
+++ b/app/selfserve/module/Olcs/src/Controller/ConversationsController.php
@@ -119,6 +119,21 @@ class ConversationsController extends AbstractController implements ToggleAwareI
             return $this->submitConversation($form);
         }
 
+        return $this->addView($form);
+    }
+
+    /**
+     * The "start a new conversation" form.
+     *
+     * Separate from addAction() so that submitConversation() can redisplay the form without
+     * calling addAction() again. It used to do exactly that, and because the request is still
+     * a POST carrying the same still-valid data, addAction() went straight back into
+     * submitConversation() — - mutual recursion with nothing to terminate it. Each cycle
+     * re-ran the uploaded-files query and re-sent the create command, so one failed submit
+     * turned into an open-ended flood of API calls that outlived the gateway timeout.
+     */
+    private function addView(\Laminas\Form\Form $form): ViewModel
+    {
         $view = new ViewModel();
         $view->setVariable('form', $form);
         $view->setVariable('backUrl', $this->url()->fromRoute('conversations'));
@@ -138,7 +153,7 @@ class ConversationsController extends AbstractController implements ToggleAwareI
             $this->flashMessengerHelper->addErrorMessage(
                 'There was an server error when submitting your conversation; please try later',
             );
-            return $this->addAction();
+            return $this->addView($form);
         }
 
         $conversationId = $response->getResult()['id']['conversation'] ?? null;
@@ -146,7 +161,7 @@ class ConversationsController extends AbstractController implements ToggleAwareI
             $this->flashMessengerHelper->addErrorMessage(
                 'There was an server error when submitting your conversation; please try later',
             );
-            return $this->addAction();
+            return $this->addView($form);
         }
 
         $this->flashMessengerHelper->addSuccessMessage('Conversation was created successfully');

--- a/app/selfserve/test/Olcs/src/Controller/ConversationsControllerTest.php
+++ b/app/selfserve/test/Olcs/src/Controller/ConversationsControllerTest.php
@@ -14,6 +14,7 @@ use Common\Service\Helper\FileUploadHelperService;
 use Common\Service\Helper\FlashMessengerHelperService;
 use Common\Service\Helper\FormHelperService;
 use Common\Service\Table\TableFactory;
+use Dvsa\Olcs\Transfer\Command\Messaging\Conversation\Create as CreateConversationCommand;
 use Dvsa\Olcs\Transfer\Command\Messaging\Message\Create as CreateMessageCommand;
 use Dvsa\Olcs\Utils\Translation\NiTextTranslation;
 use Laminas\Form\Element\Hidden;
@@ -137,6 +138,7 @@ final class ConversationsControllerTest extends TestCase
 
         $this->mockUser->shouldReceive('getUserData')
                        ->once()
+                       ->withNoArgs()
                        ->andReturn(
                            [
                                'organisationUsers' => [
@@ -313,6 +315,121 @@ final class ConversationsControllerTest extends TestCase
 
         $view = $this->sut->addAction();
         $this->assertInstanceOf(ViewModel::class, $view);
+    }
+
+    /**
+     * A failed create must redisplay the form, not re-enter addAction().
+     *
+     * submitConversation() used to return $this->addAction() on failure. The request is still a
+     * POST carrying the same still-valid data, so addAction() went straight back into
+     * submitConversation(): mutual recursion with no terminating condition. Every cycle re-ran the
+     * uploaded-files query and re-sent the create command, so a single failed submit became an
+     * open-ended flood of API calls that kept running after the gateway had already timed out —
+     * one request able to saturate a worker and hammer the API indefinitely.
+     *
+     * The ->once() expectations are the regression assertion. Under the old code handleCommand and
+     * processFiles are reached again on the second pass and Mockery fails the test.
+     */
+    public function testFailedSubmitRedisplaysTheFormWithoutRecursing(): void
+    {
+        $mockUrl = m::mock(Url::class);
+        $mockUrl->shouldReceive('fromRoute')->once()->with('conversations')->andReturn('/back/route');
+
+        $this->mockUser->shouldReceive('getUserData')
+                       ->once()
+                       ->andReturn([
+                           'organisationUsers' => [
+                               ['organisation' => ['isMessagingFileUploadEnabled' => true]],
+                           ],
+                       ]);
+        $this->sut->shouldReceive('plugin')->with('currentUser')->andReturn($this->mockUser);
+        $this->sut->shouldReceive('plugin')->with('url')->once()->andReturn($mockUrl);
+
+        $this->mockFormHelperService->shouldReceive('createForm')
+                                    ->once()
+                                    ->with(Create::class, true, false)
+                                    ->andReturn($this->mockForm);
+
+        $mockFormElement = m::mock(Hidden::class);
+        $mockFormElement->shouldReceive('setValue')
+                        ->once()
+                        ->with(m::on(static fn($v): bool => is_string($v) && preg_match('/^[0-9a-f]{40}$/', $v) === 1));
+        $mockFormElement->shouldReceive('getAttribute')->once()->with('class')->andReturn('file-upload');
+        $mockFormElement->shouldReceive('setAttribute')->once()->with('class', 'file-upload last');
+
+        $this->mockForm->shouldReceive('get')->once()->with('correlationId')->andReturn($mockFormElement);
+        $this->mockFormActions->shouldReceive('get')->once()->with('file')->andReturn($mockFormElement);
+        $this->mockForm->shouldReceive('get')->once()->with('form-actions')->andReturn($this->mockFormActions);
+        $this->mockForm->shouldReceive('setData')->once()->with([]);
+
+        $mockRequest = m::mock(Request::class);
+        $mockRequest->shouldReceive('isPost')->once()->withNoArgs()->andReturn(true);
+        $mockRequest->shouldReceive('getPost')->once()->withNoArgs()->andReturn([]);
+        $this->sut->shouldReceive('getRequest')->twice()->withNoArgs()->andReturn($mockRequest);
+
+        // Valid, so the controller proceeds to submitConversation() rather than falling through.
+        $this->mockForm->shouldReceive('isValid')->once()->withNoArgs()->andReturn(true);
+
+        $this->sut->shouldReceive('processFiles')
+                  ->once()
+                  ->with(
+                      $this->mockForm,
+                      'form-actions->file',
+                      m::on(function ($listener) {
+                          $rf = new \ReflectionFunction($listener);
+                          return $rf->getClosureThis() === $this->sut && $rf->getName() === 'processFileUpload';
+                      }),
+                      m::on(function ($listener) {
+                          $rf = new \ReflectionFunction($listener);
+                          return $rf->getClosureThis() === $this->sut && $rf->getName() === 'deleteFile';
+                      }),
+                      m::on(function ($listener) {
+                          $rf = new \ReflectionFunction($listener);
+                          return $rf->getClosureThis() === $this->sut && $rf->getName() === 'getUploadedFiles';
+                      }),
+                  )
+                  ->andReturn(false);
+
+        // mapFormDataToCommand() is private, so it runs for real; give it a form payload it can map.
+        $this->mockForm->shouldReceive('getData')
+                       ->once()
+                       ->withNoArgs()
+                       ->andReturn([
+                           'correlationId' => 'abc123',
+                           'form-actions'  => [
+                               'inputs' => [
+                                   'messageSubject' => 'Application query',
+                                   'messageContent' => 'hello',
+                                   'appOrLicNo'     => 'L710',
+                               ],
+                           ],
+                       ]);
+
+        $mockResponse = m::mock(Response::class);
+        $mockResponse->shouldReceive('isOk')->once()->withNoArgs()->andReturn(false);
+        // Asserts the mapped command, not merely that something was dispatched — which
+        // incidentally covers the private mapFormDataToCommand(). 'L710' is a licence
+        // prefix, so it must map to licence 710 and leave application unset.
+        $this->sut->shouldReceive('handleCommand')
+                  ->once()
+                  ->with(m::on(static function ($command): bool {
+                      return $command instanceof CreateConversationCommand
+                          && $command->getMessageSubject() === 'Application query'
+                          && $command->getMessageContent() === 'hello'
+                          && $command->getCorrelationId() === 'abc123'
+                          && $command->getLicence() === '710'
+                          && $command->getApplication() === null;
+                  }))
+                  ->andReturn($mockResponse);
+
+        $this->mockFlashMessengerHelper->shouldReceive('addErrorMessage')
+                                       ->once()
+                                       ->with('There was an server error when submitting your conversation; please try later');
+
+        $view = $this->sut->addAction();
+
+        $this->assertInstanceOf(ViewModel::class, $view);
+        $this->assertSame('messages-new', $view->getTemplate());
     }
 
     public function testReply(): void


### PR DESCRIPTION
## Description

submitConversation() returned $this->addAction() on both of its failure paths. The request is still a POST carrying the same, still-valid form data, so addAction() re-evaluated

    if (!$hasProcessedFiles && $isPost && $form->isValid())

and went straight back into submitConversation(). Mutual recursion with nothing that changes between passes, so nothing to terminate it.

Each cycle re-ran getUploadedFiles() and re-sent the create command, so a single failed submit became an open-ended stream of API calls that carried on long after nginx had returned 504 to the browser — observed at roughly 2.8 requests/second (on a local dev box), sustained, and only stopped by restarting the container. It also stacked a duplicate flash message per pass.

This is a denial-of-service primitive rather than a hang. Any authenticated external user who can make the create command fail can pin a php-fpm worker indefinitely and generate unbounded API load from one request; enough concurrent submits exhaust the pool. The trigger does not need to be malicious — ours was a transient API error.

Fixed by extracting the form view into addView() and returning that from the failure paths instead of re-entering the action. Behaviour is unchanged for the user: the form comes back with their data and the error message, exactly as before, but the request now ends.

The regression test asserts handleCommand() and processFiles() are each reached exactly once. Confirmed it fails against the old code — the stack trace bounces between the two call sites — and passes against the fix, rather than assuming it would.


Related issue: [VOL-7492](https://dvsa.atlassian.net/browse/VOL-7492)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-7492]: https://dvsa.atlassian.net/browse/VOL-7492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ