### PR TITLE
feat: vol-7070 Convert Retrieval entities to Doctrine attributes

### DIFF
--- a/app/api/module/Api/src/Entity/Retrieval/AbstractRetrievalLink.php
+++ b/app/api/module/Api/src/Entity/Retrieval/AbstractRetrievalLink.php
@@ -21,22 +21,16 @@ use Gedmo\Mapping\Annotation as Gedmo;
  *
  * Auto-Generated
  * @source OLCS-Entity-Generator-v2
- *
- * @ORM\MappedSuperclass
- * @ORM\HasLifecycleCallbacks
- * @ORM\Table(name="retrieval_link",
- *    indexes={
- *        @ORM\Index(name="ix_retrieval_link_expires_at", columns={"expires_at"}),
- *        @ORM\Index(name="ix_retrieval_link_flow_key", columns={"flow_key"}),
- *        @ORM\Index(name="ix_retrieval_link_created_by", columns={"created_by"}),
- *        @ORM\Index(name="ix_retrieval_link_last_modified_by", columns={"last_modified_by"}),
- *        @ORM\Index(name="uk_retrieval_link_token", columns={"token"})
- *    },
- *    uniqueConstraints={
- *        @ORM\UniqueConstraint(name="uk_retrieval_link_token", columns={"token"})
- *    }
- * )
  */
+#[ORM\Table(name: 'retrieval_link')]
+#[ORM\Index(name: 'ix_retrieval_link_expires_at', columns: ['expires_at'])]
+#[ORM\Index(name: 'ix_retrieval_link_flow_key', columns: ['flow_key'])]
+#[ORM\Index(name: 'ix_retrieval_link_created_by', columns: ['created_by'])]
+#[ORM\Index(name: 'ix_retrieval_link_last_modified_by', columns: ['last_modified_by'])]
+#[ORM\Index(name: 'uk_retrieval_link_token', columns: ['token'])]
+#[ORM\UniqueConstraint(name: 'uk_retrieval_link_token', columns: ['token'])]
+#[ORM\MappedSuperclass]
+#[ORM\HasLifecycleCallbacks]
 abstract class AbstractRetrievalLink implements BundleSerializableInterface, JsonSerializable, \Stringable
 {
     use BundleSerializableTrait;
@@ -49,124 +43,111 @@ abstract class AbstractRetrievalLink implements BundleSerializableInterface, Jso
      * Primary key.  Auto incremented if numeric.
      *
      * @var int
-     *
-     * @ORM\Id
-     * @ORM\Column(type="integer", name="id", nullable=false)
-     * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer', name: 'id', nullable: false)]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     protected $id;
 
     /**
      * Token
      *
      * @var string
-     *
-     * @ORM\Column(type="string", name="token", length=64, nullable=false)
      */
+    #[ORM\Column(type: 'string', name: 'token', length: 64, nullable: false)]
     protected $token = '';
 
     /**
      * Gate mode
      *
      * @var string
-     *
-     * @ORM\Column(type="string", name="gate_mode", length=16, nullable=false)
      */
+    #[ORM\Column(type: 'string', name: 'gate_mode', length: 16, nullable: false)]
     protected $gateMode = '';
 
     /**
      * Flow key
      *
      * @var string
-     *
-     * @ORM\Column(type="string", name="flow_key", length=64, nullable=false)
      */
+    #[ORM\Column(type: 'string', name: 'flow_key', length: 64, nullable: false)]
     protected $flowKey = '';
 
     /**
      * Source context
      *
      * @var string
-     *
-     * @ORM\Column(type="string", name="source_context", length=255, nullable=true)
      */
+    #[ORM\Column(type: 'string', name: 'source_context', length: 255, nullable: true)]
     protected $sourceContext;
 
     /**
      * Recipient email
      *
      * @var string
-     *
-     * @ORM\Column(type="string", name="recipient_email", length=255, nullable=true)
      */
+    #[ORM\Column(type: 'string', name: 'recipient_email', length: 255, nullable: true)]
     protected $recipientEmail;
 
     /**
      * Expires at
      *
      * @var \DateTime
-     *
-     * @ORM\Column(type="datetime", name="expires_at", nullable=false)
      */
+    #[ORM\Column(type: 'datetime', name: 'expires_at', nullable: false)]
     protected $expiresAt;
 
     /**
      * Revoked at
      *
      * @var \DateTime
-     *
-     * @ORM\Column(type="datetime", name="revoked_at", nullable=true)
      */
+    #[ORM\Column(type: 'datetime', name: 'revoked_at', nullable: true)]
     protected $revokedAt;
 
     /**
      * Last accessed on
      *
      * @var \DateTime
-     *
-     * @ORM\Column(type="datetime", name="last_accessed_on", nullable=true)
      */
+    #[ORM\Column(type: 'datetime', name: 'last_accessed_on', nullable: true)]
     protected $lastAccessedOn;
 
     /**
      * Created by
      *
      * @var \Dvsa\Olcs\Api\Entity\User\User
-     *
-     * @ORM\ManyToOne(targetEntity="Dvsa\Olcs\Api\Entity\User\User", fetch="LAZY")
-     * @ORM\JoinColumn(name="created_by", referencedColumnName="id", nullable=true)
-     * @Gedmo\Blameable(on="create")
      */
+    #[ORM\JoinColumn(name: 'created_by', referencedColumnName: 'id', nullable: true)]
+    #[ORM\ManyToOne(targetEntity: \Dvsa\Olcs\Api\Entity\User\User::class, fetch: 'LAZY')]
+    #[Gedmo\Blameable(on: 'create')]
     protected $createdBy;
 
     /**
      * Last modified by
      *
      * @var \Dvsa\Olcs\Api\Entity\User\User
-     *
-     * @ORM\ManyToOne(targetEntity="Dvsa\Olcs\Api\Entity\User\User", fetch="LAZY")
-     * @ORM\JoinColumn(name="last_modified_by", referencedColumnName="id", nullable=true)
-     * @Gedmo\Blameable(on="update")
      */
+    #[ORM\JoinColumn(name: 'last_modified_by', referencedColumnName: 'id', nullable: true)]
+    #[ORM\ManyToOne(targetEntity: \Dvsa\Olcs\Api\Entity\User\User::class, fetch: 'LAZY')]
+    #[Gedmo\Blameable(on: 'update')]
     protected $lastModifiedBy;
 
     /**
      * Version
      *
      * @var int
-     *
-     * @ORM\Column(type="smallint", name="version", nullable=false, options={"default": 1})
-     * @ORM\Version
      */
+    #[ORM\Column(type: 'smallint', name: 'version', nullable: false, options: ['default' => 1])]
+    #[ORM\Version]
     protected $version = 1;
 
     /**
      * Documents
      *
      * @var \Doctrine\Common\Collections\ArrayCollection
-     *
-     * @ORM\OneToMany(targetEntity="Dvsa\Olcs\Api\Entity\Retrieval\RetrievalLinkDocument", mappedBy="retrievalLink")
      */
+    #[ORM\OneToMany(targetEntity: \Dvsa\Olcs\Api\Entity\Retrieval\RetrievalLinkDocument::class, mappedBy: 'retrievalLink')]
     protected $documents;
 
     /**

--- a/app/api/module/Api/src/Entity/Retrieval/AbstractRetrievalLinkDocument.php
+++ b/app/api/module/Api/src/Entity/Retrieval/AbstractRetrievalLinkDocument.php
@@ -21,22 +21,16 @@ use Gedmo\Mapping\Annotation as Gedmo;
  *
  * Auto-Generated
  * @source OLCS-Entity-Generator-v2
- *
- * @ORM\MappedSuperclass
- * @ORM\HasLifecycleCallbacks
- * @ORM\Table(name="retrieval_link_document",
- *    indexes={
- *        @ORM\Index(name="ix_retrieval_link_document_retrieval_link_id", columns={"retrieval_link_id"}),
- *        @ORM\Index(name="ix_retrieval_link_document_document_id", columns={"document_id"}),
- *        @ORM\Index(name="ix_retrieval_link_document_created_by", columns={"created_by"}),
- *        @ORM\Index(name="ix_retrieval_link_document_last_modified_by", columns={"last_modified_by"}),
- *        @ORM\Index(name="uk_retrieval_link_document_member_ref", columns={"member_ref"})
- *    },
- *    uniqueConstraints={
- *        @ORM\UniqueConstraint(name="uk_retrieval_link_document_member_ref", columns={"member_ref"})
- *    }
- * )
  */
+#[ORM\Table(name: 'retrieval_link_document')]
+#[ORM\Index(name: 'ix_retrieval_link_document_retrieval_link_id', columns: ['retrieval_link_id'])]
+#[ORM\Index(name: 'ix_retrieval_link_document_document_id', columns: ['document_id'])]
+#[ORM\Index(name: 'ix_retrieval_link_document_created_by', columns: ['created_by'])]
+#[ORM\Index(name: 'ix_retrieval_link_document_last_modified_by', columns: ['last_modified_by'])]
+#[ORM\Index(name: 'uk_retrieval_link_document_member_ref', columns: ['member_ref'])]
+#[ORM\UniqueConstraint(name: 'uk_retrieval_link_document_member_ref', columns: ['member_ref'])]
+#[ORM\MappedSuperclass]
+#[ORM\HasLifecycleCallbacks]
 abstract class AbstractRetrievalLinkDocument implements BundleSerializableInterface, JsonSerializable, \Stringable
 {
     use BundleSerializableTrait;
@@ -49,90 +43,85 @@ abstract class AbstractRetrievalLinkDocument implements BundleSerializableInterf
      * Primary key.  Auto incremented if numeric.
      *
      * @var int
-     *
-     * @ORM\Id
-     * @ORM\Column(type="integer", name="id", nullable=false)
-     * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer', name: 'id', nullable: false)]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     protected $id;
 
     /**
      * Foreign Key to retrieval_link
      *
      * @var \Dvsa\Olcs\Api\Entity\Retrieval\RetrievalLink
-     *
-     * @ORM\ManyToOne(targetEntity="Dvsa\Olcs\Api\Entity\Retrieval\RetrievalLink", fetch="LAZY")
-     * @ORM\JoinColumn(name="retrieval_link_id", referencedColumnName="id")
      */
+    #[ORM\JoinColumn(name: 'retrieval_link_id', referencedColumnName: 'id')]
+    #[ORM\ManyToOne(
+        targetEntity: \Dvsa\Olcs\Api\Entity\Retrieval\RetrievalLink::class,
+        inversedBy: 'documents',
+        fetch: 'LAZY'
+    )]
     protected $retrievalLink;
 
     /**
      * Foreign Key to document
      *
      * @var \Dvsa\Olcs\Api\Entity\Doc\Document
-     *
-     * @ORM\ManyToOne(targetEntity="Dvsa\Olcs\Api\Entity\Doc\Document", fetch="LAZY")
-     * @ORM\JoinColumn(name="document_id", referencedColumnName="id")
      */
+    #[ORM\JoinColumn(name: 'document_id', referencedColumnName: 'id')]
+    #[ORM\ManyToOne(targetEntity: \Dvsa\Olcs\Api\Entity\Doc\Document::class, fetch: 'LAZY')]
     protected $document;
 
     /**
      * Member ref
      *
      * @var string
-     *
-     * @ORM\Column(type="string", name="member_ref", length=64, nullable=false)
      */
+    #[ORM\Column(type: 'string', name: 'member_ref', length: 64, nullable: false)]
     protected $memberRef = '';
 
     /**
      * Display filename
      *
      * @var string
-     *
-     * @ORM\Column(type="string", name="display_filename", length=255, nullable=false)
      */
+    #[ORM\Column(type: 'string', name: 'display_filename', length: 255, nullable: false)]
     protected $displayFilename = '';
 
     /**
      * Display order
      *
      * @var int
-     *
-     * @ORM\Column(type="integer", name="display_order", nullable=false, options={"default": 0})
      */
+    #[ORM\Column(type: 'integer', name: 'display_order', nullable: false, options: ['default' => 0])]
     protected $displayOrder = 0;
 
     /**
      * Created by
      *
      * @var \Dvsa\Olcs\Api\Entity\User\User
-     *
-     * @ORM\ManyToOne(targetEntity="Dvsa\Olcs\Api\Entity\User\User", fetch="LAZY")
-     * @ORM\JoinColumn(name="created_by", referencedColumnName="id", nullable=true)
-     * @Gedmo\Blameable(on="create")
      */
+    #[ORM\JoinColumn(name: 'created_by', referencedColumnName: 'id', nullable: true)]
+    #[ORM\ManyToOne(targetEntity: \Dvsa\Olcs\Api\Entity\User\User::class, fetch: 'LAZY')]
+    #[Gedmo\Blameable(on: 'create')]
     protected $createdBy;
 
     /**
      * Last modified by
      *
      * @var \Dvsa\Olcs\Api\Entity\User\User
-     *
-     * @ORM\ManyToOne(targetEntity="Dvsa\Olcs\Api\Entity\User\User", fetch="LAZY")
-     * @ORM\JoinColumn(name="last_modified_by", referencedColumnName="id", nullable=true)
-     * @Gedmo\Blameable(on="update")
      */
+    #[ORM\JoinColumn(name: 'last_modified_by', referencedColumnName: 'id', nullable: true)]
+    #[ORM\ManyToOne(targetEntity: \Dvsa\Olcs\Api\Entity\User\User::class, fetch: 'LAZY')]
+    #[Gedmo\Blameable(on: 'update')]
     protected $lastModifiedBy;
 
     /**
      * Version
      *
      * @var int
-     *
-     * @ORM\Column(type="smallint", name="version", nullable=false, options={"default": 1})
-     * @ORM\Version
      */
+    #[ORM\Column(type: 'smallint', name: 'version', nullable: false, options: ['default' => 1])]
+    #[ORM\Version]
     protected $version = 1;
 
     /**

--- a/app/api/module/Api/src/Entity/Retrieval/AbstractRetrievalLinkEvent.php
+++ b/app/api/module/Api/src/Entity/Retrieval/AbstractRetrievalLinkEvent.php
@@ -19,17 +19,13 @@ use Doctrine\Common\Collections\Collection;
  *
  * Auto-Generated
  * @source OLCS-Entity-Generator-v2
- *
- * @ORM\MappedSuperclass
- * @ORM\HasLifecycleCallbacks
- * @ORM\Table(name="retrieval_link_event",
- *    indexes={
- *        @ORM\Index(name="ix_retrieval_link_event_retrieval_link_id", columns={"retrieval_link_id"}),
- *        @ORM\Index(name="ix_retrieval_link_event_type", columns={"event_type"}),
- *        @ORM\Index(name="ix_retrieval_link_event_created_on", columns={"created_on"})
- *    }
- * )
  */
+#[ORM\Table(name: 'retrieval_link_event')]
+#[ORM\Index(name: 'ix_retrieval_link_event_retrieval_link_id', columns: ['retrieval_link_id'])]
+#[ORM\Index(name: 'ix_retrieval_link_event_type', columns: ['event_type'])]
+#[ORM\Index(name: 'ix_retrieval_link_event_created_on', columns: ['created_on'])]
+#[ORM\MappedSuperclass]
+#[ORM\HasLifecycleCallbacks]
 abstract class AbstractRetrievalLinkEvent implements BundleSerializableInterface, JsonSerializable, \Stringable
 {
     use BundleSerializableTrait;
@@ -41,75 +37,67 @@ abstract class AbstractRetrievalLinkEvent implements BundleSerializableInterface
      * Primary key.  Auto incremented if numeric.
      *
      * @var int
-     *
-     * @ORM\Id
-     * @ORM\Column(type="bigint", name="id", nullable=false)
-     * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Id]
+    #[ORM\Column(type: 'bigint', name: 'id', nullable: false)]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     protected $id;
 
     /**
      * Foreign Key to retrieval_link
      *
      * @var \Dvsa\Olcs\Api\Entity\Retrieval\RetrievalLink
-     *
-     * @ORM\ManyToOne(targetEntity="Dvsa\Olcs\Api\Entity\Retrieval\RetrievalLink", fetch="LAZY")
-     * @ORM\JoinColumn(name="retrieval_link_id", referencedColumnName="id")
      */
+    #[ORM\JoinColumn(name: 'retrieval_link_id', referencedColumnName: 'id')]
+    #[ORM\ManyToOne(targetEntity: \Dvsa\Olcs\Api\Entity\Retrieval\RetrievalLink::class, fetch: 'LAZY')]
     protected $retrievalLink;
 
     /**
      * Source context
      *
      * @var string
-     *
-     * @ORM\Column(type="string", name="source_context", length=255, nullable=true)
      */
+    #[ORM\Column(type: 'string', name: 'source_context', length: 255, nullable: true)]
     protected $sourceContext;
 
     /**
      * Event type
      *
      * @var string
-     *
-     * @ORM\Column(type="string", name="event_type", length=32, nullable=false)
      */
+    #[ORM\Column(type: 'string', name: 'event_type', length: 32, nullable: false)]
     protected $eventType = '';
 
     /**
      * Member ref
      *
      * @var string
-     *
-     * @ORM\Column(type="string", name="member_ref", length=64, nullable=true)
      */
+    #[ORM\Column(type: 'string', name: 'member_ref', length: 64, nullable: true)]
     protected $memberRef;
 
     /**
      * Ip
      *
      * @var string
-     *
-     * @ORM\Column(type="string", name="ip", length=45, nullable=true)
      */
+    #[ORM\Column(type: 'string', name: 'ip', length: 45, nullable: true)]
     protected $ip;
 
     /**
      * User agent
      *
      * @var string
-     *
-     * @ORM\Column(type="string", name="user_agent", length=255, nullable=true)
      */
+    #[ORM\Column(type: 'string', name: 'user_agent', length: 255, nullable: true)]
     protected $userAgent;
 
     /**
      * Detail
      *
      * @var string
-     *
-     * @ORM\Column(type="string", name="detail", length=255, nullable=true)
      */
+    #[ORM\Column(type: 'string', name: 'detail', length: 255, nullable: true)]
     protected $detail;
 
     /**

--- a/app/api/module/Api/src/Entity/Retrieval/AbstractRetrievalOtp.php
+++ b/app/api/module/Api/src/Entity/Retrieval/AbstractRetrievalOtp.php
@@ -19,16 +19,12 @@ use Doctrine\Common\Collections\Collection;
  *
  * Auto-Generated
  * @source OLCS-Entity-Generator-v2
- *
- * @ORM\MappedSuperclass
- * @ORM\HasLifecycleCallbacks
- * @ORM\Table(name="retrieval_otp",
- *    indexes={
- *        @ORM\Index(name="ix_retrieval_otp_retrieval_link_id", columns={"retrieval_link_id"}),
- *        @ORM\Index(name="ix_retrieval_otp_expires_at", columns={"expires_at"})
- *    }
- * )
  */
+#[ORM\Table(name: 'retrieval_otp')]
+#[ORM\Index(name: 'ix_retrieval_otp_retrieval_link_id', columns: ['retrieval_link_id'])]
+#[ORM\Index(name: 'ix_retrieval_otp_expires_at', columns: ['expires_at'])]
+#[ORM\MappedSuperclass]
+#[ORM\HasLifecycleCallbacks]
 abstract class AbstractRetrievalOtp implements BundleSerializableInterface, JsonSerializable, \Stringable
 {
     use BundleSerializableTrait;
@@ -40,84 +36,75 @@ abstract class AbstractRetrievalOtp implements BundleSerializableInterface, Json
      * Primary key.  Auto incremented if numeric.
      *
      * @var int
-     *
-     * @ORM\Id
-     * @ORM\Column(type="integer", name="id", nullable=false)
-     * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer', name: 'id', nullable: false)]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     protected $id;
 
     /**
      * Foreign Key to retrieval_link
      *
      * @var \Dvsa\Olcs\Api\Entity\Retrieval\RetrievalLink
-     *
-     * @ORM\ManyToOne(targetEntity="Dvsa\Olcs\Api\Entity\Retrieval\RetrievalLink", fetch="LAZY")
-     * @ORM\JoinColumn(name="retrieval_link_id", referencedColumnName="id")
      */
+    #[ORM\JoinColumn(name: 'retrieval_link_id', referencedColumnName: 'id')]
+    #[ORM\ManyToOne(targetEntity: \Dvsa\Olcs\Api\Entity\Retrieval\RetrievalLink::class, fetch: 'LAZY')]
     protected $retrievalLink;
 
     /**
      * Code hash
      *
      * @var string
-     *
-     * @ORM\Column(type="string", name="code_hash", length=255, nullable=false)
      */
+    #[ORM\Column(type: 'string', name: 'code_hash', length: 255, nullable: false)]
     protected $codeHash = '';
 
     /**
      * Attempts
      *
      * @var int
-     *
-     * @ORM\Column(type="integer", name="attempts", nullable=false, options={"default": 0})
      */
+    #[ORM\Column(type: 'integer', name: 'attempts', nullable: false, options: ['default' => 0])]
     protected $attempts = 0;
 
     /**
      * Max attempts
      *
      * @var int
-     *
-     * @ORM\Column(type="integer", name="max_attempts", nullable=false, options={"default": 5})
      */
+    #[ORM\Column(type: 'integer', name: 'max_attempts', nullable: false, options: ['default' => 5])]
     protected $maxAttempts = 5;
 
     /**
      * Expires at
      *
      * @var \DateTime
-     *
-     * @ORM\Column(type="datetime", name="expires_at", nullable=false)
      */
+    #[ORM\Column(type: 'datetime', name: 'expires_at', nullable: false)]
     protected $expiresAt;
 
     /**
      * Consumed at
      *
      * @var \DateTime
-     *
-     * @ORM\Column(type="datetime", name="consumed_at", nullable=true)
      */
+    #[ORM\Column(type: 'datetime', name: 'consumed_at', nullable: true)]
     protected $consumedAt;
 
     /**
      * Invalidated at
      *
      * @var \DateTime
-     *
-     * @ORM\Column(type="datetime", name="invalidated_at", nullable=true)
      */
+    #[ORM\Column(type: 'datetime', name: 'invalidated_at', nullable: true)]
     protected $invalidatedAt;
 
     /**
      * Request ip
      *
      * @var string
-     *
-     * @ORM\Column(type="string", name="request_ip", length=45, nullable=true)
      */
+    #[ORM\Column(type: 'string', name: 'request_ip', length: 45, nullable: true)]
     protected $requestIp;
 
     /**

--- a/app/api/module/Api/src/Entity/Retrieval/RetrievalLink.php
+++ b/app/api/module/Api/src/Entity/Retrieval/RetrievalLink.php
@@ -6,20 +6,14 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * RetrievalLink Entity
- *
- * @ORM\Entity
- * @ORM\Table(name="retrieval_link",
- *    indexes={
- *        @ORM\Index(name="ix_retrieval_link_expires_at", columns={"expires_at"}),
- *        @ORM\Index(name="ix_retrieval_link_flow_key", columns={"flow_key"}),
- *        @ORM\Index(name="ix_retrieval_link_created_by", columns={"created_by"}),
- *        @ORM\Index(name="ix_retrieval_link_last_modified_by", columns={"last_modified_by"})
- *    },
- *    uniqueConstraints={
- *        @ORM\UniqueConstraint(name="uk_retrieval_link_token", columns={"token"})
- *    }
- * )
  */
+#[ORM\Table(name: 'retrieval_link')]
+#[ORM\Index(name: 'ix_retrieval_link_expires_at', columns: ['expires_at'])]
+#[ORM\Index(name: 'ix_retrieval_link_flow_key', columns: ['flow_key'])]
+#[ORM\Index(name: 'ix_retrieval_link_created_by', columns: ['created_by'])]
+#[ORM\Index(name: 'ix_retrieval_link_last_modified_by', columns: ['last_modified_by'])]
+#[ORM\UniqueConstraint(name: 'uk_retrieval_link_token', columns: ['token'])]
+#[ORM\Entity]
 class RetrievalLink extends AbstractRetrievalLink
 {
 }

--- a/app/api/module/Api/src/Entity/Retrieval/RetrievalLinkDocument.php
+++ b/app/api/module/Api/src/Entity/Retrieval/RetrievalLinkDocument.php
@@ -6,20 +6,14 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * RetrievalLinkDocument Entity
- *
- * @ORM\Entity
- * @ORM\Table(name="retrieval_link_document",
- *    indexes={
- *        @ORM\Index(name="ix_retrieval_link_document_retrieval_link_id", columns={"retrieval_link_id"}),
- *        @ORM\Index(name="ix_retrieval_link_document_document_id", columns={"document_id"}),
- *        @ORM\Index(name="ix_retrieval_link_document_created_by", columns={"created_by"}),
- *        @ORM\Index(name="ix_retrieval_link_document_last_modified_by", columns={"last_modified_by"})
- *    },
- *    uniqueConstraints={
- *        @ORM\UniqueConstraint(name="uk_retrieval_link_document_member_ref", columns={"member_ref"})
- *    }
- * )
  */
+#[ORM\Table(name: 'retrieval_link_document')]
+#[ORM\Index(name: 'ix_retrieval_link_document_retrieval_link_id', columns: ['retrieval_link_id'])]
+#[ORM\Index(name: 'ix_retrieval_link_document_document_id', columns: ['document_id'])]
+#[ORM\Index(name: 'ix_retrieval_link_document_created_by', columns: ['created_by'])]
+#[ORM\Index(name: 'ix_retrieval_link_document_last_modified_by', columns: ['last_modified_by'])]
+#[ORM\UniqueConstraint(name: 'uk_retrieval_link_document_member_ref', columns: ['member_ref'])]
+#[ORM\Entity]
 class RetrievalLinkDocument extends AbstractRetrievalLinkDocument
 {
 }

--- a/app/api/module/Api/src/Entity/Retrieval/RetrievalLinkEvent.php
+++ b/app/api/module/Api/src/Entity/Retrieval/RetrievalLinkEvent.php
@@ -6,16 +6,12 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * RetrievalLinkEvent Entity
- *
- * @ORM\Entity
- * @ORM\Table(name="retrieval_link_event",
- *    indexes={
- *        @ORM\Index(name="ix_retrieval_link_event_retrieval_link_id", columns={"retrieval_link_id"}),
- *        @ORM\Index(name="ix_retrieval_link_event_type", columns={"event_type"}),
- *        @ORM\Index(name="ix_retrieval_link_event_created_on", columns={"created_on"})
- *    }
- * )
  */
+#[ORM\Table(name: 'retrieval_link_event')]
+#[ORM\Index(name: 'ix_retrieval_link_event_retrieval_link_id', columns: ['retrieval_link_id'])]
+#[ORM\Index(name: 'ix_retrieval_link_event_type', columns: ['event_type'])]
+#[ORM\Index(name: 'ix_retrieval_link_event_created_on', columns: ['created_on'])]
+#[ORM\Entity]
 class RetrievalLinkEvent extends AbstractRetrievalLinkEvent
 {
 }

--- a/app/api/module/Api/src/Entity/Retrieval/RetrievalOtp.php
+++ b/app/api/module/Api/src/Entity/Retrieval/RetrievalOtp.php
@@ -6,15 +6,11 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * RetrievalOtp Entity
- *
- * @ORM\Entity
- * @ORM\Table(name="retrieval_otp",
- *    indexes={
- *        @ORM\Index(name="ix_retrieval_otp_retrieval_link_id", columns={"retrieval_link_id"}),
- *        @ORM\Index(name="ix_retrieval_otp_expires_at", columns={"expires_at"})
- *    }
- * )
  */
+#[ORM\Table(name: 'retrieval_otp')]
+#[ORM\Index(name: 'ix_retrieval_otp_retrieval_link_id', columns: ['retrieval_link_id'])]
+#[ORM\Index(name: 'ix_retrieval_otp_expires_at', columns: ['expires_at'])]
+#[ORM\Entity]
 class RetrievalOtp extends AbstractRetrievalOtp
 {
 }


### PR DESCRIPTION
## Description

<!--
Include a summary of the change here.
-->
Migrates the Retrieval entities from Doctrine annotations to PHP 8 attributes as part of the Doctrine ORM 3 upgrade.

Related issue: [VOL-7070](https://dvsa.atlassian.net/browse/VOL-7070)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-7070]: https://dvsa.atlassian.net/browse/VOL-7070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ