### PR TITLE
fix: rds cluster name was incorrect

### DIFF
--- a/infra/terraform/environments/prep/main.tf
+++ b/infra/terraform/environments/prep/main.tf
@@ -152,14 +152,22 @@ locals {
     {
       effect = "Allow"
       actions = [
-        "rds:CreateDBInstance",
-        "rds:DescribeDBInstances",
+        "rds:CreateDBInstance"
       ]
       resources = [
         "arn:aws:rds:eu-west-1:146997448015:cluster:olcs-anon-*",
         "arn:aws:rds:eu-west-1:146997448015:db:olcs-anon-*",
         "arn:aws:rds:eu-west-1:146997448015:db:ni-extract-*",
         "arn:aws:rds:eu-west-1:146997448015:cluster:ni-extract-*"
+      ]
+    },
+        {
+      effect = "Allow"
+      actions = [
+        "rds:DescribeDBInstances"
+      ]
+      resources = [
+        "arn:aws:rds:eu-west-1:146997448015:db:*",
       ]
     },
     {

--- a/infra/terraform/environments/prep/main.tf
+++ b/infra/terraform/environments/prep/main.tf
@@ -116,7 +116,7 @@ locals {
       ]
       resources = [
 
-        "arn:aws:rds:eu-west-1:146997448015:cluster:apppp-aurora-olcsdb-cluster",
+        "arn:aws:rds:eu-west-1:146997448015:cluster:prep-aurora-olcsdb-cluster",
         "arn:aws:rds:eu-west-1:146997448015:cluster-snapshot:olcs-anon-*",
         "arn:aws:rds:eu-west-1:146997448015:cluster-snapshot:olcs-db-anon-*",
         "arn:aws:rds:eu-west-1:146997448015:cluster-snapshot:ni-extract-*",
@@ -130,7 +130,7 @@ locals {
         "rds:DescribeDBClusters",
       ]
       resources = [
-        "arn:aws:rds:eu-west-1:146997448015:cluster:apppp-aurora-olcsdb-cluster",
+        "arn:aws:rds:eu-west-1:146997448015:cluster:prep-aurora-olcsdb-cluster",
         "arn:aws:rds:eu-west-1:146997448015:cluster:olcs-*",
         "arn:aws:rds:eu-west-1:146997448015:cluster:ni-extract-*"
       ]


### PR DESCRIPTION
## Description

As per title, the rds aurora cluster was using the vol-app naming convention. I had assumed at point of writing that it would use the vol-terraform legacy naming structure. This caused an issue with permissions when the ni-compliance job was unable to create a snapshot.

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
