### PR TITLE
chore: gate prod environment deploy on prep terraform success

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -596,10 +596,19 @@ jobs:
 
   deploy_prod:
     name: (prod)
+    # Gated on prep: previously prep and prod both unlocked as soon as the prod account
+    # apply finished, so one misclick could approve prod before prep had ever run. Prod
+    # now waits until prep has at least been ATTEMPTED (its later stages -- migrations,
+    # cache clear, tests -- may fail and prod stays approvable, so a known prep failure
+    # can be judged and overridden by a human), but prep's Environment Apply must have
+    # SUCCEEDED: a terraform change that failed against prep, or was never applied there,
+    # has no business being applied to prod. Note this also means rejecting prep's
+    # approval blocks prod -- there is deliberately no prod-without-prep path here.
     if: |
       always() &&
       !cancelled() &&
-      !failure() &&
+      contains(fromJSON('["success", "failure"]'), needs.deploy_prep.result) &&
+      needs.deploy_prep.outputs.terraform-env-result == 'success' &&
       needs.release-please.outputs.release_created &&
       !contains(needs.get-version.outputs.api, 'rc') &&
       !contains(needs.get-version.outputs.cli, 'rc') &&
@@ -612,6 +621,7 @@ jobs:
       - orchestrator
       - terraform-account-prod
       - push-to-prod-ecr
+      - deploy_prep
     concurrency:
       group: ${{ github.workflow }}-prod
     uses: ./.github/workflows/deploy-and-test.yaml

--- a/.github/workflows/deploy-and-test.yaml
+++ b/.github/workflows/deploy-and-test.yaml
@@ -49,6 +49,10 @@ on:
       etl_ref:
         type: string
         required: true
+    outputs:
+      terraform-env-result:
+        description: "Result of the Environment Apply job (success/failure/skipped/cancelled)"
+        value: ${{ jobs.terraform_env.result }}
     secrets:
       VOL_GITHUB_APP_PRIVATE_KEY:
         required: true


### PR DESCRIPTION
## Description

deploy_prep and deploy_prod previously unlocked at the same moment (both gated only on the prod account apply), so a single misclick could approve prod before prep had ever been attempted.

deploy_prod now needs deploy_prep and requires:
  * prep to have been attempted (result success or failure -- later prep failures such as migrations or tests stay advisory, a human can judge them and still approve prod), and
  * prep's Environment Apply job to have succeeded, surfaced via a new terraform-env-result output on deploy-and-test.yaml. Terraform that failed against prep, or never ran there, cannot be applied to prod.

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
