### PR TITLE
fix: vol 5983 view unrelated fee error

### DIFF
--- a/lib/olcs-transfer/src/Query/Fee/Fee.php
+++ b/lib/olcs-transfer/src/Query/Fee/Fee.php
@@ -3,6 +3,7 @@
 namespace Dvsa\Olcs\Transfer\Query\Fee;
 
 use Dvsa\Olcs\Transfer\Query\AbstractQuery;
+use Dvsa\Olcs\Transfer\Util\Annotation as Transfer;
 use Dvsa\Olcs\Transfer\FieldType;
 use Dvsa\Olcs\Transfer\FieldType\Traits as FieldTypeTraits;
 


### PR DESCRIPTION
## Description

Following on from previous PR  [#1523](https://github.com/dvsa/vol-app/pull/1523), an import on Fee.php was missed with stops annotation blocks from working.

Related issue: [VOL-5983](https://dvsa.atlassian.net/browse/VOL-5983)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-5983]: https://dvsa.atlassian.net/browse/VOL-5983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ