### PR TITLE
fix: build, test and deploy on changes under lib/

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -54,19 +54,21 @@ jobs:
     outputs:
       # Docs
       should-deploy-docs: ${{ steps.changed-website-files.outputs.any_modified == 'true' || null }}
-      # App
-      should-build-app: ${{ needs.release-please.outputs.release_created || steps.changed-api-files.outputs.any_modified == 'true' || steps.changed-selfserve-files.outputs.any_modified == 'true' || steps.changed-internal-files.outputs.any_modified == 'true' || null }}
-      should-build-api: ${{ needs.release-please.outputs.release_created || steps.changed-api-files.outputs.any_modified == 'true' || null }}
-      should-build-selfserve: ${{ needs.release-please.outputs.release_created || steps.changed-selfserve-files.outputs.any_modified == 'true' || null }}
-      should-build-internal: ${{ needs.release-please.outputs.release_created || steps.changed-internal-files.outputs.any_modified == 'true' || null }}
+      # App  (a change to an in-tree shared lib rebuilds every app, since all apps consume them)
+      should-build-app: ${{ needs.release-please.outputs.release_created || steps.changed-api-files.outputs.any_modified == 'true' || steps.changed-selfserve-files.outputs.any_modified == 'true' || steps.changed-internal-files.outputs.any_modified == 'true' || steps.changed-lib-files.outputs.any_modified == 'true' || null }}
+      should-build-api: ${{ needs.release-please.outputs.release_created || steps.changed-api-files.outputs.any_modified == 'true' || steps.changed-lib-files.outputs.any_modified == 'true' || null }}
+      should-build-selfserve: ${{ needs.release-please.outputs.release_created || steps.changed-selfserve-files.outputs.any_modified == 'true' || steps.changed-lib-files.outputs.any_modified == 'true' || null }}
+      should-build-internal: ${{ needs.release-please.outputs.release_created || steps.changed-internal-files.outputs.any_modified == 'true' || steps.changed-lib-files.outputs.any_modified == 'true' || null }}
+      # Libs (in-tree shared libraries under lib/)
+      should-build-libs: ${{ needs.release-please.outputs.release_created || steps.changed-lib-files.outputs.any_modified == 'true' || null }}
       # Assets
       should-build-assets: ${{ needs.release-please.outputs.release_created || steps.changed-assets-files.outputs.any_modified == 'true' || null }}
       # Docker
       should-build-and-push-docker: ${{ needs.release-please.outputs.release_created || steps.changed-api-docker-files.outputs.any_modified == 'true' || steps.changed-selfserve-docker-files.outputs.any_modified == 'true' || steps.changed-internal-docker-files.outputs.any_modified == 'true' || steps.changed-cli-docker-files.outputs.any_modified == 'true' || null}}
-      should-build-and-push-api-docker: ${{ needs.release-please.outputs.release_created || steps.changed-api-docker-files.outputs.any_modified == 'true' || steps.changed-api-files.outputs.any_modified == 'true' || null }}
-      should-build-and-push-cli-docker: ${{ needs.release-please.outputs.release_created || steps.changed-cli-docker-files.outputs.any_modified == 'true' || steps.changed-api-files.outputs.any_modified == 'true' || null }}
-      should-build-and-push-selfserve-docker: ${{ needs.release-please.outputs.release_created || steps.changed-selfserve-docker-files.outputs.any_modified == 'true' || steps.changed-selfserve-files.outputs.any_modified == 'true' || null }}
-      should-build-and-push-internal-docker: ${{ needs.release-please.outputs.release_created || steps.changed-internal-docker-files.outputs.any_modified == 'true' || steps.changed-internal-files.outputs.any_modified == 'true' || null }}
+      should-build-and-push-api-docker: ${{ needs.release-please.outputs.release_created || steps.changed-api-docker-files.outputs.any_modified == 'true' || steps.changed-api-files.outputs.any_modified == 'true' || steps.changed-lib-files.outputs.any_modified == 'true' || null }}
+      should-build-and-push-cli-docker: ${{ needs.release-please.outputs.release_created || steps.changed-cli-docker-files.outputs.any_modified == 'true' || steps.changed-api-files.outputs.any_modified == 'true' || steps.changed-lib-files.outputs.any_modified == 'true' || null }}
+      should-build-and-push-selfserve-docker: ${{ needs.release-please.outputs.release_created || steps.changed-selfserve-docker-files.outputs.any_modified == 'true' || steps.changed-selfserve-files.outputs.any_modified == 'true' || steps.changed-lib-files.outputs.any_modified == 'true' || null }}
+      should-build-and-push-internal-docker: ${{ needs.release-please.outputs.release_created || steps.changed-internal-docker-files.outputs.any_modified == 'true' || steps.changed-internal-files.outputs.any_modified == 'true' || steps.changed-lib-files.outputs.any_modified == 'true' || null }}
       # Terraform account
       should-apply-account-terraform: ${{ needs.release-please.outputs.release_created || steps.changed-accounts-terraform-files.outputs.any_modified == 'true' || null }}
       # Terraform environment
@@ -90,6 +92,11 @@ jobs:
         with:
           files: |
             app/internal/**
+      - uses: tj-actions/changed-files@v47
+        id: changed-lib-files
+        with:
+          files: |
+            lib/**
       - uses: tj-actions/changed-files@v47
         id: changed-assets-files
         with:
@@ -170,22 +177,30 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      # lib is part of every app's version because it is part of every app's artefact:
+      # composer resolves lib/<name> through a path repository and php.yaml materialises
+      # those symlinks into real directories before packaging. The action resolves a version
+      # with `git rev-list -1 -- <project-path>`, so without lib here a commit touching only
+      # lib/ leaves the version unchanged — the image would be rebuilt under a tag that
+      # already exists, and terraform would see no change and deploy nothing.
       - id: api-version
         uses: dvsa/.github/.github/actions/get-vol-app-version@v5.0.10
         with:
-          project-path: app/api infra/docker/api
+          project-path: app/api infra/docker/api lib
       - id: cli-version
         uses: dvsa/.github/.github/actions/get-vol-app-version@v5.0.10
         with:
-          project-path: app/api infra/docker/cli
+          project-path: app/api infra/docker/cli lib
       - id: selfserve-version
         uses: dvsa/.github/.github/actions/get-vol-app-version@v5.0.10
         with:
-          project-path: app/selfserve infra/docker/selfserve
+          project-path: app/selfserve infra/docker/selfserve lib
       - id: internal-version
         uses: dvsa/.github/.github/actions/get-vol-app-version@v5.0.10
         with:
-          project-path: app/internal infra/docker/internal
+          project-path: app/internal infra/docker/internal lib
+      # Assets are built from app/cdn alone and ship to the CDN bucket rather than in an
+      # app image, so lib is deliberately absent here.
       - id: assets-version
         uses: dvsa/.github/.github/actions/get-vol-app-version@v5.0.10
         with:
@@ -245,6 +260,26 @@ jobs:
     permissions:
       contents: read
 
+  lib:
+    name: Lib
+    if: ${{ needs.orchestrator.outputs.should-build-libs }}
+    needs:
+      - orchestrator
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          - olcs-logging
+          - olcs-utils
+          - olcs-transfer
+          - olcs-common
+          - olcs-auth
+    uses: ./.github/workflows/php-lib.yaml
+    with:
+      project: ${{ matrix.project }}
+    permissions:
+      contents: read
+
   docker:
     name: Docker
     if: ${{ always() && !cancelled() && !failure() && (needs.orchestrator.outputs.should-build-app || needs.orchestrator.outputs.should-build-and-push-docker) }}
@@ -254,6 +289,10 @@ jobs:
       - orchestrator
       - get-version
       - app
+      # A lib failure must stop the push, not just be reported. `lib` is skipped when nothing
+      # under lib/ changed, and a skipped need is not a failure, so !failure() above still lets
+      # the ordinary app-only path through.
+      - lib
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -158,22 +158,25 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+      # Kept identical to cd.yaml: the version an app is built under here has to mean the same
+      # thing as the version it is deployed under there. lib is part of it because it is part of
+      # every app's artefact. See the note in cd.yaml.
       - id: api-version
         uses: dvsa/.github/.github/actions/get-vol-app-version@v5.0.10
         with:
-          project-path: app/api infra/docker/api
+          project-path: app/api infra/docker/api lib
       - id: cli-version
         uses: dvsa/.github/.github/actions/get-vol-app-version@v5.0.10
         with:
-          project-path: app/api infra/docker/cli
+          project-path: app/api infra/docker/cli lib
       - id: selfserve-version
         uses: dvsa/.github/.github/actions/get-vol-app-version@v5.0.10
         with:
-          project-path: app/selfserve infra/docker/selfserve
+          project-path: app/selfserve infra/docker/selfserve lib
       - id: internal-version
         uses: dvsa/.github/.github/actions/get-vol-app-version@v5.0.10
         with:
-          project-path: app/internal infra/docker/internal
+          project-path: app/internal infra/docker/internal lib
       - id: assets-version
         uses: dvsa/.github/.github/actions/get-vol-app-version@v5.0.10
         with:


### PR DESCRIPTION
## Description

A commit touching only lib/ produced no images and ran no PHP tests on main. All three apps consume the in-tree libs — composer resolves lib/<name> through a path repository and php.yaml materialises those symlinks into real directories at package time — so the change was in the artefact conceptually but nothing rebuilt it.

Two independent causes, and fixing either alone would not have worked.

The orchestrator never looked at lib/. Its should-build-* outputs came from app/api, app/selfserve, app/internal, app/cdn, infra/docker and infra/terraform only, so a lib-only push left should-build-app null, the app job skipped, and the docker job with it. ci.yaml has detected this since the libs were absorbed; cd.yaml was never given the same step.

The version would not have moved either. get-vol-app-version resolves a version with

    git rev-list -1 --abbrev-commit <ref> -- <project-path>

and lib was in no project-path. A lib-only commit therefore left every app's version at the SHA of the last commit touching app/<name>, so the image would have been rebuilt and pushed over a tag that already existed, and terraform would have seen an unchanged tag and deployed nothing. lib is now part of each app's project-path — of its version, because it is part of its artefact. app/cdn keeps its own path: assets ship to the CDN bucket rather than in an app image.

The same project-path change is made in ci.yaml, so the version an app is built under means the same thing as the version it is deployed under. It also stops two concurrent lib-only PRs computing the same version and cancelling each other through the app-<project>-<version> concurrency group.

Adds the lib job cd.yaml never had, matching ci.yaml's matrix, and makes docker depend on it so a failing lib suite stops the push rather than merely being reported. lib is skipped when nothing under lib/ changed, and a skipped need is not a failure, so the existing app-only path is unaffected.

Scope is deliberately coarse — any lib change rebuilds every app — matching the comment ci.yaml already carries. app/api does not require olcs-common or olcs-auth today, but over-building is cheap and under-building is the bug being fixed here.

Verified: both files parse, and actionlint reports 33 findings before and after, all pre-existing shellcheck style warnings in unrelated steps.

Related issue: [VOL-7516](https://dvsa.atlassian.net/browse/VOL-7516)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-7516]: https://dvsa.atlassian.net/browse/VOL-7516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ